### PR TITLE
feat: 주문 API 스펙 변경으로 DTO 변경 / 환불로직 카프카 도입

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://${KAFKA_HOST:-localhost}:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+  postgres:
+    image: postgres:16
+    container_name: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: userdb
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:

--- a/service/user/build.gradle
+++ b/service/user/build.gradle
@@ -48,13 +48,17 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // DB Driver
-    runtimeOnly 'com.h2database:h2'
+//    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.postgresql:postgresql'
 
     // Swagger / OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'
 
     // RestTemplate
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/service/user/build.gradle
+++ b/service/user/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // DB Driver
-//    runtimeOnly 'com.h2database:h2'
+    testRuntimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'
 
     // Swagger / OpenAPI

--- a/service/user/src/main/java/jabaclass/user/common/config/KafkaConfig.java
+++ b/service/user/src/main/java/jabaclass/user/common/config/KafkaConfig.java
@@ -1,0 +1,62 @@
+package jabaclass.user.common.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+
+	@Value("${spring.kafka.bootstrap-servers}")
+	private String bootstrapServers;
+
+	@Value("${spring.kafka.consumer.group-id}")
+	private String groupId;
+
+	@Bean
+	public ConsumerFactory<String, String> consumerFactory() {
+		Map<String, Object> config = new HashMap<>();
+		config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		config.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+		config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		return new DefaultKafkaConsumerFactory<>(config);
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+		ConcurrentKafkaListenerContainerFactory<String, String> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+		factory.setConsumerFactory(consumerFactory());
+		factory.setCommonErrorHandler(errorHandler());
+		return factory;
+	}
+
+	@Bean
+	public DefaultErrorHandler errorHandler() {
+		FixedBackOff backOff = new FixedBackOff(1000L, 3L);
+		DefaultErrorHandler handler = new DefaultErrorHandler(backOff);
+
+		handler.setRetryListeners((record, ex, deliveryAttempt) ->
+			log.warn("재시도 중 - topic: {}, attempt: {}, error: {}",
+				record.topic(), deliveryAttempt, ex.getMessage())
+		);
+		return handler;
+	}
+}

--- a/service/user/src/main/java/jabaclass/user/common/kafka/OrderRefundedEvent.java
+++ b/service/user/src/main/java/jabaclass/user/common/kafka/OrderRefundedEvent.java
@@ -1,0 +1,13 @@
+package jabaclass.user.common.kafka;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record OrderRefundedEvent(
+	UUID orderId,
+	UUID userId,
+	UUID productScheduleId,
+	int quantity,
+	BigDecimal depositAmount
+) {
+}

--- a/service/user/src/main/java/jabaclass/user/deposit/application/usecase/RefundDepositUseCase.java
+++ b/service/user/src/main/java/jabaclass/user/deposit/application/usecase/RefundDepositUseCase.java
@@ -1,0 +1,30 @@
+package jabaclass.user.deposit.application.usecase;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jabaclass.user.deposit.domain.exception.DepositErrorCode;
+import jabaclass.user.deposit.domain.exception.DepositException;
+import jabaclass.user.user.domain.model.User;
+import jabaclass.user.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RefundDepositUseCase {
+
+	private final UserRepository userRepository;
+
+	@Transactional
+	public void refund(UUID userId, BigDecimal amount) {
+		User user = userRepository.findByIdWithLock(userId)
+			.orElseThrow(() -> new DepositException(DepositErrorCode.NOT_FOUND_USER));
+
+		user.chargeDeposit(amount);
+	}
+
+}

