### PR TITLE
Feature : 상품 일정 삭제/목록

### DIFF
--- a/service/product/src/main/java/jabaclass/product/application/service/ProductService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/ProductService.java
@@ -111,6 +111,7 @@ public class ProductService implements ProductUseCase {
 		// 본인 상품인지 확인
 		matchProductAndSellerId(productId, seller.sellerId());
 
+		product.changeStatus(ProductStatus.DISABLE);
 		product.changeDelete();
 
 		return DeleteProductResposeDto.from(productId, ProductStatus.DISABLE);

--- a/service/product/src/main/java/jabaclass/product/application/service/ProductService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/ProductService.java
@@ -45,11 +45,7 @@ public class ProductService implements ProductUseCase {
 	@Transactional
 	public ProductResponseDto create(CreateProductRequestDto requestDto) {
 		// seller 룰을 확인
-		SellerResponseDto seller = findBySellerIdOrThrow(requestDto.sellerId());
-		SellerRole role = SellerRole.from(seller.role());
-		if (role != SellerRole.SELLER) {
-			throw new BusinessException(CommonErrorCode.NOT_SELLER);
-		}
+		SellerResponseDto seller = validateAndGetSeller();
 
 		Product product = Product.builder()
 			.sellerId(requestDto.sellerId())
@@ -70,15 +66,9 @@ public class ProductService implements ProductUseCase {
 	@Override
 	@Transactional
 	public ProductResponseDto update(UpdateProductRequestDto requestDto, UUID productId) {
-		UUID sellerId = auditorAwareService.getCurrentAuditor()
-			.orElseThrow(() -> new BusinessException(CommonErrorCode.EMPTY_USER));
+		// seller 룰을 확인
+		SellerResponseDto seller = validateAndGetSeller();
 
-		// sellerId를 확인
-		SellerResponseDto seller = findBySellerIdOrThrow(sellerId);
-		SellerRole role = SellerRole.from(seller.role());
-		if (role != SellerRole.SELLER) {
-			throw new BusinessException(CommonErrorCode.NOT_SELLER);
-		}
 		// 상품 존재하는지 확인
 		Product product = findByIdOrThrow(productId);
 		// 본인 상품인지 확인
@@ -97,15 +87,9 @@ public class ProductService implements ProductUseCase {
 	@Override
 	@Transactional
 	public DeleteProductResposeDto delete(UUID productId) {
-		UUID sellerId = auditorAwareService.getCurrentAuditor()
-			.orElseThrow(() -> new BusinessException(CommonErrorCode.EMPTY_USER));
-
-		// sellerId를 확인
-		SellerResponseDto seller = findBySellerIdOrThrow(sellerId);
-		SellerRole role = SellerRole.from(seller.role());
-		if (role != SellerRole.SELLER) {
-			throw new BusinessException(CommonErrorCode.NOT_SELLER);
-		}
+		// seller 룰을 확인
+		SellerResponseDto seller = validateAndGetSeller();
+		
 		// 상품 존재하는지 확인
 		Product product = findByIdOrThrow(productId);
 		// 본인 상품인지 확인
@@ -193,6 +177,17 @@ public class ProductService implements ProductUseCase {
 			.orElseThrow(() -> new BusinessException(CommonErrorCode.SELLER_NOT_FOUND));
 
 		return sellerInfo;
+	}
+
+	private SellerResponseDto validateAndGetSeller() {
+		UUID sellerId = auditorAwareService.getCurrentAuditor()
+			.orElseThrow(() -> new BusinessException(CommonErrorCode.EMPTY_USER));
+		SellerResponseDto seller = findBySellerIdOrThrow(sellerId);
+		SellerRole role = SellerRole.from(seller.role());
+		if (role != SellerRole.SELLER) {
+			throw new BusinessException(CommonErrorCode.NOT_SELLER);
+		}
+		return seller;
 	}
 
 }

--- a/service/product/src/main/java/jabaclass/product/application/service/ScheduleService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/ScheduleService.java
@@ -44,15 +44,7 @@ public class ScheduleService implements ScheduleUseCase {
 	@Override
 	@Transactional
 	public SchedulesResponseDto create(CreateScheduleRequestDto requestDto, UUID productId) {
-		UUID sellerId = auditorAwareService.getCurrentAuditor()
-			.orElseThrow(() -> new BusinessException(CommonErrorCode.EMPTY_USER));
-
-		// seller 룰을 확인
-		SellerResponseDto seller = findBySellerIdOrThrow(sellerId);
-		SellerRole role = SellerRole.from(seller.role());
-		if (role != SellerRole.SELLER) {
-			throw new BusinessException(CommonErrorCode.NOT_SELLER);
-		}
+		SellerResponseDto seller = validateAndGetSeller();
 
 		// 상품 존재하는지 확인
 		Product product = productUseCase.findByIdOrThrow(productId);
@@ -95,21 +87,18 @@ public class ScheduleService implements ScheduleUseCase {
 	@Override
 	@Transactional
 	public DeleteScheduleResposeDto delete(UUID productId, UUID scheduleId) {
-		UUID sellerId = auditorAwareService.getCurrentAuditor()
-			.orElseThrow(() -> new BusinessException(CommonErrorCode.EMPTY_USER));
+		SellerResponseDto seller = validateAndGetSeller();
 
-		// sellerId를 확인
-		SellerResponseDto seller = findBySellerIdOrThrow(sellerId);
-		SellerRole role = SellerRole.from(seller.role());
-		if (role != SellerRole.SELLER) {
-			throw new BusinessException(CommonErrorCode.NOT_SELLER);
-		}
 		// 상품 존재하는지 확인
 		Product product = productUseCase.findByIdOrThrow(productId);
 		// 상품 일자가 존재하는지
 		Schedule schedule = findByIdOrThrow(scheduleId);
 		// 본인 상품인지 확인
 		productUseCase.matchProductAndSellerId(product.getId(), seller.sellerId());
+
+		if (!schedule.getProductId().equals(product.getId())) {
+			throw new BusinessException(CommonErrorCode.MATCH_FAIL);
+		}
 
 		schedule.changeStatus(ReservedStatus.CLOSED);
 		schedule.changeDelete();
@@ -120,15 +109,7 @@ public class ScheduleService implements ScheduleUseCase {
 	@Override
 	@Transactional
 	public SchedulesResponseDto update(UpdateScheduleRequestDto requestDto, UUID productId, UUID scheduleId) {
-		UUID sellerId = auditorAwareService.getCurrentAuditor()
-			.orElseThrow(() -> new BusinessException(CommonErrorCode.EMPTY_USER));
-
-		// seller 룰을 확인
-		SellerResponseDto seller = findBySellerIdOrThrow(sellerId);
-		SellerRole role = SellerRole.from(seller.role());
-		if (role != SellerRole.SELLER) {
-			throw new BusinessException(CommonErrorCode.NOT_SELLER);
-		}
+		SellerResponseDto seller = validateAndGetSeller();
 
 		// 상품 존재하는지 확인
 		productUseCase.findByIdOrThrow(productId);
@@ -236,6 +217,17 @@ public class ScheduleService implements ScheduleUseCase {
 		if (!start.isBefore(end)) {
 			throw new BusinessException(CommonErrorCode.INVALID_TIME_RANGE);
 		}
+	}
+
+	private SellerResponseDto validateAndGetSeller() {
+		UUID sellerId = auditorAwareService.getCurrentAuditor()
+			.orElseThrow(() -> new BusinessException(CommonErrorCode.EMPTY_USER));
+		SellerResponseDto seller = findBySellerIdOrThrow(sellerId);
+		SellerRole role = SellerRole.from(seller.role());
+		if (role != SellerRole.SELLER) {
+			throw new BusinessException(CommonErrorCode.NOT_SELLER);
+		}
+		return seller;
 	}
 
 }

--- a/service/product/src/main/java/jabaclass/product/application/service/ScheduleService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/ScheduleService.java
@@ -16,12 +16,14 @@ import jabaclass.product.application.usecase.ScheduleUseCase;
 import jabaclass.product.common.exception.CommonErrorCode;
 import jabaclass.product.domain.model.Product;
 import jabaclass.product.domain.model.Schedule;
+import jabaclass.product.domain.model.status.ReservedStatus;
 import jabaclass.product.domain.repository.ScheduleRepository;
 import jabaclass.product.infrastructure.acl.dto.SellerResponseDto;
 import jabaclass.product.infrastructure.acl.dto.SellerRole;
 import jabaclass.product.presentation.dto.request.CreateScheduleRequestDto;
 import jabaclass.product.presentation.dto.request.OrderRequestDto;
 import jabaclass.product.presentation.dto.request.UpdateScheduleRequestDto;
+import jabaclass.product.presentation.dto.respose.DeleteScheduleResposeDto;
 import jabaclass.product.presentation.dto.respose.OrderResponseDto;
 import jabaclass.product.presentation.dto.respose.SchedulesResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -91,8 +93,28 @@ public class ScheduleService implements ScheduleUseCase {
 	}
 
 	@Override
-	public SchedulesResponseDto delete(CreateScheduleRequestDto createScheduleRequestDto) {
-		return null;
+	@Transactional
+	public DeleteScheduleResposeDto delete(UUID productId, UUID scheduleId) {
+		UUID sellerId = auditorAwareService.getCurrentAuditor()
+			.orElseThrow(() -> new BusinessException(CommonErrorCode.EMPTY_USER));
+
+		// sellerId를 확인
+		SellerResponseDto seller = findBySellerIdOrThrow(sellerId);
+		SellerRole role = SellerRole.from(seller.role());
+		if (role != SellerRole.SELLER) {
+			throw new BusinessException(CommonErrorCode.NOT_SELLER);
+		}
+		// 상품 존재하는지 확인
+		Product product = productUseCase.findByIdOrThrow(productId);
+		// 상품 일자가 존재하는지
+		Schedule schedule = findByIdOrThrow(scheduleId);
+		// 본인 상품인지 확인
+		productUseCase.matchProductAndSellerId(product.getId(), seller.sellerId());
+
+		schedule.changeStatus(ReservedStatus.CLOSED);
+		schedule.changeDelete();
+
+		return DeleteScheduleResposeDto.from(scheduleId, ReservedStatus.CLOSED);
 	}
 
 	@Override
@@ -140,8 +162,12 @@ public class ScheduleService implements ScheduleUseCase {
 	}
 
 	@Override
-	public SchedulesResponseDto select(CreateScheduleRequestDto createScheduleRequestDto) {
-		return null;
+	public List<SchedulesResponseDto> schedulesList(UUID productId) {
+		List<Schedule> list = scheduleRepository.findByProductIdAndDeleteDtIsNull(productId);
+
+		return list.stream()
+			.map(SchedulesResponseDto::from)
+			.toList();
 	}
 
 	// 상품 검증 -> 예약 가능 상태 return

--- a/service/product/src/main/java/jabaclass/product/application/usecase/ScheduleUseCase.java
+++ b/service/product/src/main/java/jabaclass/product/application/usecase/ScheduleUseCase.java
@@ -18,7 +18,7 @@ public interface ScheduleUseCase {
 	// 스케줄 삭제
 	DeleteScheduleResposeDto delete(UUID productId, UUID scheduleId);
 
-	// 스게줄 수정
+	// 스케줄 수정
 	SchedulesResponseDto update(UpdateScheduleRequestDto requestDto, UUID productId, UUID scheduleId);
 
 	// 스케줄 검색

--- a/service/product/src/main/java/jabaclass/product/application/usecase/ScheduleUseCase.java
+++ b/service/product/src/main/java/jabaclass/product/application/usecase/ScheduleUseCase.java
@@ -1,10 +1,12 @@
 package jabaclass.product.application.usecase;
 
+import java.util.List;
 import java.util.UUID;
 
 import jabaclass.product.presentation.dto.request.CreateScheduleRequestDto;
 import jabaclass.product.presentation.dto.request.OrderRequestDto;
 import jabaclass.product.presentation.dto.request.UpdateScheduleRequestDto;
+import jabaclass.product.presentation.dto.respose.DeleteScheduleResposeDto;
 import jabaclass.product.presentation.dto.respose.OrderResponseDto;
 import jabaclass.product.presentation.dto.respose.SchedulesResponseDto;
 
@@ -14,13 +16,13 @@ public interface ScheduleUseCase {
 	SchedulesResponseDto create(CreateScheduleRequestDto requestDto, UUID productId);
 
 	// 스케줄 삭제
-	SchedulesResponseDto delete(CreateScheduleRequestDto requestDto);
+	DeleteScheduleResposeDto delete(UUID productId, UUID scheduleId);
 
 	// 스게줄 수정
 	SchedulesResponseDto update(UpdateScheduleRequestDto requestDto, UUID productId, UUID scheduleId);
 
 	// 스케줄 검색
-	SchedulesResponseDto select(CreateScheduleRequestDto requestDto);
+	List<SchedulesResponseDto> schedulesList(UUID productId);
 
 	OrderResponseDto verification(OrderRequestDto requestDto);
 

--- a/service/product/src/main/java/jabaclass/product/domain/repository/ScheduleRepository.java
+++ b/service/product/src/main/java/jabaclass/product/domain/repository/ScheduleRepository.java
@@ -31,4 +31,6 @@ public interface ScheduleRepository {
 
 	Optional<Schedule> findById(UUID schedulesId);
 
+	List<Schedule> findByProductIdAndDeleteDtIsNull(UUID productId);
+
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ScheduleJpaRepository.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ScheduleJpaRepository.java
@@ -48,4 +48,6 @@ public interface ScheduleJpaRepository extends JpaRepository<Schedule, UUID> {
 		@Param("endTime") LocalTime endTime,
 		@Param("id") UUID id
 	);
+
+	List<Schedule> findByProductIdAndDeleteDtIsNull(UUID productId);
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ScheduleRepositoryAdapter.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ScheduleRepositoryAdapter.java
@@ -47,4 +47,9 @@ public class ScheduleRepositoryAdapter implements ScheduleRepository {
 	public Optional<Schedule> findById(UUID schedulesId) {
 		return scheduleJpaRepository.findById(schedulesId);
 	}
+
+	@Override
+	public List<Schedule> findByProductIdAndDeleteDtIsNull(UUID productId) {
+		return scheduleJpaRepository.findByProductIdAndDeleteDtIsNull(productId);
+	}
 }

--- a/service/product/src/main/java/jabaclass/product/presentation/ProductRestController.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/ProductRestController.java
@@ -1,5 +1,6 @@
 package jabaclass.product.presentation;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
@@ -24,6 +25,7 @@ import jabaclass.product.presentation.dto.request.SearchProductRequestDto;
 import jabaclass.product.presentation.dto.request.UpdateProductRequestDto;
 import jabaclass.product.presentation.dto.request.UpdateScheduleRequestDto;
 import jabaclass.product.presentation.dto.respose.DeleteProductResposeDto;
+import jabaclass.product.presentation.dto.respose.DeleteScheduleResposeDto;
 import jabaclass.product.presentation.dto.respose.OrderResponseDto;
 import jabaclass.product.presentation.dto.respose.ProductResponseDto;
 import jabaclass.product.presentation.dto.respose.SchedulesResponseDto;
@@ -137,6 +139,26 @@ public class ProductRestController implements ProductOpenApi {
 	@PostMapping("/reservations/release")
 	public void schedulesVerification(@RequestBody OrderRequestDto requestDto) {
 		scheduleUseCase.restoringInventory(requestDto);
+	}
+
+	@Override
+	@DeleteMapping("/{productId}/schedules/{scheduleId}")
+	public ResponseEntity<ApiResponseDto<DeleteScheduleResposeDto>> schedulesDelete(@PathVariable UUID productId,
+		@PathVariable UUID scheduleId) {
+		DeleteScheduleResposeDto response = scheduleUseCase.delete(productId, scheduleId);
+
+		return ResponseEntity.ok()
+			.body(ApiResponseDto.success(HttpStatus.OK, "성공적으로 삭제 되었습니다.", response));
+	}
+
+	@Override
+	@GetMapping("/{productId}/schedules")
+	public ResponseEntity<ApiResponseDto<List<SchedulesResponseDto>>> schedulesSelectList(
+		@PathVariable UUID productId) {
+		List<SchedulesResponseDto> response = scheduleUseCase.schedulesList(productId);
+
+		return ResponseEntity.ok()
+			.body(ApiResponseDto.success(HttpStatus.OK, "성공적으로 검색 되었습니다.", response));
 	}
 
 }

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/respose/DeleteScheduleResposeDto.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/respose/DeleteScheduleResposeDto.java
@@ -1,0 +1,25 @@
+package jabaclass.product.presentation.dto.respose;
+
+import java.util.UUID;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jabaclass.product.domain.model.status.ReservedStatus;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "상품 삭제 응답")
+public record DeleteScheduleResposeDto(
+	@NotNull(message = "상품 Id를 입력해주세요.")
+	@Schema(description = "상품 일정 ID", example = "11111111-1111-1111-1111-111111111111")
+	UUID scheduleId,
+
+	@Schema(description = "상태", example = "AVAILABLE")
+	ReservedStatus status
+) {
+
+	public static DeleteScheduleResposeDto from(UUID scheduleId, ReservedStatus status) {
+		return new DeleteScheduleResposeDto(
+			scheduleId, status
+		);
+	}
+
+}

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/respose/DeleteScheduleResposeDto.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/respose/DeleteScheduleResposeDto.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jabaclass.product.domain.model.status.ReservedStatus;
 import jakarta.validation.constraints.NotNull;
 
-@Schema(description = "상품 삭제 응답")
+@Schema(description = "상품 일정 삭제 응답")
 public record DeleteScheduleResposeDto(
 	@NotNull(message = "상품 Id를 입력해주세요.")
 	@Schema(description = "상품 일정 ID", example = "11111111-1111-1111-1111-111111111111")

--- a/service/product/src/main/java/jabaclass/product/presentation/openapi/ProductOpenApi.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/openapi/ProductOpenApi.java
@@ -1,5 +1,6 @@
 package jabaclass.product.presentation.openapi;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import jabaclass.product.presentation.dto.request.SearchProductRequestDto;
 import jabaclass.product.presentation.dto.request.UpdateProductRequestDto;
 import jabaclass.product.presentation.dto.request.UpdateScheduleRequestDto;
 import jabaclass.product.presentation.dto.respose.DeleteProductResposeDto;
+import jabaclass.product.presentation.dto.respose.DeleteScheduleResposeDto;
 import jabaclass.product.presentation.dto.respose.OrderResponseDto;
 import jabaclass.product.presentation.dto.respose.ProductResponseDto;
 import jabaclass.product.presentation.dto.respose.SchedulesResponseDto;
@@ -122,4 +124,27 @@ public interface ProductOpenApi {
 	)
 	@CommonErrorResponses
 	void schedulesVerification(OrderRequestDto requestDto);
+
+	@Operation(summary = "상품 일정 삭제", description = "상품 일정을 삭제 합니다.")
+	@ApiResponse(
+		responseCode = "200",
+		description = "스케줄 삭제 성공",
+		content = @Content(
+			schema = @Schema(implementation = DeleteScheduleResposeDto.class)
+		)
+	)
+	@CommonErrorResponses
+	ResponseEntity<ApiResponseDto<DeleteScheduleResposeDto>> schedulesDelete(UUID productId, UUID scheduleId);
+
+	@Operation(summary = "상품 일정 검색", description = "상품 일정을 검색 합니다.")
+	@ApiResponse(
+		responseCode = "200",
+		description = "스케줄 검색 성공",
+		content = @Content(
+			schema = @Schema(implementation = SchedulesResponseDto.class)
+		)
+	)
+	@CommonErrorResponses
+	ResponseEntity<ApiResponseDto<List<SchedulesResponseDto>>> schedulesSelectList(UUID productId);
+
 }

--- a/service/product/src/main/java/jabaclass/product/presentation/openapi/ProductOpenApi.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/openapi/ProductOpenApi.java
@@ -141,7 +141,8 @@ public interface ProductOpenApi {
 		responseCode = "200",
 		description = "스케줄 검색 성공",
 		content = @Content(
-			schema = @Schema(implementation = SchedulesResponseDto.class)
+			array = @io.swagger.v3.oas.annotations.media.ArraySchema(
+				schema = @Schema(implementation = SchedulesResponseDto.class))
 		)
 	)
 	@CommonErrorResponses

--- a/service/product/src/test/java/jabaclass/product/ProductCUDTest.java
+++ b/service/product/src/test/java/jabaclass/product/ProductCUDTest.java
@@ -1,8 +1,11 @@
 package jabaclass.product;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 import java.math.BigDecimal;
 import java.util.Optional;
@@ -35,8 +38,7 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 
 @ExtendWith(MockitoExtension.class)
-public class ProductCUDTest {
-	private Validator validator;
+class ProductCUDTest {
 
 	@InjectMocks
 	private ProductService productService;
@@ -53,38 +55,33 @@ public class ProductCUDTest {
 	@Mock
 	private AuditorAwareService auditorAwareService;
 
-	// test 상품
-	private Product product1;
+	private static final UUID SELLER_ID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+	private static final BigDecimal PRICE = new BigDecimal("1000.50");
 
-	UUID productId = UUID.randomUUID();
+	private Validator validator;
+	private UUID productId;
+	private Product product;
 
 	@BeforeEach
-	void setup() {
-		product1 = Product.builder()
+	void setUp() {
+		validator = Validation.buildDefaultValidatorFactory().getValidator();
+		productId = UUID.randomUUID();
+
+		product = Product.builder()
 			.id(productId)
 			.sellerId(SELLER_ID)
 			.title("상품A")
 			.maxCapacity(10)
-			.description("테스트1")
+			.description("테스트 상품")
 			.descriptionImage(UUID.randomUUID().toString())
 			.price(PRICE)
 			.status(ProductStatus.ENABLE)
 			.build();
 	}
 
-	@BeforeEach
-	void setUp() {
-		validator = Validation.buildDefaultValidatorFactory().getValidator();
-	}
-
-	private static final BigDecimal PRICE = new BigDecimal("1000.50");
-
-	private static final UUID SELLER_ID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
-
 	@Test
-	void 상품_생성_테스트() {
-		// given
-		CreateProductRequestDto product = new CreateProductRequestDto(
+	void 상품_생성에_성공한다() {
+		CreateProductRequestDto request = new CreateProductRequestDto(
 			SELLER_ID,
 			"테스트상품",
 			5,
@@ -93,38 +90,27 @@ public class ProductCUDTest {
 			PRICE,
 			ProductStatus.ENABLE
 		);
-
-		// Stub: seller 조회
+		given(auditorAwareService.getCurrentAuditor()).willReturn(Optional.of(SELLER_ID));
 		given(sellerRepository.findSeller(eq(SELLER_ID)))
 			.willReturn(Optional.of(new SellerResponseDto(SELLER_ID, "테스트 판매자", "SELLER")));
-
-		// Stub: repository.save -> 입력 객체 그대로 반환 + 단위 테스트용 ID 설정
 		given(productRepository.save(any(Product.class)))
 			.willAnswer(invocation -> {
-				Product p = invocation.getArgument(0);
-				ReflectionTestUtils.setField(p, "id", UUID.randomUUID());
-				return p;
+				Product saved = invocation.getArgument(0);
+				ReflectionTestUtils.setField(saved, "id", UUID.randomUUID());
+				return saved;
 			});
 
-		// when
-		ProductResponseDto saved = productService.create(product);
+		ProductResponseDto saved = productService.create(request);
 
-		// then: 값 검증
 		assertThat(saved.title()).isEqualTo("테스트상품");
 		assertThat(saved.price()).isEqualByComparingTo(PRICE);
-
-		// then: repository 호출 검증
-		verify(productRepository, times(1)).save(any(Product.class));
-
-		// then: 이벤트 발행 검증
-		verify(publisher, times(1)).publishEvent(any(ProductEventResponseDto.class));
-
+		then(productRepository).should().save(any(Product.class));
+		then(publisher).should().publishEvent(any(ProductEventResponseDto.class));
 	}
 
 	@Test
-	void 인원수_0이면_상품_생성시_예외가_발생() {
-		// given
-		CreateProductRequestDto product = new CreateProductRequestDto(
+	void 최대인원이_0이면_상품_생성_검증에_실패한다() {
+		CreateProductRequestDto request = new CreateProductRequestDto(
 			SELLER_ID,
 			"테스트상품",
 			0,
@@ -134,20 +120,15 @@ public class ProductCUDTest {
 			ProductStatus.ENABLE
 		);
 
-		// 직접 Validator 호출
-		Set<ConstraintViolation<CreateProductRequestDto>> violations = validator.validate(product);
+		Set<ConstraintViolation<CreateProductRequestDto>> violations = validator.validate(request);
 
-		assertThat(violations).extracting("message")
+		assertThat(violations).extracting(ConstraintViolation::getMessage)
 			.contains("예약 가능 인원수를 입력해주세요.");
-
-		then(productRepository).should(never()).save(any());
-		then(publisher).should(never()).publishEvent(any());
 	}
 
 	@Test
-	void 상품명_공백_상품_생성시_예외가_발생() {
-		// given
-		CreateProductRequestDto product = new CreateProductRequestDto(
+	void 상품명이_비어있으면_상품_생성_검증에_실패한다() {
+		CreateProductRequestDto request = new CreateProductRequestDto(
 			SELLER_ID,
 			"",
 			10,
@@ -157,20 +138,15 @@ public class ProductCUDTest {
 			ProductStatus.ENABLE
 		);
 
-		// 직접 Validator 호출
-		Set<ConstraintViolation<CreateProductRequestDto>> violations = validator.validate(product);
+		Set<ConstraintViolation<CreateProductRequestDto>> violations = validator.validate(request);
 
-		assertThat(violations).extracting("message")
+		assertThat(violations).extracting(ConstraintViolation::getMessage)
 			.contains("상품명을 입력해주세요.");
-
-		then(productRepository).should(never()).save(any());
-		then(publisher).should(never()).publishEvent(any());
 	}
 
 	@Test
-	void 판매자_미기재_상품_생성시_예외가_발생() {
-		// given
-		CreateProductRequestDto product = new CreateProductRequestDto(
+	void 판매자ID가_없으면_상품_생성_검증에_실패한다() {
+		CreateProductRequestDto request = new CreateProductRequestDto(
 			null,
 			"테스트상품",
 			10,
@@ -180,43 +156,33 @@ public class ProductCUDTest {
 			ProductStatus.ENABLE
 		);
 
-		// 직접 Validator 호출
-		Set<ConstraintViolation<CreateProductRequestDto>> violations = validator.validate(product);
+		Set<ConstraintViolation<CreateProductRequestDto>> violations = validator.validate(request);
 
-		assertThat(violations).extracting("message")
+		assertThat(violations).extracting(ConstraintViolation::getMessage)
 			.contains("판매자 Id를 입력해주세요.");
-
-		then(productRepository).should(never()).save(any());
-		then(publisher).should(never()).publishEvent(any());
 	}
 
 	@Test
-	void 상품가격_0원_상품_생성시_예외가_발생() {
-		BigDecimal ZERO = new BigDecimal("0");
-		// given
-		CreateProductRequestDto product = new CreateProductRequestDto(
+	void 가격이_0이면_상품_생성_검증에_실패한다() {
+		CreateProductRequestDto request = new CreateProductRequestDto(
 			SELLER_ID,
 			"테스트상품",
 			10,
 			"테스트 상품 입니다.",
 			UUID.randomUUID().toString(),
-			ZERO,
+			BigDecimal.ZERO,
 			ProductStatus.ENABLE
 		);
 
-		// 직접 Validator 호출
-		Set<ConstraintViolation<CreateProductRequestDto>> violations = validator.validate(product);
+		Set<ConstraintViolation<CreateProductRequestDto>> violations = validator.validate(request);
 
-		assertThat(violations).extracting("message")
+		assertThat(violations).extracting(ConstraintViolation::getMessage)
 			.contains("가격은 1원 이상이어야 합니다.");
-
-		then(productRepository).should(never()).save(any());
-		then(publisher).should(never()).publishEvent(any());
 	}
 
 	@Test
-	void 판매자가_존재하지_않으면_예외가_발생() {
-		CreateProductRequestDto product = new CreateProductRequestDto(
+	void 판매자가_존재하지_않으면_상품_생성에_실패한다() {
+		CreateProductRequestDto request = new CreateProductRequestDto(
 			SELLER_ID,
 			"테스트상품",
 			5,
@@ -225,19 +191,17 @@ public class ProductCUDTest {
 			PRICE,
 			ProductStatus.ENABLE
 		);
-		// given
-		// ... product DTO 생성
+		given(auditorAwareService.getCurrentAuditor()).willReturn(Optional.of(SELLER_ID));
 		given(sellerRepository.findSeller(any(UUID.class))).willReturn(Optional.empty());
 
-		// when & then
-		assertThatThrownBy(() -> productService.create(product))
+		assertThatThrownBy(() -> productService.create(request))
 			.isInstanceOf(BusinessException.class)
 			.hasMessage("존재하지 않는 판매자 입니다.");
 	}
 
 	@Test
-	void 판매자_권한이_없으면_예외가_발생() {
-		CreateProductRequestDto product = new CreateProductRequestDto(
+	void 판매자_권한이_없으면_상품_생성에_실패한다() {
+		CreateProductRequestDto request = new CreateProductRequestDto(
 			SELLER_ID,
 			"테스트상품",
 			5,
@@ -246,20 +210,18 @@ public class ProductCUDTest {
 			PRICE,
 			ProductStatus.ENABLE
 		);
-		// ... product DTO 생성
+		given(auditorAwareService.getCurrentAuditor()).willReturn(Optional.of(SELLER_ID));
 		given(sellerRepository.findSeller(any(UUID.class)))
 			.willReturn(Optional.of(new SellerResponseDto(SELLER_ID, "일반 사용자", "USER")));
 
-		// when & then
-		assertThatThrownBy(() -> productService.create(product))
+		assertThatThrownBy(() -> productService.create(request))
 			.isInstanceOf(BusinessException.class)
 			.hasMessage("판매자가 아닙니다.");
 	}
 
 	@Test
-	void 상품_수정_성공() {
-		// given
-		UpdateProductRequestDto updateDto = new UpdateProductRequestDto(
+	void 상품_수정에_성공한다() {
+		UpdateProductRequestDto request = new UpdateProductRequestDto(
 			"수정상품",
 			10,
 			"수정 설명",
@@ -267,111 +229,69 @@ public class ProductCUDTest {
 			new BigDecimal("1200.00"),
 			ProductStatus.ENABLE
 		);
-
-		/// Stub: seller 조회
-		when(auditorAwareService.getCurrentAuditor())
-			.thenReturn(Optional.of(SELLER_ID));
-
-		given(sellerRepository.findSeller(eq(SELLER_ID)))
-			.willReturn(Optional.of(new SellerResponseDto(
-				SELLER_ID, "테스트 판매자", "SELLER"
-			)));
-
-		// 상품 조회 (1번)
-		given(productRepository.findById(productId))
-			.willReturn(Optional.of(product1));
-
-		// 권한 체크 (2번)
-		given(productRepository.findByIdAndSellerId(productId, SELLER_ID))
-			.willReturn(Optional.of(product1));
-
-		// when
-		ProductResponseDto updated = productService.update(updateDto, productId);
-
-		// then
-		assertThat(updated.title()).isEqualTo("수정상품");
-		assertThat(updated.price()).isEqualByComparingTo(updateDto.price());
-	}
-
-	@Test
-	void 없는_상품_수정_시_예외발생() {
-		UUID productId = UUID.randomUUID();
-		UpdateProductRequestDto updateDto = new UpdateProductRequestDto(
-			"수정상품",
-			10,
-			"수정 설명",
-			UUID.randomUUID().toString(),
-			new BigDecimal("1200.00"),
-			ProductStatus.ENABLE
-		);
-
-		// 존재하는 판매자
-		// Stub: seller 조회
-		when(auditorAwareService.getCurrentAuditor())
-			.thenReturn(Optional.of(SELLER_ID));
-
+		given(auditorAwareService.getCurrentAuditor()).willReturn(Optional.of(SELLER_ID));
 		given(sellerRepository.findSeller(eq(SELLER_ID)))
 			.willReturn(Optional.of(new SellerResponseDto(SELLER_ID, "테스트 판매자", "SELLER")));
+		given(productRepository.findById(productId)).willReturn(Optional.of(product));
+		given(productRepository.findByIdAndSellerId(productId, SELLER_ID)).willReturn(Optional.of(product));
 
-		given(productRepository.findById(productId)).willReturn(Optional.empty());
+		ProductResponseDto updated = productService.update(request, productId);
 
-		assertThatThrownBy(() -> productService.update(updateDto, productId))
-			.isInstanceOf(BusinessException.class)
-			.hasMessage("존재하지 않는 상품 ID 입니다.");
-
-		then(productRepository).should(never()).save(any(Product.class));
+		assertThat(updated.title()).isEqualTo("수정상품");
+		assertThat(updated.price()).isEqualByComparingTo(request.price());
 	}
 
 	@Test
-	void 상품_삭제_성공() {
-		// 존재하는 판매자
-		when(auditorAwareService.getCurrentAuditor())
-			.thenReturn(Optional.of(SELLER_ID));
-
-		// Stub: seller 조회
+	void 존재하지_않는_상품은_수정에_실패한다() {
+		UUID missingProductId = UUID.randomUUID();
+		UpdateProductRequestDto request = new UpdateProductRequestDto(
+			"수정상품",
+			10,
+			"수정 설명",
+			UUID.randomUUID().toString(),
+			new BigDecimal("1200.00"),
+			ProductStatus.ENABLE
+		);
+		given(auditorAwareService.getCurrentAuditor()).willReturn(Optional.of(SELLER_ID));
 		given(sellerRepository.findSeller(eq(SELLER_ID)))
-			.willReturn(Optional.of(new SellerResponseDto(
-				SELLER_ID, "테스트 판매자", "SELLER"
-			)));
+			.willReturn(Optional.of(new SellerResponseDto(SELLER_ID, "테스트 판매자", "SELLER")));
+		given(productRepository.findById(missingProductId)).willReturn(Optional.empty());
 
-		//  상품 조회 (1번)
-		given(productRepository.findById(productId))
-			.willReturn(Optional.of(product1));
+		assertThatThrownBy(() -> productService.update(request, missingProductId))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("존재하지 않는 상품 ID 입니다.");
+	}
 
-		//  권한 체크 (2번)
-		given(productRepository.findByIdAndSellerId(productId, SELLER_ID))
-			.willReturn(Optional.of(product1));
+	@Test
+	void 상품_삭제에_성공한다() {
+		given(auditorAwareService.getCurrentAuditor()).willReturn(Optional.of(SELLER_ID));
+		given(sellerRepository.findSeller(eq(SELLER_ID)))
+			.willReturn(Optional.of(new SellerResponseDto(SELLER_ID, "테스트 판매자", "SELLER")));
+		given(productRepository.findById(productId)).willReturn(Optional.of(product));
+		given(productRepository.findByIdAndSellerId(productId, SELLER_ID)).willReturn(Optional.of(product));
 
-		// when
 		productService.delete(productId);
 
-		// then
-		assertThat(product1.getDeleteDt()).isNotNull();
+		assertThat(product.getDeleteDt()).isNotNull();
+		assertThat(product.getStatus()).isEqualTo(ProductStatus.DISABLE);
 	}
 
 	@Test
-	void 없는_상품_삭제_시_예외발생() {
-		UUID productId = UUID.randomUUID();
-		given(productRepository.findById(productId)).willReturn(Optional.empty());
-
-		// 존재하는 판매자
-		// Stub: seller 조회
-		when(auditorAwareService.getCurrentAuditor())
-			.thenReturn(Optional.of(SELLER_ID));
-
+	void 존재하지_않는_상품은_삭제에_실패한다() {
+		UUID missingProductId = UUID.randomUUID();
+		given(auditorAwareService.getCurrentAuditor()).willReturn(Optional.of(SELLER_ID));
 		given(sellerRepository.findSeller(eq(SELLER_ID)))
 			.willReturn(Optional.of(new SellerResponseDto(SELLER_ID, "테스트 판매자", "SELLER")));
+		given(productRepository.findById(missingProductId)).willReturn(Optional.empty());
 
-		assertThatThrownBy(() -> productService.delete(productId))
+		assertThatThrownBy(() -> productService.delete(missingProductId))
 			.isInstanceOf(BusinessException.class)
 			.hasMessage("존재하지 않는 상품 ID 입니다.");
-
-		then(productRepository).should(times(1)).findById(productId);
 	}
 
 	@Test
-	void 다른_판매자가_수정하면_예외() {
-		UpdateProductRequestDto updateDto = new UpdateProductRequestDto(
+	void 다른_판매자의_상품은_수정할_수_없다() {
+		UpdateProductRequestDto request = new UpdateProductRequestDto(
 			"수정상품",
 			10,
 			"수정 설명",
@@ -379,22 +299,17 @@ public class ProductCUDTest {
 			new BigDecimal("1200.00"),
 			ProductStatus.ENABLE
 		);
-		when(auditorAwareService.getCurrentAuditor())
-			.thenReturn(Optional.of(SELLER_ID));
-
+		given(auditorAwareService.getCurrentAuditor()).willReturn(Optional.of(SELLER_ID));
 		given(sellerRepository.findSeller(any(UUID.class)))
 			.willAnswer(invocation -> {
 				UUID id = invocation.getArgument(0);
 				return Optional.of(new SellerResponseDto(id, "판매자", "SELLER"));
 			});
+		given(productRepository.findById(any(UUID.class))).willReturn(Optional.of(product));
+		given(productRepository.findByIdAndSellerId(any(UUID.class), any(UUID.class))).willReturn(Optional.empty());
 
-		// 같은 productId로 맞춰야 함
-		given(productRepository.findById(any(UUID.class)))
-			.willReturn(Optional.of(product1));
-
-		assertThatThrownBy(() -> productService.update(updateDto, SELLER_ID))
+		assertThatThrownBy(() -> productService.update(request, SELLER_ID))
 			.isInstanceOf(BusinessException.class)
 			.hasMessage("해당 상품은 본인 상품이 아닙니다.");
 	}
-
 }

--- a/service/product/src/test/java/jabaclass/product/ScheduleTest.java
+++ b/service/product/src/test/java/jabaclass/product/ScheduleTest.java
@@ -16,6 +16,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -53,6 +54,7 @@ import jabaclass.product.presentation.ProductRestController;
 import jabaclass.product.presentation.dto.request.CreateScheduleRequestDto;
 import jabaclass.product.presentation.dto.request.OrderRequestDto;
 import jabaclass.product.presentation.dto.request.UpdateScheduleRequestDto;
+import jabaclass.product.presentation.dto.respose.DeleteScheduleResposeDto;
 import jabaclass.product.presentation.dto.respose.OrderResponseDto;
 import jabaclass.product.presentation.dto.respose.SchedulesResponseDto;
 import jakarta.validation.ConstraintViolation;
@@ -463,6 +465,77 @@ class ScheduleTest {
 		productRestController.schedulesVerification(request);
 
 		then(scheduleUseCase).should().restoringInventory(request);
+	}
+
+	@Test
+	void 일정_삭제에_성공한다() {
+		prepareAuthorizedSellerAndOwnedProduct();
+		given(scheduleRepository.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
+
+		DeleteScheduleResposeDto result = scheduleService.delete(PRODUCT_ID, SCHEDULE_ID);
+
+		assertThat(result.scheduleId()).isEqualTo(SCHEDULE_ID);
+		assertThat(result.status()).isEqualTo(ReservedStatus.CLOSED);
+		assertThat(schedule.getStatus()).isEqualTo(ReservedStatus.CLOSED);
+		assertThat(schedule.getDeleteDt()).isNotNull();
+	}
+
+	@Test
+	void 상품의_일정_목록을_조회한다() {
+		Schedule secondSchedule = Schedule.builder()
+			.productId(PRODUCT_ID)
+			.scheduleDt(LocalDate.now().plusDays(2))
+			.startTime(LocalTime.of(14, 0))
+			.endTime(LocalTime.of(16, 0))
+			.status(ReservedStatus.AVAILABLE)
+			.maxCapacity(8)
+			.build();
+		ReflectionTestUtils.setField(secondSchedule, "id", UUID.randomUUID());
+
+		given(scheduleRepository.findByProductIdAndDeleteDtIsNull(PRODUCT_ID))
+			.willReturn(List.of(schedule, secondSchedule));
+
+		List<SchedulesResponseDto> result = scheduleService.schedulesList(PRODUCT_ID);
+
+		assertThat(result).hasSize(2);
+		assertThat(result).extracting(SchedulesResponseDto::productId)
+			.containsOnly(PRODUCT_ID);
+	}
+
+	@Test
+	void 삭제_요청이_들어오면_컨트롤러가_유스케이스를_호출한다() {
+		DeleteScheduleResposeDto response = DeleteScheduleResposeDto.from(SCHEDULE_ID, ReservedStatus.CLOSED);
+		given(scheduleUseCase.delete(PRODUCT_ID, SCHEDULE_ID)).willReturn(response);
+
+		ResponseEntity<?> result = productRestController.schedulesDelete(PRODUCT_ID, SCHEDULE_ID);
+
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		then(scheduleUseCase).should().delete(PRODUCT_ID, SCHEDULE_ID);
+	}
+
+	@Test
+	void 목록_조회_요청이_들어오면_컨트롤러가_유스케이스를_호출한다() {
+		List<SchedulesResponseDto> response = List.of(
+			new SchedulesResponseDto(
+				SCHEDULE_ID,
+				PRODUCT_ID,
+				LocalDate.now().plusDays(1),
+				LocalTime.of(10, 0),
+				LocalTime.of(12, 0),
+				"AVAILABLE",
+				10,
+				SELLER_ID,
+				LocalDateTime.now(),
+				SELLER_ID,
+				LocalDateTime.now()
+			)
+		);
+		given(scheduleUseCase.schedulesList(PRODUCT_ID)).willReturn(response);
+
+		ResponseEntity<?> result = productRestController.schedulesSelectList(PRODUCT_ID);
+
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		then(scheduleUseCase).should().schedulesList(PRODUCT_ID);
 	}
 
 	private void prepareAuthorizedSellerAndOwnedProduct() {


### PR DESCRIPTION
## 관련 이슈
- Close #81 

## 변경 요약
- 상품 일정의 삭제 및 상품별 일정 검색 기능 추가
-

## 주요 변경점
- `ScheduleService`, `ScheduleUseCase`, `OrderRequestDto`, `OrderResponseDto`, `ProductRestController`

## 테스트
- [x] 로컬 실행 확인
- [x] 테스트 통과
- [x] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트

- 