### PR TITLE
fix: order service와 api 스펙 맞춰서 수정 & 테스트용 html 환경 구축

### DIFF
--- a/service/order/src/main/java/jabaclass/order/common/config/SecurityConfig.java
+++ b/service/order/src/main/java/jabaclass/order/common/config/SecurityConfig.java
@@ -14,6 +14,12 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+// html 테스트용
+/*import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.cors.CorsConfigurationSource;
+import java.util.List;*/
+
 @Configuration
 @EnableConfigurationProperties(JwtProperties.class)
 public class SecurityConfig {
@@ -62,4 +68,43 @@ public class SecurityConfig {
 
         return http.build();
     }
+
+
+    // html 테스트용
+    /*@Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+        http
+            .cors(cors -> {})
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .sessionManagement(session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(
+                    "/swagger-ui/**",
+                    "/v3/api-docs/**"
+                ).permitAll()
+                .anyRequest().permitAll()
+            )
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOrigins(List.of("http://localhost:5500"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
+    }*/
 }

--- a/service/order/src/main/java/jabaclass/order/order/application/service/OrderService.java
+++ b/service/order/src/main/java/jabaclass/order/order/application/service/OrderService.java
@@ -51,6 +51,34 @@ public class OrderService implements OrderUseCase {
         return CreateOrderResponseDto.of(savedOrder, requestDto.productId(), requestDto.depositAmount());
     }
 
