### PR TITLE
feat: Order -> Product 응답 구조 변경

### DIFF
--- a/service/order/src/main/java/jabaclass/order/order/application/client/ProductClient.java
+++ b/service/order/src/main/java/jabaclass/order/order/application/client/ProductClient.java
@@ -2,11 +2,12 @@ package jabaclass.order.order.application.client;
 
 import java.util.UUID;
 
+import jabaclass.order.order.infrastructure.client.product.dto.ProductReservationStatus;
 import jabaclass.order.order.infrastructure.client.product.dto.ProductReservationResponseDto;
 
 public interface ProductClient {
 
-    ProductReservationResponseDto reserve(UUID productScheduleId, Integer quantity);
+    ProductReservationResponseDto reserve(UUID productScheduleId, UUID userId, Integer quantity);
 
-    void release(UUID productScheduleId, Integer quantity);
+    void updateReservation(UUID productScheduleId, UUID userId, ProductReservationStatus status, UUID productUserId, Integer quantity);
 }

--- a/service/order/src/main/java/jabaclass/order/order/application/service/OrderService.java
+++ b/service/order/src/main/java/jabaclass/order/order/application/service/OrderService.java
@@ -18,6 +18,7 @@ import jabaclass.order.order.presentation.dto.request.UpdateOrderPaymentStatusRe
 import jabaclass.order.order.presentation.dto.response.CreateOrderResponseDto;
 import jabaclass.order.order.presentation.dto.response.OrderResponseDto;
 import jabaclass.order.order.infrastructure.client.product.dto.ProductReservationResponseDto;