--- a/service/user/src/main/java/jabaclass/user/deposit/infrastructure/kafka/DepositRefundConsumer.java
+++ b/service/user/src/main/java/jabaclass/user/deposit/infrastructure/kafka/DepositRefundConsumer.java
@@ -1,0 +1,39 @@
+package jabaclass.user.deposit.infrastructure.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jabaclass.user.common.kafka.OrderRefundedEvent;
+import jabaclass.user.deposit.application.usecase.RefundDepositUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DepositRefundConsumer {
+
+	private final RefundDepositUseCase refundDepositUseCase;
+	private final ObjectMapper objectMapper;
+
+	@KafkaListener(
+		topics = "order.refunded",
+		groupId = "deposit-service"
+	)
+	public void consume(String message) {
+		try {
+			OrderRefundedEvent event = objectMapper.readValue(message, OrderRefundedEvent.class);
+
+			log.info("예치금 복구 이벤트 수신 - orderId: {}, userId: {}, amount: {}",
+				event.orderId(), event.userId(), event.depositAmount());
+
+			refundDepositUseCase.refund(event.userId(), event.depositAmount());
+
+		} catch (Exception e) {
+			log.error("예치금 복구 실패 - message: {}, error: {}", message, e.getMessage());
+			throw new RuntimeException(e); // 재시도를 위해 예외 던짐
+		}
+	}
+}

--- a/service/user/src/main/java/jabaclass/user/deposit/presentation/controller/DepositRestController.java
+++ b/service/user/src/main/java/jabaclass/user/deposit/presentation/controller/DepositRestController.java
@@ -13,6 +13,7 @@ import jabaclass.user.deposit.application.usecase.UseDepositUseCase;
 import jabaclass.user.deposit.application.usecase.ValidateDepositUseCase;
 import jabaclass.user.deposit.presentation.dto.request.UseDepositRequestDto;
 import jabaclass.user.deposit.presentation.dto.request.ValidateDepositRequestDto;
