### PR TITLE
fix: PaymentClientImpl의 외부 결제 API 응답 바디 null 처리 추가

### DIFF
--- a/service/user/src/main/java/jabaclass/user/deposit/application/DepositHistoryStatusUpdater.java
+++ b/service/user/src/main/java/jabaclass/user/deposit/application/DepositHistoryStatusUpdater.java
@@ -6,14 +6,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import jabaclass.user.deposit.domain.DepositHistory;
 import jabaclass.user.deposit.domain.DepositStatus;
-import jabaclass.user.deposit.domain.repository.DepositHistoryRepository;
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class DepositHistoryStatusUpdater {
-
-	private final DepositHistoryRepository depositHistoryRepository;
 
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void updateFailed(DepositHistory depositHistory) {

--- a/service/user/src/main/java/jabaclass/user/deposit/infrastructure/client/PaymentClient.java
+++ b/service/user/src/main/java/jabaclass/user/deposit/infrastructure/client/PaymentClient.java
@@ -9,5 +9,5 @@ public interface PaymentClient {
 
 	UUID prepareDepositPayment(UUID userId, BigDecimal amount, String paymentMethod);
 
-	boolean confirmDepositPayment(UUID prepareId);
+	boolean confirmDepositPayment(UUID depositPaymentsId);
 }

--- a/service/user/src/main/java/jabaclass/user/deposit/infrastructure/client/PaymentClientImpl.java
+++ b/service/user/src/main/java/jabaclass/user/deposit/infrastructure/client/PaymentClientImpl.java
@@ -53,7 +53,7 @@ public class PaymentClientImpl implements PaymentClient {
 
 			DepositPrepareResponseDto body = response.getBody();
 			if (body == null) {
-				log.error("결제 준비 응답 바디 없음 userId={}", userId);  // ✅ userId 추가
+				log.error("결제 준비 응답 바디 없음 userId={}", userId);
 				throw new BusinessException(DepositErrorCode.PAYMENT_SERVICE_UNAVAILABLE);
 			}
 
@@ -82,7 +82,7 @@ public class PaymentClientImpl implements PaymentClient {
 				throw new BusinessException(DepositErrorCode.PAYMENT_SERVICE_UNAVAILABLE);
 			}
 
-			return body.isPaid();  // ✅ response.getBody() → body
+			return body.isPaid();
 
 		} catch (RestClientException e) {
 			log.error("결제 승인 실패 depositPaymentsId={}", depositPaymentsId, e);

--- a/service/user/src/main/java/jabaclass/user/deposit/infrastructure/client/PaymentClientImpl.java
+++ b/service/user/src/main/java/jabaclass/user/deposit/infrastructure/client/PaymentClientImpl.java
@@ -51,7 +51,13 @@ public class PaymentClientImpl implements PaymentClient {
 				url, request, DepositPrepareResponseDto.class
 			);
 
-			return response.getBody().depositPaymentsId();
+			DepositPrepareResponseDto body = response.getBody();
+			if (body == null) {
+				log.error("결제 준비 응답 바디 없음 userId={}", userId);  // ✅ userId 추가
+				throw new BusinessException(DepositErrorCode.PAYMENT_SERVICE_UNAVAILABLE);
+			}
+
+			return body.depositPaymentsId();
 
 		} catch (RestClientException e) {
 			log.error("결제 준비 실패 userId={}", userId, e);
@@ -60,20 +66,26 @@ public class PaymentClientImpl implements PaymentClient {
 	}
 
 	@Override
-	public boolean confirmDepositPayment(UUID prepareId) {
+	public boolean confirmDepositPayment(UUID depositPaymentsId) {
 		try {
 			String url = paymentServiceUrl + "/api/v1/payments/deposits/confirm";
 
-			DepositConfirmRequestDto request = new DepositConfirmRequestDto(prepareId);
+			DepositConfirmRequestDto request = new DepositConfirmRequestDto(depositPaymentsId);
 
 			ResponseEntity<DepositConfirmResponseDto> response = restTemplate.postForEntity(
 				url, request, DepositConfirmResponseDto.class
 			);
 
-			return response.getBody().isPaid();
+			DepositConfirmResponseDto body = response.getBody();
+			if (body == null) {
+				log.error("결제 승인 응답 바디 없음 depositPaymentsId={}", depositPaymentsId);
+				throw new BusinessException(DepositErrorCode.PAYMENT_SERVICE_UNAVAILABLE);
+			}
+
+			return body.isPaid();  // ✅ response.getBody() → body
 
 		} catch (RestClientException e) {
-			log.error("결제 승인 실패 prepareId={}", prepareId, e);
+			log.error("결제 승인 실패 depositPaymentsId={}", depositPaymentsId, e);
 			throw new BusinessException(DepositErrorCode.PAYMENT_SERVICE_UNAVAILABLE);
 		}
 	}


### PR DESCRIPTION
## 관련 이슈
- Close #54 

## 변경 요약
- PaymentClientImpl의 외부 결제 API 응답 바디 null 처리 추가

## 주요 변경점
- `prepareDepositPayment()` 응답 바디 null 체크 및 예외 처리 추가
- `confirmDepositPayment()` 응답 바디 null 체크 및 예외 처리 추가
- `confirmDepositPayment()` 파라미터명 `prepareId` → `depositPaymentsId` 통일
- null 체크 후 `response.getBody()` 재호출 버그 수정 → `body` 변수 사용으로 변경

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트
- RestTemplate `getBody()` null 반환 시 기존 `RestClientException` catch 블록에 잡히지 않아 NPE 발생 가능성이 있어 명시적 null 체크로 방어 처리했습니다.