+import jabaclass.order.order.infrastructure.client.product.dto.ProductReservationStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,13 +37,14 @@ public class OrderService implements OrderUseCase {
     public CreateOrderResponseDto create(UUID userId, CreateOrderRequestDto requestDto) {
         validateCreateRequest(requestDto);
         validateDeposit(userId, requestDto.depositAmount());
-        ProductReservationResponseDto reservation = validateAndReserveProduct(requestDto);
+        ProductReservationResponseDto reservation = validateAndReserveProduct(userId, requestDto);
         BigDecimal totalAmount = calculateTotalAmount(reservation.price(), requestDto.quantity());
         validateDepositAmount(requestDto.depositAmount(), totalAmount);
 
         Order order = Order.create(
             requestDto.productScheduleId(),
             userId,
+            reservation.productUserId(),
             requestDto.quantity(),
             totalAmount
         );
@@ -70,6 +72,7 @@ public class OrderService implements OrderUseCase {
         Order order = Order.create(
             requestDto.productScheduleId(),
             userId,
+            UUID.randomUUID(),
             requestDto.quantity(),
             totalAmount
         );
@@ -155,13 +158,18 @@ public class OrderService implements OrderUseCase {
         }
     }
 
-    private ProductReservationResponseDto validateAndReserveProduct(CreateOrderRequestDto requestDto) {
+    private ProductReservationResponseDto validateAndReserveProduct(UUID userId, CreateOrderRequestDto requestDto) {
         ProductReservationResponseDto response = productClient.reserve(
             requestDto.productScheduleId(),
+            userId,
             requestDto.quantity()
         );
 
         if (response == null || !response.valid()) {
+            throw new BusinessException(OrderErrorCode.ORDER_PRODUCT_NOT_AVAILABLE);
+        }
+
+        if (response.productUserId() == null) {
             throw new BusinessException(OrderErrorCode.ORDER_PRODUCT_NOT_AVAILABLE);
         }
 
@@ -183,20 +191,45 @@ public class OrderService implements OrderUseCase {
     }
 
     private void processPaymentSuccess(Order order, BigDecimal depositAmount) {
+        UUID productUserId = requireProductUserId(order);
+
         if (depositAmount.signum() > 0) {
             depositClient.use(order.getUserId(), depositAmount);
         }
 
+        productClient.updateReservation(
+            order.getProductScheduleId(),
+            order.getUserId(),
+            ProductReservationStatus.SUCCESS,
+            productUserId,
+            order.getQuantity()
+        );
         order.pay();
     }
 
     private void processPaymentFailure(Order order) {
-        productClient.release(order.getProductScheduleId(), order.getQuantity());
+        UUID productUserId = requireProductUserId(order);
+
+        productClient.updateReservation(
+            order.getProductScheduleId(),
+            order.getUserId(),
+            ProductReservationStatus.FAILED,
+            productUserId,
+            order.getQuantity()
+        );
         order.failPayment();
     }
 
     private void processPaymentCancel(Order order) {
-        productClient.release(order.getProductScheduleId(), order.getQuantity());
+        UUID productUserId = requireProductUserId(order);
+
+        productClient.updateReservation(
+            order.getProductScheduleId(),
+            order.getUserId(),
+            ProductReservationStatus.CANCEL,
+            productUserId,
+            order.getQuantity()
+        );
         order.cancel();
     }
 
@@ -219,5 +252,13 @@ public class OrderService implements OrderUseCase {
         if (depositAmount.compareTo(totalAmount) > 0) {
             throw new IllegalArgumentException("예치금 사용 금액은 주문 가격보다 클 수 없습니다.");
         }
+    }
+
+    private UUID requireProductUserId(Order order) {
+        if (order.getProductUserId() == null) {
+            throw new IllegalStateException("상품 소유자 ID가 없는 주문입니다.");
+        }
+
+        return order.getProductUserId();
     }
 }

--- a/service/order/src/main/java/jabaclass/order/order/domain/model/Order.java
+++ b/service/order/src/main/java/jabaclass/order/order/domain/model/Order.java
@@ -27,6 +27,9 @@ public class Order {
 	@Column(name = "user_id", nullable = false)
 	private UUID userId;
 
+	@Column(name = "product_user_id")
+	private UUID productUserId;
+
 	@Column(name = "quantity", nullable = false)
 	private Integer quantity;
 
@@ -44,6 +47,7 @@ public class Order {
 		UUID id,
 		UUID productScheduleId,
 		UUID userId,
+		UUID productUserId,
 		Integer quantity,
 		BigDecimal price,
 		OrderStatus status
@@ -51,6 +55,7 @@ public class Order {
 		this.id = id;
 		this.productScheduleId = productScheduleId;
 		this.userId = userId;
+		this.productUserId = productUserId;
 		this.quantity = quantity;
 		this.price = price;
 		this.status = status;
@@ -59,16 +64,19 @@ public class Order {
 	public static Order create(
 		UUID productScheduleId,
 		UUID userId,
+		UUID productUserId,
 		Integer quantity,
 		BigDecimal price
 	) {
 		validateQuantity(quantity);
+		validateProductUserId(productUserId);
 		validatePrice(price);
 
 		return new Order(
 			UUID.randomUUID(),
 			productScheduleId,
 			userId,
+			productUserId,
 			quantity,
 			price,
 			OrderStatus.PENDING
@@ -106,6 +114,12 @@ public class Order {
 	private static void validateQuantity(Integer quantity) {
 		if (Objects.isNull(quantity) || quantity <= 0) {
 			throw new IllegalArgumentException("수량은 1 이상이어야 합니다.");
+		}
+	}
+
+	private static void validateProductUserId(UUID productUserId) {
+		if (Objects.isNull(productUserId)) {
+			throw new IllegalArgumentException("상품 소유자 ID는 비어 있을 수 없습니다.");
 		}
 	}
 

--- a/service/order/src/main/java/jabaclass/order/order/infrastructure/client/product/ProductClientAdapter.java
+++ b/service/order/src/main/java/jabaclass/order/order/infrastructure/client/product/ProductClientAdapter.java
@@ -6,6 +6,7 @@ import jabaclass.order.order.application.client.ProductClient;
 import jabaclass.order.order.infrastructure.client.product.dto.ProductReservationReleaseRequestDto;
 import jabaclass.order.order.infrastructure.client.product.dto.ProductReservationRequestDto;
 import jabaclass.order.order.infrastructure.client.product.dto.ProductReservationResponseDto;
+import jabaclass.order.order.infrastructure.client.product.dto.ProductReservationStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -21,19 +22,20 @@ public class ProductClientAdapter implements ProductClient {
     private String productBaseUrl;
 
     @Override
-    public ProductReservationResponseDto reserve(UUID productScheduleId, Integer quantity) {
+    public ProductReservationResponseDto reserve(UUID productScheduleId, UUID userId, Integer quantity) {
         return restTemplate.postForObject(
             productBaseUrl + "/api/v1/products/reservations",
-            new ProductReservationRequestDto(productScheduleId, quantity),
+            new ProductReservationRequestDto(productScheduleId, userId, ProductReservationStatus.PENDING, quantity),
             ProductReservationResponseDto.class
         );
     }
 
     @Override
-    public void release(UUID productScheduleId, Integer quantity) {
+    public void updateReservation(UUID productScheduleId, UUID userId, ProductReservationStatus status, UUID productUserId,
+        Integer quantity) {
         restTemplate.postForLocation(
             productBaseUrl + "/api/v1/products/reservations/release",
-            new ProductReservationReleaseRequestDto(productScheduleId, quantity)
+            new ProductReservationReleaseRequestDto(productScheduleId, userId, status, productUserId, quantity)
         );
     }
 }

--- a/service/order/src/main/java/jabaclass/order/order/infrastructure/client/product/dto/ProductReservationReleaseRequestDto.java
+++ b/service/order/src/main/java/jabaclass/order/order/infrastructure/client/product/dto/ProductReservationReleaseRequestDto.java
@@ -4,6 +4,9 @@ import java.util.UUID;
 
 public record ProductReservationReleaseRequestDto(
     UUID productScheduleId,
+    UUID userId,
+    ProductReservationStatus status,
+    UUID productUserId,
     Integer quantity
 ) {
 }

--- a/service/order/src/main/java/jabaclass/order/order/infrastructure/client/product/dto/ProductReservationRequestDto.java
+++ b/service/order/src/main/java/jabaclass/order/order/infrastructure/client/product/dto/ProductReservationRequestDto.java
@@ -4,6 +4,8 @@ import java.util.UUID;
 
 public record ProductReservationRequestDto(
     UUID productScheduleId,
+    UUID userId,
+    ProductReservationStatus status,
     Integer quantity
 ) {
 }

--- a/service/order/src/main/java/jabaclass/order/order/infrastructure/client/product/dto/ProductReservationResponseDto.java
+++ b/service/order/src/main/java/jabaclass/order/order/infrastructure/client/product/dto/ProductReservationResponseDto.java
@@ -1,10 +1,12 @@
 package jabaclass.order.order.infrastructure.client.product.dto;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 public record ProductReservationResponseDto(
     BigDecimal price,
     Integer quantity,
+    UUID productUserId,
     boolean valid
 ) {
 }

--- a/service/order/src/main/java/jabaclass/order/order/infrastructure/client/product/dto/ProductReservationStatus.java
+++ b/service/order/src/main/java/jabaclass/order/order/infrastructure/client/product/dto/ProductReservationStatus.java
@@ -1,0 +1,8 @@
+package jabaclass.order.order.infrastructure.client.product.dto;
+
+public enum ProductReservationStatus {
+    PENDING,
+    SUCCESS,
+    FAILED,
+    CANCEL
+}

--- a/service/order/src/test/java/jabaclass/order/order/application/service/OrderServiceTest.java
+++ b/service/order/src/test/java/jabaclass/order/order/application/service/OrderServiceTest.java
@@ -17,6 +17,7 @@ import jabaclass.order.order.presentation.dto.request.UpdateOrderPaymentStatusRe
 import jabaclass.order.order.presentation.dto.response.CreateOrderResponseDto;
 import jabaclass.order.order.presentation.dto.response.OrderResponseDto;
 import jabaclass.order.order.infrastructure.client.product.dto.ProductReservationResponseDto;
+import jabaclass.order.order.infrastructure.client.product.dto.ProductReservationStatus;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -53,6 +55,7 @@ class OrderServiceTest {
     void 주문을_생성한다() {
         // given
         UUID userId = UUID.randomUUID();
+        UUID productUserId = UUID.randomUUID();
         CreateOrderRequestDto requestDto = new CreateOrderRequestDto(
             UUID.randomUUID(),
             UUID.randomUUID(),
@@ -60,8 +63,8 @@ class OrderServiceTest {
             new BigDecimal("3000")
         );
         given(depositClient.isValid(userId, requestDto.depositAmount())).willReturn(true);
-        given(productClient.reserve(requestDto.productScheduleId(), requestDto.quantity()))
-            .willReturn(new ProductReservationResponseDto(new BigDecimal("10000"), requestDto.quantity(), true));
+        given(productClient.reserve(requestDto.productScheduleId(), userId, requestDto.quantity()))
+            .willReturn(new ProductReservationResponseDto(new BigDecimal("10000"), requestDto.quantity(), productUserId, true));
         given(orderRepository.save(any(Order.class)))
             .willAnswer(invocation -> invocation.getArgument(0));
 
@@ -77,7 +80,8 @@ class OrderServiceTest {
         assertThat(actual.depositAmount()).isEqualByComparingTo(requestDto.depositAmount());
         assertThat(actual.paymentAmount()).isEqualByComparingTo("17000");
         assertThat(actual.status()).isEqualTo(OrderStatus.PENDING);
-        then(orderRepository).should().save(any(Order.class));
+        then(productClient).should().reserve(requestDto.productScheduleId(), userId, requestDto.quantity());
+        then(orderRepository).should().save(argThat(order -> productUserId.equals(order.getProductUserId())));
     }
 
     @Test
@@ -128,8 +132,8 @@ class OrderServiceTest {
             new BigDecimal("1000")
         );
         given(depositClient.isValid(userId, requestDto.depositAmount())).willReturn(true);
-        given(productClient.reserve(requestDto.productScheduleId(), requestDto.quantity()))
-            .willReturn(new ProductReservationResponseDto(new BigDecimal("10000"), requestDto.quantity(), false));
+        given(productClient.reserve(requestDto.productScheduleId(), userId, requestDto.quantity()))
+            .willReturn(new ProductReservationResponseDto(new BigDecimal("10000"), requestDto.quantity(), null, false));
 
         // when & then
         assertThatThrownBy(() -> orderService.create(userId, requestDto))
@@ -142,6 +146,7 @@ class OrderServiceTest {
     void 주문을_조회한다() {
         // given
         Order order = Order.create(
+            UUID.randomUUID(),
             UUID.randomUUID(),
             UUID.randomUUID(),
             1,
@@ -180,12 +185,14 @@ class OrderServiceTest {
         Order firstOrder = Order.create(
             UUID.randomUUID(),
             userId,
+            UUID.randomUUID(),
             1,
             new BigDecimal("5000")
         );
         Order secondOrder = Order.create(
             UUID.randomUUID(),
             userId,
+            UUID.randomUUID(),
             2,
             new BigDecimal("10000")
         );
@@ -207,6 +214,7 @@ class OrderServiceTest {
         Order order = Order.create(
             UUID.randomUUID(),
             userId,
+            UUID.randomUUID(),
             1,
             new BigDecimal("7000")
         );
@@ -228,6 +236,7 @@ class OrderServiceTest {
         Order order = Order.create(
             UUID.randomUUID(),
             userId,
+            UUID.randomUUID(),
             1,
             new BigDecimal("15000")
         );
@@ -245,6 +254,7 @@ class OrderServiceTest {
     void 다른_사용자의_주문을_취소하면_예외가_발생한다() {
         // given
         Order order = Order.create(
+            UUID.randomUUID(),
             UUID.randomUUID(),
             UUID.randomUUID(),
             1,
@@ -266,6 +276,7 @@ class OrderServiceTest {
         Order order = Order.create(
             UUID.randomUUID(),
             userId,
+            UUID.randomUUID(),
             1,
             new BigDecimal("15000")
         );
@@ -285,6 +296,7 @@ class OrderServiceTest {
         Order order = Order.create(
             UUID.randomUUID(),
             UUID.randomUUID(),
+            UUID.randomUUID(),
             1,
             new BigDecimal("15000")
         );
@@ -300,9 +312,11 @@ class OrderServiceTest {
     @Test
     void 결제_성공을_반영한다() {
         // given
+        UUID productUserId = UUID.randomUUID();
         Order order = Order.create(
             UUID.randomUUID(),
             UUID.randomUUID(),
+            productUserId,
             1,
             new BigDecimal("15000")
         );
@@ -319,14 +333,23 @@ class OrderServiceTest {
         // then
         assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID);
         then(depositClient).should().use(order.getUserId(), new BigDecimal("5000"));
+        then(productClient).should().updateReservation(
+            order.getProductScheduleId(),
+            order.getUserId(),
+            ProductReservationStatus.SUCCESS,
+            productUserId,
+            order.getQuantity()
+        );
     }
 
     @Test
     void 결제_실패를_반영한다() {
         // given
+        UUID productUserId = UUID.randomUUID();
         Order order = Order.create(
             UUID.randomUUID(),
             UUID.randomUUID(),
+            productUserId,
             2,
             new BigDecimal("15000")
         );
@@ -342,15 +365,23 @@ class OrderServiceTest {
 
         // then
         assertThat(order.getStatus()).isEqualTo(OrderStatus.FAILED);
-        then(productClient).should().release(order.getProductScheduleId(), order.getQuantity());
+        then(productClient).should().updateReservation(
+            order.getProductScheduleId(),
+            order.getUserId(),
+            ProductReservationStatus.FAILED,
+            productUserId,
+            order.getQuantity()
+        );
     }
 
     @Test
     void 결제_취소를_반영한다() {
         // given
+        UUID productUserId = UUID.randomUUID();
         Order order = Order.create(
             UUID.randomUUID(),
             UUID.randomUUID(),
+            productUserId,
             2,
             new BigDecimal("15000")
         );
@@ -366,6 +397,12 @@ class OrderServiceTest {
 
         // then
         assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
-        then(productClient).should().release(order.getProductScheduleId(), order.getQuantity());
+        then(productClient).should().updateReservation(
+            order.getProductScheduleId(),
+            order.getUserId(),
+            ProductReservationStatus.CANCEL,
+            productUserId,
+            order.getQuantity()
+        );
     }
 }

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/request/OrderRequestDto.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/request/OrderRequestDto.java
@@ -9,6 +9,15 @@ public record OrderRequestDto(
 	@Schema(description = "주문 일정 Id", example = "550e8400-e29b-41d4-a716-446655440000")
 	UUID productScheduleId,
 
+	@Schema(description = "주문자 Id", example = "550e8400-e29b-41d4-a716-446655440001")
+	UUID userId,
+
+	@Schema(description = "주문 예약 상태", example = "PENDING")
+	ReservationRequestStatus status,
+
+	@Schema(description = "상품 소유자 Id", example = "550e8400-e29b-41d4-a716-446655440002", nullable = true)
+	UUID productUserId,
+
 	@Schema(description = "예약 인원", example = "2")
 	int quantity
 ) {

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/request/ReservationRequestStatus.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/request/ReservationRequestStatus.java
@@ -1,0 +1,8 @@
+package jabaclass.product.presentation.dto.request;
+
+public enum ReservationRequestStatus {
+	PENDING,
+	SUCCESS,
+	FAILED,
+	CANCEL
+}

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/respose/OrderResponseDto.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/respose/OrderResponseDto.java
@@ -1,6 +1,7 @@
 package jabaclass.product.presentation.dto.respose;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jabaclass.product.domain.model.Product;
@@ -12,6 +13,9 @@ public record OrderResponseDto(
 	@Schema(description = "예약 인원", example = "2")
 	int quantity,
 
+	@Schema(description = "상품 소유자 Id", example = "550e8400-e29b-41d4-a716-446655440002", nullable = true)
+	UUID productUserId,
+
 	@Schema(description = "상품 예약 가능 여부", example = "true")
 	boolean valid
 ) {
@@ -19,6 +23,7 @@ public record OrderResponseDto(
 		return new OrderResponseDto(
 			product.getPrice(),
 			quantity,
+			valid ? product.getSellerId() : null,
 			valid
 		);
 	}

--- a/service/product/src/test/java/jabaclass/product/ScheduleTest.java
+++ b/service/product/src/test/java/jabaclass/product/ScheduleTest.java
@@ -53,6 +53,7 @@ import jabaclass.product.infrastructure.acl.dto.SellerResponseDto;
 import jabaclass.product.presentation.ProductRestController;
 import jabaclass.product.presentation.dto.request.CreateScheduleRequestDto;
 import jabaclass.product.presentation.dto.request.OrderRequestDto;
+import jabaclass.product.presentation.dto.request.ReservationRequestStatus;
 import jabaclass.product.presentation.dto.request.UpdateScheduleRequestDto;
 import jabaclass.product.presentation.dto.respose.DeleteScheduleResposeDto;
 import jabaclass.product.presentation.dto.respose.OrderResponseDto;
@@ -91,6 +92,7 @@ class ScheduleTest {
 	private static final UUID SELLER_ID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
 	private static final UUID PRODUCT_ID = UUID.fromString("223e4567-e89b-12d3-a456-426614174000");
 	private static final UUID SCHEDULE_ID = UUID.fromString("323e4567-e89b-12d3-a456-426614174000");
+	private static final UUID USER_ID = UUID.fromString("423e4567-e89b-12d3-a456-426614174000");
 	private static final BigDecimal PRICE = new BigDecimal("1000.50");
 
 	private final ObjectMapper objectMapper = new ObjectMapper();
@@ -407,13 +409,14 @@ class ScheduleTest {
 
 	@Test
 	void 예약_검증에_성공하면_재고를_차감하고_true를_반환한다() {
-		OrderRequestDto request = new OrderRequestDto(SCHEDULE_ID, 3);
+		OrderRequestDto request = new OrderRequestDto(SCHEDULE_ID, USER_ID, ReservationRequestStatus.PENDING, null, 3);
 		given(scheduleRepository.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
 		given(productUseCase.findByIdOrThrow(PRODUCT_ID)).willReturn(product);
 
 		OrderResponseDto result = scheduleService.verification(request);
 
 		assertThat(result.quantity()).isEqualTo(3);
+		assertThat(result.productUserId()).isEqualTo(product.getSellerId());
 		assertThat(result.valid()).isTrue();
 		assertThat(result.price()).isEqualByComparingTo(PRICE);
 		assertThat(schedule.getMaxCapacity()).isEqualTo(7);
@@ -421,13 +424,14 @@ class ScheduleTest {
 
 	@Test
 	void 예약_수량이_재고보다_많으면_false를_반환하고_재고를_유지한다() {
-		OrderRequestDto request = new OrderRequestDto(SCHEDULE_ID, 11);
+		OrderRequestDto request = new OrderRequestDto(SCHEDULE_ID, USER_ID, ReservationRequestStatus.PENDING, null, 11);
 		given(scheduleRepository.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
 		given(productUseCase.findByIdOrThrow(PRODUCT_ID)).willReturn(product);
 
 		OrderResponseDto result = scheduleService.verification(request);
 
 		assertThat(result.quantity()).isEqualTo(11);
+		assertThat(result.productUserId()).isNull();
 		assertThat(result.valid()).isFalse();
 		assertThat(result.price()).isEqualByComparingTo(PRICE);
 		assertThat(schedule.getMaxCapacity()).isEqualTo(10);
@@ -435,7 +439,13 @@ class ScheduleTest {
 
 	@Test
 	void 재고_복원_요청이_오면_수량만큼_재고를_복구한다() {
-		OrderRequestDto request = new OrderRequestDto(SCHEDULE_ID, 2);
+		OrderRequestDto request = new OrderRequestDto(
+			SCHEDULE_ID,
+			USER_ID,
+			ReservationRequestStatus.FAILED,
+			product.getSellerId(),
+			2
+		);
 		schedule.changeMaxCapacity(6);
 		given(scheduleRepository.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
 		given(productUseCase.findByIdOrThrow(PRODUCT_ID)).willReturn(product);
@@ -447,8 +457,8 @@ class ScheduleTest {
 
 	@Test
 	void 예약_검증_요청이_들어오면_컨트롤러가_유스케이스를_호출한다() {
-		OrderRequestDto request = new OrderRequestDto(SCHEDULE_ID, 2);
-		OrderResponseDto response = new OrderResponseDto(PRICE, 2, true);
+		OrderRequestDto request = new OrderRequestDto(SCHEDULE_ID, USER_ID, ReservationRequestStatus.PENDING, null, 2);
+		OrderResponseDto response = new OrderResponseDto(PRICE, 2, product.getSellerId(), true);
 		given(scheduleUseCase.verification(request)).willReturn(response);
 
 		ResponseEntity<OrderResponseDto> result = productRestController.schedulesReservations(request);
@@ -460,7 +470,13 @@ class ScheduleTest {
 
 	@Test
 	void 재고_복원_요청이_들어오면_컨트롤러가_유스케이스를_호출한다() {
-		OrderRequestDto request = new OrderRequestDto(SCHEDULE_ID, 2);
+		OrderRequestDto request = new OrderRequestDto(
+			SCHEDULE_ID,
+			USER_ID,
+			ReservationRequestStatus.CANCEL,
+			product.getSellerId(),
+			2
+		);
 
 		productRestController.schedulesVerification(request);
 


### PR DESCRIPTION
## 관련 이슈
- Close #69

## 변경 요약
- Products 예약/복구 API 요청 형식에 `userId`, `status`, `productUserId`를 반영
- Order 생성 시 Products 응답의 `productUserId`를 저장하고, 결제 성공/실패/취소 시 동일한 형식으로 전달하도록 수정

## 주요 변경점
- `Order -> Products` 예약 요청 시 `status=PENDING`과 `userId`를 함께 전달하도록 변경
- Products 예약 응답에 `productUserId`를 추가하고, 예약 성공 시 Order 엔티티에 저장
- 결제 `SUCCESS/FAILED/CANCELLED` 처리 시 `/reservations/release`로 `status`, `userId`, `productUserId`, `quantity` 전달
- Product/Order 테스트 코드 및 DTO 동기화

## 테스트
- [x] 로컬 실행 확인
- [x] 테스트 통과
- [x] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트
- `productUserId`를 현재 `UUID`로 처리했는데, 실제 계약 타입과 일치하는지 확인 부탁드립니다.
- 결제 성공 시에도 `/reservations/release`를 호출하는 현재 흐름이 Products 쪽 정책과 맞는지 확인 부탁드립니다.
