### PR TITLE
feat: JWT 인증 필터 구현 및 공통 인증 예외 아키텍처 구축

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom "org.springframework.boot:spring-boot-dependencies:4.0.4"
+        mavenBom "org.springframework.boot:spring-boot-dependencies:3.2.5"
     }
 }
 

--- a/common/src/main/java/jabastore/auth/exception/ErrorCode.java
+++ b/common/src/main/java/jabastore/auth/exception/ErrorCode.java
@@ -1,0 +1,8 @@
+package jabastore.auth.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getStatus();
+    String getMessage();
+}

--- a/common/src/main/java/jabastore/auth/exception/JwtAuthException.java
+++ b/common/src/main/java/jabastore/auth/exception/JwtAuthException.java
@@ -1,0 +1,19 @@
+package jabastore.auth.exception;
+
+public class JwtAuthException extends RuntimeException {
+
+    private final JwtErrorCode errorCode;
+
+    public JwtAuthException(JwtErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public JwtErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public org.springframework.http.HttpStatus getStatus() {
+        return errorCode.getStatus();
+    }
+}

--- a/common/src/main/java/jabastore/auth/exception/JwtAuthException.java
+++ b/common/src/main/java/jabastore/auth/exception/JwtAuthException.java
@@ -1,5 +1,7 @@
 package jabastore.auth.exception;
 
+import org.springframework.http.HttpStatus;
+
 public class JwtAuthException extends RuntimeException {
 
     private final JwtErrorCode errorCode;
@@ -13,7 +15,7 @@ public class JwtAuthException extends RuntimeException {
         return errorCode;
     }
 
-    public org.springframework.http.HttpStatus getStatus() {
+    public HttpStatus getStatus() {
         return errorCode.getStatus();
     }
 }

--- a/common/src/main/java/jabastore/auth/exception/JwtErrorCode.java
+++ b/common/src/main/java/jabastore/auth/exception/JwtErrorCode.java
@@ -1,0 +1,31 @@
+package jabastore.auth.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum JwtErrorCode implements ErrorCode{
+
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰 형식입니다."),
+    MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰 형식이 올바르지 않습니다."),
+    EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    JwtErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/common/src/main/java/jabastore/auth/exception/JwtErrorCode.java
+++ b/common/src/main/java/jabastore/auth/exception/JwtErrorCode.java
@@ -2,7 +2,7 @@ package jabastore.auth.exception;
 
 import org.springframework.http.HttpStatus;
 
-public enum JwtErrorCode implements ErrorCode{
+public enum JwtErrorCode implements ErrorCode {
 
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
@@ -17,7 +17,6 @@ public enum JwtErrorCode implements ErrorCode{
         this.status = status;
         this.message = message;
     }
-
 
     @Override
     public HttpStatus getStatus() {

--- a/common/src/main/java/jabastore/auth/filter/JwtAuthenticationFilter.java
+++ b/common/src/main/java/jabastore/auth/filter/JwtAuthenticationFilter.java
@@ -1,18 +1,18 @@
 package jabastore.auth.filter;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,16 +25,13 @@ import jabastore.auth.jwt.JwtTokenResolver;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
-    private final UserDetailsService userDetailsService;
     private final JwtTokenResolver tokenResolver;
     private final ObjectMapper objectMapper;
 
     public JwtAuthenticationFilter(JwtProvider jwtProvider,
-                                   UserDetailsService userDetailsService,
                                    JwtTokenResolver tokenResolver,
                                    ObjectMapper objectMapper) {
         this.jwtProvider = jwtProvider;
-        this.userDetailsService = userDetailsService;
         this.tokenResolver = tokenResolver;
         this.objectMapper = objectMapper;
     }
@@ -54,21 +51,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         try {
-            if (!jwtProvider.isAccessToken(token)) {
+            Claims claims = jwtProvider.parseClaims(token);
+
+            if (!jwtProvider.isAccessToken(claims)) {
                 writeErrorResponse(response, JwtErrorCode.INVALID_TOKEN);
                 return;
             }
 
-            UUID userId = jwtProvider.getUserId(token);
+            UUID userId = jwtProvider.getUserId(claims);
 
-            UserDetails userDetails =
-                    userDetailsService.loadUserByUsername(userId.toString());
-
+            // ROLE은 Redis 도입 후 처리 예정
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(
-                            userDetails,
+                            userId,
                             null,
-                            userDetails.getAuthorities()
+                            Collections.emptyList()
                     );
 
             SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/common/src/main/java/jabastore/auth/filter/JwtAuthenticationFilter.java
+++ b/common/src/main/java/jabastore/auth/filter/JwtAuthenticationFilter.java
@@ -1,14 +1,9 @@
 package jabastore.auth.filter;
 
-import jabastore.auth.exception.JwtAuthException;
-import jabastore.auth.exception.JwtErrorCode;
-import jabastore.auth.jwt.JwtProvider;
-import jabastore.auth.jwt.JwtTokenResolver;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
+
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -16,9 +11,16 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
-import java.util.UUID;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jabastore.auth.exception.JwtAuthException;
+import jabastore.auth.exception.JwtErrorCode;
+import jabastore.auth.jwt.JwtProvider;
+import jabastore.auth.jwt.JwtTokenResolver;
 
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
@@ -27,8 +29,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenResolver tokenResolver;
     private final ObjectMapper objectMapper;
 
-    public JwtAuthenticationFilter(JwtProvider jwtProvider, UserDetailsService userDetailsService,
-                                   JwtTokenResolver tokenResolver, ObjectMapper objectMapper) {
+    public JwtAuthenticationFilter(JwtProvider jwtProvider,
+                                   UserDetailsService userDetailsService,
+                                   JwtTokenResolver tokenResolver,
+                                   ObjectMapper objectMapper) {
         this.jwtProvider = jwtProvider;
         this.userDetailsService = userDetailsService;
         this.tokenResolver = tokenResolver;
@@ -43,6 +47,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String token = tokenResolver.resolveToken(request);
 
+        // 토큰 없으면 조용히 통과 (permitAll 요청 고려)
         if (token == null) {
             filterChain.doFilter(request, response);
             return;

--- a/common/src/main/java/jabastore/auth/filter/JwtAuthenticationFilter.java
+++ b/common/src/main/java/jabastore/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,90 @@
+package jabastore.auth.filter;
+
+import jabastore.auth.exception.JwtAuthException;
+import jabastore.auth.exception.JwtErrorCode;
+import jabastore.auth.jwt.JwtProvider;
+import jabastore.auth.jwt.JwtTokenResolver;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Map;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final UserDetailsService userDetailsService;
+    private final JwtTokenResolver tokenResolver;
+    private final ObjectMapper objectMapper;
+
+    public JwtAuthenticationFilter(JwtProvider jwtProvider, UserDetailsService userDetailsService,
+                                   JwtTokenResolver tokenResolver, ObjectMapper objectMapper) {
+        this.jwtProvider = jwtProvider;
+        this.userDetailsService = userDetailsService;
+        this.tokenResolver = tokenResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = tokenResolver.resolveToken(request);
+
+        if (token == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            if (!jwtProvider.isAccessToken(token)) {
+                writeErrorResponse(response, JwtErrorCode.INVALID_TOKEN);
+                return;
+            }
+
+            UUID userId = jwtProvider.getUserId(token);
+
+            UserDetails userDetails =
+                    userDetailsService.loadUserByUsername(userId.toString());
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userDetails,
+                            null,
+                            userDetails.getAuthorities()
+                    );
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        } catch (JwtAuthException e) {
+            writeErrorResponse(response, e.getErrorCode());
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void writeErrorResponse(HttpServletResponse response,
+                                    JwtErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(
+                objectMapper.writeValueAsString(
+                        Map.of("message", errorCode.getMessage())
+                )
+        );
+    }
+}

--- a/common/src/main/java/jabastore/auth/jwt/JwtProvider.java
+++ b/common/src/main/java/jabastore/auth/jwt/JwtProvider.java
@@ -1,14 +1,19 @@
 package jabastore.auth.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.security.Keys;
-
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 import java.util.UUID;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import jabastore.auth.exception.JwtAuthException;
+import jabastore.auth.exception.JwtErrorCode;
 
 public class JwtProvider {
 
@@ -34,11 +39,10 @@ public class JwtProvider {
     }
 
     // DB 일치 여부 확인은 user-service AuthService 책임
-    // 예외처리는 exception 만들면서 수정할 계획
     public String reissueAccessToken(String refreshToken) {
         Claims claims = parseClaims(refreshToken);
         if (!TokenType.REFRESH.name().equals(claims.get(CLAIM_TYPE, String.class))) {
-            throw new IllegalArgumentException("refresh token이 아닙니다.");
+            throw new JwtAuthException(JwtErrorCode.INVALID_TOKEN);
         }
         UUID userId = UUID.fromString(claims.get(CLAIM_USER_ID, String.class));
         return generateAccessToken(userId);
@@ -64,13 +68,22 @@ public class JwtProvider {
         );
     }
 
-    // 예외처리는 exception 만들면서 수정할 계획
     public Claims parseClaims(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new JwtAuthException(JwtErrorCode.EXPIRED_TOKEN);
+        } catch (MalformedJwtException e) {
+            throw new JwtAuthException(JwtErrorCode.MALFORMED_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            throw new JwtAuthException(JwtErrorCode.UNSUPPORTED_TOKEN);
+        } catch (io.jsonwebtoken.JwtException | IllegalArgumentException e) {
+            throw new JwtAuthException(JwtErrorCode.INVALID_TOKEN);
+        }
     }
 
     private String generate(UUID userId, long validity, TokenType tokenType) {

--- a/common/src/main/java/jabastore/auth/jwt/JwtProvider.java
+++ b/common/src/main/java/jabastore/auth/jwt/JwtProvider.java
@@ -52,6 +52,10 @@ public class JwtProvider {
         return UUID.fromString(parseClaims(token).get(CLAIM_USER_ID, String.class));
     }
 
+    public UUID getUserId(Claims claims) {
+        return UUID.fromString(claims.get(CLAIM_USER_ID, String.class));
+    }
+
     public Date getIssuedAt(String token) {
         return parseClaims(token).getIssuedAt();
     }
@@ -60,6 +64,10 @@ public class JwtProvider {
         return TokenType.ACCESS.name().equals(
                 parseClaims(token).get(CLAIM_TYPE, String.class)
         );
+    }
+
+    public boolean isAccessToken(Claims claims) {
+        return TokenType.ACCESS.name().equals(claims.get(CLAIM_TYPE, String.class));
     }
 
     public boolean isRefreshToken(String token) {


### PR DESCRIPTION
## 관련 이슈
- Close #14
- Close #15

## 변경 요약
- JwtAuthenticationFilter 구현
- JwtAuthException, JwtErrorCode, ErrorCode 구현
- build.gradle BOM 버전 조정

## 주요 변경점
- JwtAuthenticationFilter 구현
  - OncePerRequestFilter 상속으로 요청당 1회 실행 보장
  - 토큰 없는 요청은 조용히 통과 (permitAll 요청 고려)
  - access token 타입 검증으로 refresh token을 이용한 API 접근 차단
  - JwtAuthException catch 후 Filter 레벨에서 직접 JSON 에러 응답 처리
  - ObjectMapper 생성자 주입 방식 적용
  - UserDetailsService를 생성자로 주입받아 각 서비스에서 구현체 제공

- ErrorCode 인터페이스 구현
  - HttpStatus, message 반환 메서드 정의

- JwtErrorCode enum 구현
  - ErrorCode 인터페이스 구현
  - EXPIRED_TOKEN, INVALID_TOKEN, UNSUPPORTED_TOKEN, MALFORMED_TOKEN, EMPTY_TOKEN 정의

- JwtAuthException 구현
  - JwtErrorCode를 감싸는 커스텀 RuntimeException
  - Filter에서 발생한 JWT 관련 예외를 일관되게 처리

- JwtProvider 예외 처리 수정
  - JwtProvider 구현 pr에 작성해놨던 것 처럼 exception 구현 완료 후 JwtProvider에 적용하여 수정

- build.gradle BOM 버전 조정
  - Spring Boot BOM 4.0.4 → 3.x.x 로 낮춤

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트
- Filter는 @RestControllerAdvice 범위 밖이므로 writeErrorResponse로 직접 응답을 작성했습니다.
- UserDetailsService 구현체(CustomUserDetailsService)는 각 서비스에서 작성해야 합니다.
  - loadUserByUsername 인자는 userId(UUID String)입니다.