### PR TITLE
refactor: UserController 기능 SecurityUtil에 맞게 변경

### DIFF
--- a/service/user/build.gradle
+++ b/service/user/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     // DB Driver
     testRuntimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'com.h2database:h2'
 
     // Swagger / OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'

--- a/service/user/src/main/java/jabaclass/user/user/presentation/controller/UserController.java
+++ b/service/user/src/main/java/jabaclass/user/user/presentation/controller/UserController.java
@@ -1,6 +1,7 @@
 package jabaclass.user.user.presentation.controller;
 
 
+import jabaclass.user.common.util.SecurityUtil;
 import java.util.List;
 import java.util.UUID;
 
@@ -50,37 +51,33 @@ public class UserController implements UserApi {
 
 	@GetMapping("/me")
 	public ResponseEntity<UserResponseDto> getMyInfo(
-		//@AuthenticationPrincipal CustomUserPrincipal principal //Todo
 	) {
-		UUID userId = UUID.randomUUID();
+		UUID userId = SecurityUtil.getCurrentUserId();
 		return ResponseEntity.ok(userUseCase.getMyInfo(userId));
 	}
 
 	@PutMapping("/me")
 	public ResponseEntity<Void> updateMyInfo(
-		//@AuthenticationPrincipal CustomUserPrincipal principal, //Todo
 		@Valid @RequestBody UpdateUserRequestDto request
 	) {
-		UUID userId = UUID.randomUUID();
+		UUID userId = SecurityUtil.getCurrentUserId();
 		userUseCase.updateMyInfo(userId, request);
 		return ResponseEntity.noContent().build();
 	}
 
 	@PutMapping("/me/email")
 	public ResponseEntity<Void> changeEmail(
-		//@AuthenticationPrincipal CustomUserPrincipal principal, //Todo
 		@Valid @RequestBody ChangeMyEmailRequestDto request
 	) {
-		UUID userId = UUID.randomUUID();
+		UUID userId = SecurityUtil.getCurrentUserId();
 		userUseCase.changeEmail(userId, request);
 		return ResponseEntity.noContent().build();
 	}
 
 	@DeleteMapping("/me")
 	public ResponseEntity<Void> withdraw(
-		//@AuthenticationPrincipal CustomUserPrincipal principal //Todo
 	) {
-		UUID userId = UUID.randomUUID();
+		UUID userId = SecurityUtil.getCurrentUserId();
 		userUseCase.withdraw(userId);
 		return ResponseEntity.noContent().build();
 	}


### PR DESCRIPTION
## 관련 이슈
- #71 
- #68 

## 변경 요약
- @AuthenticationPrincipal 대신 custom util을 사용하는 선택을 하면서 UserController에 주석처리된 to-do 부분을 제거하고 Random UUID 대신 util을 사용하도록 코드 작성하였습니다.

## 주요 변경점
- @SecurityUtil에 맞는 코드로 변경

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트

- 다른 서비스에서 DB에 있는 Random UUID를 꺼내 사용하지 않아도 됩니다.