### PR TITLE
feat : 내 정보 조회 구현

### DIFF
--- a/service/user/build.gradle
+++ b/service/user/build.gradle
@@ -19,11 +19,34 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // DB Driver
+    runtimeOnly 'com.h2database:h2'
+
+    // Swagger / OpenAPI
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
 }
 
 tasks.named('test') {

--- a/service/user/src/main/java/jabaclass/user/common/config/JpaAuditingConfig.java
+++ b/service/user/src/main/java/jabaclass/user/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package jabaclass.user.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/service/user/src/main/java/jabaclass/user/common/dto/ApiResponseDto.java
+++ b/service/user/src/main/java/jabaclass/user/common/dto/ApiResponseDto.java
@@ -1,0 +1,30 @@
+package jabaclass.user.common.dto;
+
+import org.springframework.http.HttpStatus;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Getter;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
+public class ApiResponseDto<T> {
+	private HttpStatus status;
+	private String message;
+	private final T data;
+
+	private ApiResponseDto(HttpStatus status, String message, T data) {
+		this.status = status;
+		this.message = message;
+		this.data = data;
+	}
+
+	public static <T> ApiResponseDto<T> success(HttpStatus status, String message, T data) {
+		return new ApiResponseDto<>(status, message, data);
+	}
+
+	public static ApiResponseDto<Void> fail(HttpStatus status, String message) {
+		return new ApiResponseDto<>(status, message, null);
+	}
+
+}

--- a/service/user/src/main/java/jabaclass/user/common/error/BusinessException.java
+++ b/service/user/src/main/java/jabaclass/user/common/error/BusinessException.java
@@ -1,0 +1,22 @@
+package jabaclass.user.common.error;
+
+import org.springframework.http.HttpStatus;
+
+public class BusinessException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public BusinessException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+
+	public HttpStatus getStatus() {
+		return errorCode.getStatus();
+	}
+
+	public String getMessage() {
+		return errorCode.getMessage();
+	}
+
+}

--- a/service/user/src/main/java/jabaclass/user/common/error/CommonErrorCode.java
+++ b/service/user/src/main/java/jabaclass/user/common/error/CommonErrorCode.java
@@ -1,0 +1,29 @@
+package jabaclass.user.common.error;
+
+import org.springframework.http.HttpStatus;
+
+public enum CommonErrorCode implements ErrorCode {
+
+	//400 BAD_REQUEST 잘못된 요청
+	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "파라미터 값을 확인해주세요."),
+	//500 INTERNAL SERVER ERROR
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다. 서버 팀에 연락주세요!");
+
+	private final HttpStatus status;
+	private final String message;
+
+	CommonErrorCode(HttpStatus status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return status;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/service/user/src/main/java/jabaclass/user/common/error/ErrorCode.java
+++ b/service/user/src/main/java/jabaclass/user/common/error/ErrorCode.java
@@ -1,0 +1,10 @@
+package jabaclass.user.common.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+	HttpStatus getStatus();
+
+	String getMessage();
+}

--- a/service/user/src/main/java/jabaclass/user/common/error/GlobalExceptionHandler.java
+++ b/service/user/src/main/java/jabaclass/user/common/error/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package jabaclass.user.common.error;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import jabaclass.user.common.dto.ApiResponseDto;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	// Validation 에러 처리
+	// request 값의 문제이므로 HttpStatus.BAD_REQUEST로 고정했습니다.
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ApiResponseDto<Void>> handleValidationException(MethodArgumentNotValidException ex) {
+		// 모든 필드 에러 메시지 중 첫 번째 가져오기
+		String message = ex.getBindingResult()
+			.getFieldError()  // 첫 번째 에러
+			.getDefaultMessage(); // DTO에 설정한 메시지
+
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(ApiResponseDto.fail(HttpStatus.BAD_REQUEST, message));
+	}
+
+	// BusinessException 처리
+	// 서비스 로직의 예외 처리 입니다.
+	@ExceptionHandler(BusinessException.class)
+	public ResponseEntity<ApiResponseDto<Void>> handleBusinessException(BusinessException ex) {
+		return ResponseEntity
+			.status(ex.getStatus())
+			.body(ApiResponseDto.fail(ex.getStatus(), ex.getMessage()));
+	}
+
+	// 서버 에러 처리
+	// 500 에러에 대한 처리로, 500 고정 해두었습니다
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ApiResponseDto<Void>> handleServerError(Exception ex) {
+		return ResponseEntity
+			.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(ApiResponseDto.fail(CommonErrorCode.INTERNAL_SERVER_ERROR.getStatus()
+				, CommonErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
+	}
+}

--- a/service/user/src/main/java/jabaclass/user/common/model/BaseEntity.java
+++ b/service/user/src/main/java/jabaclass/user/common/model/BaseEntity.java
@@ -1,0 +1,42 @@
+package jabaclass.user.common.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@MappedSuperclass
+@NoArgsConstructor
+@SuperBuilder
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "id", updatable = false, nullable = false)
+	private UUID id;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+}
+
+
+