+import jabaclass.user.deposit.presentation.dto.response.ValidateDepositResponseDto;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -24,12 +25,12 @@ public class DepositRestController {
 	private final UseDepositUseCase useDepositUseCase;
 
 	@PostMapping("/validate")
-	public ResponseEntity<Boolean> validateDeposit(
+	public ResponseEntity<ValidateDepositResponseDto> validateDeposit(
 		@AuthenticationPrincipal UUID userId,
 		@RequestBody ValidateDepositRequestDto request
 	) {
-		boolean available = validateDepositUseCase.validate(userId, request.depositAmount());
-		return ResponseEntity.ok(available);
+		boolean valid = validateDepositUseCase.validate(userId, request.depositAmount());
+		return ResponseEntity.ok(new ValidateDepositResponseDto(valid));
 	}
 
 	@PostMapping("/use")

--- a/service/user/src/main/java/jabaclass/user/deposit/presentation/controller/DepositRestController.java
+++ b/service/user/src/main/java/jabaclass/user/deposit/presentation/controller/DepositRestController.java
@@ -1,9 +1,6 @@
 package jabaclass.user.deposit.presentation.controller;
 
-import java.util.UUID;
-
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,20 +23,18 @@ public class DepositRestController {
 
 	@PostMapping("/validate")
 	public ResponseEntity<ValidateDepositResponseDto> validateDeposit(
-		@AuthenticationPrincipal UUID userId,
 		@RequestBody ValidateDepositRequestDto request
 	) {
-		boolean valid = validateDepositUseCase.validate(userId, request.depositAmount());
+		boolean valid = validateDepositUseCase.validate(request.userId(), request.depositAmount());
 		return ResponseEntity.ok(new ValidateDepositResponseDto(valid));
 	}
 
 	@PostMapping("/use")
 	public ResponseEntity<Void> useDeposit(
-		@AuthenticationPrincipal UUID userId,
 		@RequestBody UseDepositRequestDto request
 	) {
 
-		useDepositUseCase.use(userId, request.depositAmount());
+		useDepositUseCase.use(request.userId(), request.depositAmount());
 		return ResponseEntity.ok().build();
 	}
 }

--- a/service/user/src/main/java/jabaclass/user/deposit/presentation/dto/request/UseDepositRequestDto.java
+++ b/service/user/src/main/java/jabaclass/user/deposit/presentation/dto/request/UseDepositRequestDto.java
@@ -1,8 +1,10 @@
 package jabaclass.user.deposit.presentation.dto.request;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 public record UseDepositRequestDto(
+	UUID userId,
 	BigDecimal depositAmount
 ) {
 }

--- a/service/user/src/main/java/jabaclass/user/deposit/presentation/dto/request/ValidateDepositRequestDto.java
+++ b/service/user/src/main/java/jabaclass/user/deposit/presentation/dto/request/ValidateDepositRequestDto.java
@@ -1,8 +1,10 @@
 package jabaclass.user.deposit.presentation.dto.request;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 public record ValidateDepositRequestDto(
+	UUID userId,
 	BigDecimal depositAmount
 ) {
 }

--- a/service/user/src/main/java/jabaclass/user/deposit/presentation/dto/response/ValidateDepositResponseDto.java
+++ b/service/user/src/main/java/jabaclass/user/deposit/presentation/dto/response/ValidateDepositResponseDto.java
@@ -1,0 +1,6 @@
+package jabaclass.user.deposit.presentation.dto.response;
+
+public record ValidateDepositResponseDto(
+	boolean valid
+) {
+}

--- a/service/user/src/main/resources/application.yml
+++ b/service/user/src/main/resources/application.yml
@@ -6,16 +6,21 @@ spring:
     name: user
   profiles:
     active: dev
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: deposit-service
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    listener:
+      ack-mode: record
 
   datasource:
-    url: jdbc:h2:mem:userdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+    url: jdbc:postgresql://localhost:5432/userdb
+    driver-class-name: org.postgresql.Driver
+    username: ${POSTGRES_USER:postgres}
+    password: ${POSTGRES_PASSWORD:postgres}
   jpa:
     hibernate:
       ddl-auto: create-drop
@@ -23,7 +28,25 @@ spring:
       hibernate:
         format_sql: true
     show-sql: true
-    database-platform: org.hibernate.dialect.H2Dialect
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+
+  #  datasource:
+  #    url: jdbc:h2:mem:userdb
+  #    driver-class-name: org.h2.Driver
+  #    username: sa
+  #    password:
+  #  h2:
+  #    console:
+  #      enabled: true
+  #      path: /h2-console
+  #  jpa:
+  #    hibernate:
+  #      ddl-auto: create-drop
+  #    properties:
+  #      hibernate:
+  #        format_sql: true
+  #    show-sql: true
+  #    database-platform: org.hibernate.dialect.H2Dialect
 
   mail:
     host: ${MAIL_HOST:localhost}
@@ -49,3 +72,4 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-validity: 3600000
   refresh-token-validity: 604800000
+

--- a/service/user/src/test/resources/application-test.yml
+++ b/service/user/src/test/resources/application-test.yml
@@ -1,4 +1,27 @@
 spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: false
+    database-platform: org.hibernate.dialect.H2Dialect
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: deposit-service-test
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    listener:
+      ack-mode: record
+
   mail:
     host: localhost
     port: 1025


### PR DESCRIPTION
## 관련 이슈
- Close #59

## 변경 요약
- Kafka Consumer 기반 예치금 환불 이벤트 처리 구현
- PostgreSQL 연동 및 Docker 환경 구성
- 주문 흐름 API 스펙 변경으로 인한 DTO / Contorller 수정

## 주요 변경점
- `order.refunded` 토픽 구독하는 `DepositRefundConsumer` 구현
- `RefundDepositUseCase` 구현 (예치금 복구 로직)
- `KafkaConfig` 설정 추가 (`@EnableKafka`, 재시도 핸들러 포함)
- `OrderRefundedEvent` DTO 추가 (`common/kafka/dto` 패키지)
- H2 → PostgreSQL 전환 및 `docker-compose.yml`에 postgres 추가
- `application.yml` kafka/datasource 설정 추가

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트
- Kafka Consumer 재시도 횟수(3회) 및 간격(1초) 적절한지 확인 부탁드립니다
- RefundDepositUseCase에서 비관적 락(`findByIdWithLock`) 사용이 적절한지 확인 부탁드립니다