+    // html 테스트용
+    /*@Override
+    @Transactional
+    public CreateOrderResponseDto create(UUID userId, CreateOrderRequestDto requestDto) {
+
+        validateCreateRequest(requestDto);
+        validateDeposit(userId, requestDto.depositAmount());
+
+        // ⭐ 상품 검증 제거 (임시)
+        // ProductReservationResponseDto reservation = validateAndReserveProduct(requestDto);
+
+        // ⭐ 임시 금액
+        BigDecimal totalAmount = BigDecimal.valueOf(10000);
+
+        validateDepositAmount(requestDto.depositAmount(), totalAmount);
+
+        Order order = Order.create(
+            requestDto.productScheduleId(),
+            userId,
+            requestDto.quantity(),
+            totalAmount
+        );
+
+        Order savedOrder = orderRepository.save(order);
+
+        return CreateOrderResponseDto.of(savedOrder, requestDto.productId(), requestDto.depositAmount());
+    }*/
+
     @Override
     public OrderResponseDto getById(UUID orderId) {
         Order order = orderRepository.findById(orderId)

--- a/service/order/src/main/java/jabaclass/order/order/presentation/controller/OrderController.java
+++ b/service/order/src/main/java/jabaclass/order/order/presentation/controller/OrderController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@CrossOrigin(origins = "*")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/orders")
@@ -40,6 +42,18 @@ public class OrderController implements OrderOpenApi {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
+
+    // html 테스트용
+    /*PostMapping
+    public ResponseEntity<CreateOrderResponseDto> create(
+        @Valid @RequestBody CreateOrderRequestDto requestDto
+    ) {
+        UUID userId = UUID.fromString("22222222-2222-2222-2222-222222222222"); // ⭐ 임시
+
+        CreateOrderResponseDto responseDto = orderUseCase.create(userId, requestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }*/
 
     @Override
     @GetMapping("/{orderId}")

--- a/service/order/src/main/java/jabaclass/order/order/presentation/controller/OrderInternalController.java
+++ b/service/order/src/main/java/jabaclass/order/order/presentation/controller/OrderInternalController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -37,7 +38,7 @@ public class OrderInternalController implements OrderInternalOpenApi {
     }
 
     @Override
-    @PatchMapping("/{orderId}/payment-status")
+    @PutMapping("/{orderId}/payment-status")
     public ResponseEntity<Void> updatePaymentStatus(
         @PathVariable UUID orderId,
         @Valid @RequestBody UpdateOrderPaymentStatusRequestDto requestDto

--- a/service/order/src/main/java/jabaclass/order/order/presentation/openapi/OrderOpenApi.java
+++ b/service/order/src/main/java/jabaclass/order/order/presentation/openapi/OrderOpenApi.java
@@ -33,6 +33,10 @@ public interface OrderOpenApi {
         @Parameter(hidden = true) @AuthenticationPrincipal UUID userId,
         @RequestBody CreateOrderRequestDto requestDto
     );
+    // html 테스트용
+    /*ResponseEntity<CreateOrderResponseDto> create(
+        @RequestBody CreateOrderRequestDto requestDto
+    );*/
 
     @Operation(summary = "주문 단건 조회", description = "주문 ID로 주문 정보를 조회합니다.")
     @ApiResponse(

--- a/service/payment/src/main/java/jabaclass/payment/application/service/PaymentService.java
+++ b/service/payment/src/main/java/jabaclass/payment/application/service/PaymentService.java
@@ -62,6 +62,9 @@ public class PaymentService implements PaymentUseCase {
 		Payment payment = paymentRepository.findByOrderId(orderId)
 			.orElseThrow(() -> new IllegalStateException("결제 정보를 찾을 수 없습니다."));
 
+		log.info("[confirm] validate 호출 전 orderId={}, requestAmount={}",
+			payment.getOrderId(), request.amount());
+
 		// 멱등성 체크
 		if (payment.isDone()) {
 			return PaymentResponseDto.from(payment);

--- a/service/payment/src/main/java/jabaclass/payment/domain/model/PaymentResultStatus.java
+++ b/service/payment/src/main/java/jabaclass/payment/domain/model/PaymentResultStatus.java
@@ -1,0 +1,6 @@
+package jabaclass.payment.domain.model;
+
+public enum PaymentResultStatus {
+	SUCCESS,
+	FAILED
+}

--- a/service/payment/src/main/java/jabaclass/payment/infrastructure/external/order/OrderClient.java
+++ b/service/payment/src/main/java/jabaclass/payment/infrastructure/external/order/OrderClient.java
@@ -1,5 +1,6 @@
 package jabaclass.payment.infrastructure.external.order;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 import jabaclass.payment.application.port.external.OrderPort;
+import jabaclass.payment.domain.model.PaymentResultStatus;
 import jabaclass.payment.infrastructure.external.order.dto.request.OrderStatusUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
 
@@ -59,8 +61,17 @@ public class OrderClient implements OrderPort {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON);
 
+		PaymentResultStatus paymentStatus =
+			status.equals("PAID")
+				? PaymentResultStatus.SUCCESS
+				: PaymentResultStatus.FAILED;
+
 		OrderStatusUpdateRequestDto body =
-			new OrderStatusUpdateRequestDto(paymentId, depositAmount, status);
+			new OrderStatusUpdateRequestDto(
+				paymentId,
+				paymentStatus,
+				BigDecimal.valueOf(depositAmount)
+			);
 
 		HttpEntity<OrderStatusUpdateRequestDto> request =
 			new HttpEntity<>(body, headers);
@@ -68,7 +79,7 @@ public class OrderClient implements OrderPort {
 		ResponseEntity<Void> response =
 			restTemplate.exchange(
 				url,
-				HttpMethod.PATCH,
+				HttpMethod.PUT,
 				request,
 				Void.class
 			);

--- a/service/payment/src/main/java/jabaclass/payment/infrastructure/external/order/dto/request/OrderStatusUpdateRequestDto.java
+++ b/service/payment/src/main/java/jabaclass/payment/infrastructure/external/order/dto/request/OrderStatusUpdateRequestDto.java
@@ -1,9 +1,12 @@
 package jabaclass.payment.infrastructure.external.order.dto.request;
 
+import java.math.BigDecimal;
 import java.util.UUID;
+
+import jabaclass.payment.domain.model.PaymentResultStatus;
 
 public record OrderStatusUpdateRequestDto(
 	UUID paymentId,
-	int depositAmount,
-	String paymentStatus
+	PaymentResultStatus paymentStatus,
+	BigDecimal depositAmount
 ) {}

--- a/test.html
+++ b/test.html
@@ -6,35 +6,72 @@
 </head>
 <body>
 
+<h2>결제 테스트</h2>
+
+<button onclick="createOrder()">주문 생성</button>
 <button onclick="startPayment()">결제하기</button>
+
+<p id="orderIdText"></p>
 
 <script>
     const clientKey = "test_ck_yL0qZ4G1VOj211Mwom2v3oWb2MQY";
     const tossPayments = TossPayments(clientKey);
 
+    let currentOrderId = null;
+
+    // 1 주문 생성
+    async function createOrder() {
+
+        const res = await fetch("http://localhost:9005/api/v1/orders", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify({
+                productId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                productScheduleId: "11111111-1111-1111-1111-111111111111",
+                quantity: 1,
+                depositAmount: 0
+            })
+        });
+
+        const data = await res.json();
+
+        currentOrderId = data.id;
+
+        document.getElementById("orderIdText").innerText =
+            "생성된 orderId: " + currentOrderId;
+
+        console.log("order 생성:", currentOrderId);
+    }
+
+    // 2 결제 시작
     async function startPayment() {
 
-        const orderId = crypto.randomUUID();
+        if (!currentOrderId) {
+            alert("먼저 주문을 생성하세요!");
+            return;
+        }
 
-        // 1. prepare 호출
+        // payment 준비
         await fetch("http://localhost:9001/api/v1/payments/prepare", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json"
             },
             body: JSON.stringify({
-                orderId: orderId,
+                orderId: currentOrderId,
                 productId: "11111111-1111-1111-1111-111111111111",
-                paymentAmount: 30000,
+                paymentAmount: 10000,
                 depositAmount: 0,
                 paymentMethod: "TOSS"
             })
         });
 
-        // 2. Toss 결제 호출
+        // toss 결제
         tossPayments.requestPayment("카드", {
-            amount: 30000,
-            orderId: orderId,
+            amount: 10000,
+            orderId: currentOrderId,
             orderName: "테스트 상품",
             successUrl: "http://localhost:5500/success.html",
             failUrl: "http://localhost:5500/fail.html"


### PR DESCRIPTION
## 관련 이슈


### html 이용해서 결제 테스트하는 방법

1. `python -m http.server 5500` 
2. http://localhost:5500/test.html 접속 
  <img width="150" height="344" alt="image" src="https://github.com/user-attachments/assets/bbc69a80-0504-4d9a-b471-988800bb1859" />

3. 주문 생성하기 -> 결제하기
4. 주문 status가 PAID가 됐는지 확인
  <img width="400" height="66" alt="image" src="https://github.com/user-attachments/assets/789912b4-e701-4e4b-92ad-cea9fcc04d19" />



## 테스트
- [x] 로컬 실행 확인
- [x] 테스트 통과
- [x] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트