--- a/service/user/src/main/java/jabaclass/user/user/application/exception/UserErrorCode.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/exception/UserErrorCode.java
@@ -1,0 +1,26 @@
+package jabaclass.user.user.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+import jabaclass.user.common.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+	DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다.");
+
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public HttpStatus getStatus() {
+		return null;
+	}
+
+	@Override
+	public String getMessage() {
+		return "";
+	}
+}

--- a/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
@@ -23,7 +23,7 @@ public class UserService implements UserUseCase {
 	@Override
 	public UserResponseDto findMyInfo(UUID userId) {
 		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)); //Todo 커스텀 예외 추가
+			.orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
 		return UserResponseDto.from(user);
 	}

--- a/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
@@ -21,7 +21,7 @@ public class UserService implements UserUseCase {
 	private final UserRepository userRepository;
 
 	@Override
-	public UserResponseDto getMyInfo(UUID userId) {
+	public UserResponseDto findMyInfo(UUID userId) {
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)); //Todo 커스텀 예외 추가
 

--- a/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
@@ -1,0 +1,30 @@
+package jabaclass.user.user.application.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jabaclass.user.common.error.BusinessException;
+import jabaclass.user.user.application.exception.UserErrorCode;
+import jabaclass.user.user.application.usercase.UserUseCase;
+import jabaclass.user.user.domain.model.User;
+import jabaclass.user.user.domain.repository.UserRepository;
+import jabaclass.user.user.presentation.dto.response.UserResponseDto;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService implements UserUseCase {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public UserResponseDto getMyInfo(UUID userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)); //Todo 커스텀 예외 추가
+
+		return UserResponseDto.from(user);
+	}
+}

--- a/service/user/src/main/java/jabaclass/user/user/application/usercase/UserUseCase.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/usercase/UserUseCase.java
@@ -6,5 +6,5 @@ import jabaclass.user.user.presentation.dto.response.UserResponseDto;
 
 public interface UserUseCase {
 
-	UserResponseDto getMyInfo(UUID userId);
+	UserResponseDto findMyInfo(UUID userId);
 }

--- a/service/user/src/main/java/jabaclass/user/user/application/usercase/UserUseCase.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/usercase/UserUseCase.java
@@ -1,0 +1,10 @@
+package jabaclass.user.user.application.usercase;
+
+import java.util.UUID;
+
+import jabaclass.user.user.presentation.dto.response.UserResponseDto;
+
+public interface UserUseCase {
+
+	UserResponseDto getMyInfo(UUID userId);
+}

--- a/service/user/src/main/java/jabaclass/user/user/domain/model/SocialType.java
+++ b/service/user/src/main/java/jabaclass/user/user/domain/model/SocialType.java
@@ -1,0 +1,8 @@
+package jabaclass.user.user.domain.model;
+
+public enum SocialType {
+	KAKAO,
+	NAVER,
+	GOOGLE,
+	APPLE
+}

--- a/service/user/src/main/java/jabaclass/user/user/domain/model/User.java
+++ b/service/user/src/main/java/jabaclass/user/user/domain/model/User.java
@@ -1,0 +1,57 @@
+package jabaclass.user.user.domain.model;
+
+import java.math.BigDecimal;
+
+import jabaclass.user.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(name = "users")
+public class User extends BaseEntity {
+
+	@Column(name = "name", nullable = false, length = 50)
+	private String name;
+
+	@Column(name = "email", nullable = false, unique = true, length = 320)
+	private String email;
+
+	@Column(name = "password", nullable = false, length = 255)
+	private String password;
+
+	@Column(name = "phone", nullable = false, length = 20)
+	private String phone;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "role", nullable = false, length = 20)
+	private UserRole role;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "social_type", length = 20)
+	private SocialType socialType;
+
+	@Column(name = "social_id", length = 255)
+	private String socialId;
+
+	@Builder.Default
+	@Column(name = "deposit", nullable = false, precision = 19, scale = 2)
+	private BigDecimal deposit = BigDecimal.ZERO;
+
+	public void updateProfile(String name, String phone) {
+		this.name = name;
+		this.phone = phone;
+	}
+}

