### PR TITLE
chore: gitignore에 gradle 캐시파일 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,16 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### macOS ###
+.DS_Store
+
+### Gradle Cache###
+caches/
+daemon/
+wrapper/dists/
+
+### Gradle & Build ###
+.gradle/
+build/
+out/


### PR DESCRIPTION
## 관련 이슈
- Close #25 

## 변경 요약
- gitignore에 Gradle 캐시 및 빌드 관련된 파일 추가
- macOS 파일 DS_Store 추가

## 주요 변경점
- 혹시 모를 상황에 대비하여 gitignore에 필요한 파일 추가했습니다.

## 테스트

## 리뷰 포인트