--- a/service/user/src/main/java/jabaclass/user/user/domain/model/UserRole.java
+++ b/service/user/src/main/java/jabaclass/user/user/domain/model/UserRole.java
@@ -1,0 +1,7 @@
+package jabaclass.user.user.domain.model;
+
+public enum UserRole {
+	USER,
+	SELLER,
+	ADMIN
+}

--- a/service/user/src/main/java/jabaclass/user/user/domain/repository/UserRepository.java
+++ b/service/user/src/main/java/jabaclass/user/user/domain/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package jabaclass.user.user.domain.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import jabaclass.user.user.domain.model.User;
+
+public interface UserRepository {
+
+	Optional<User> findById(UUID userId);
+}

--- a/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserJpaRepository.java
+++ b/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserJpaRepository.java
@@ -1,0 +1,10 @@
+package jabaclass.user.user.infrastructure.persistence;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import jabaclass.user.user.domain.model.User;
+
+public interface UserJpaRepository extends JpaRepository<User, UUID> {
+}

--- a/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -1,0 +1,22 @@
+package jabaclass.user.user.infrastructure.persistence;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import jabaclass.user.user.domain.model.User;
+import jabaclass.user.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryAdapter implements UserRepository {
+
+	private final UserJpaRepository userJpaRepository;
+
+	@Override
+	public Optional<User> findById(UUID userId) {
+		return userJpaRepository.findById(userId);
+	}
+}

--- a/service/user/src/main/java/jabaclass/user/user/presentation/controller/UserController.java
+++ b/service/user/src/main/java/jabaclass/user/user/presentation/controller/UserController.java
@@ -19,11 +19,11 @@ public class UserController {
 	private final UserUseCase userUseCase;
 
 	@GetMapping("/me")
-	public ResponseEntity<UserResponseDto> getMyInfo(
+	public ResponseEntity<UserResponseDto> findMyInfo(
 	) {
 		UUID requesterId = UUID.randomUUID(); // Todo 추후 인증 객체에서 id 추출
 
-		UserResponseDto response = userUseCase.getMyInfo(requesterId);
+		UserResponseDto response = userUseCase.findMyInfo(requesterId);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/service/user/src/main/java/jabaclass/user/user/presentation/controller/UserController.java
+++ b/service/user/src/main/java/jabaclass/user/user/presentation/controller/UserController.java
@@ -1,0 +1,29 @@
+package jabaclass.user.user.presentation.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jabaclass.user.user.application.usercase.UserUseCase;
+import jabaclass.user.user.presentation.dto.response.UserResponseDto;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+	private final UserUseCase userUseCase;
+
+	@GetMapping("/me")
+	public ResponseEntity<UserResponseDto> getMyInfo(
+	) {
+		UUID requesterId = UUID.randomUUID(); // Todo 추후 인증 객체에서 id 추출
+
+		UserResponseDto response = userUseCase.getMyInfo(requesterId);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/service/user/src/main/java/jabaclass/user/user/presentation/dto/response/UserResponseDto.java
+++ b/service/user/src/main/java/jabaclass/user/user/presentation/dto/response/UserResponseDto.java
@@ -1,0 +1,27 @@
+package jabaclass.user.user.presentation.dto.response;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import jabaclass.user.user.domain.model.User;
+import jabaclass.user.user.domain.model.UserRole;
+
+public record UserResponseDto(
+	UUID userId,
+	String name,
+	String email,
+	String phone,
+	UserRole role,
+	BigDecimal deposit
+) {
+	public static UserResponseDto from(User user) {
+		return new UserResponseDto(
+			user.getId(),
+			user.getName(),
+			user.getEmail(),
+			user.getPhone(),
+			user.getRole(),
+			user.getDeposit()
+		);
+	}
+}


### PR DESCRIPTION
## 관련 이슈
- Close #33 

## 변경 요약
- 유저 본인 정보 조회 API 구현
- User 모듈 초기 구조 및 공통 설정 세팅

## 주요 변경점
- GET /api/v1/users/me 엔드포인트 추가
- User 엔티티 및 관련 enum 추가
- 유저 조회용 Controller / Service / UseCase / Repository 구조 추가
- JPA Repository 및 Adapter 구현
- 공통 BaseEntity 적용
- 공통 예외 처리 구조 및 UserErrorCode 추가

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트
- 아직 시큐리티 관련 코드와  스웨거는 적용하지 않았습니다.
- 테스트 코드 추후에 추가하겠습니다.