### PR TITLE
refactor: 취소 상태를 CANCELLED로 통일

### DIFF
--- a/service/order/src/main/java/jabaclass/order/order/application/service/OrderService.java
+++ b/service/order/src/main/java/jabaclass/order/order/application/service/OrderService.java
@@ -177,17 +177,11 @@ public class OrderService implements OrderUseCase {
     }
 
     private void processPaymentResult(Order order, UpdateOrderPaymentStatusRequestDto requestDto) {
-        if (requestDto.paymentStatus() == PaymentResultStatus.SUCCESS) {
-            processPaymentSuccess(order, requestDto.depositAmount());
-            return;
+        switch (requestDto.paymentStatus()) {
+            case SUCCESS -> processPaymentSuccess(order, requestDto.depositAmount());
+            case FAILED -> processPaymentFailure(order);
+            case CANCELLED -> processPaymentCancel(order);
         }
-
-        if (requestDto.paymentStatus() == PaymentResultStatus.FAILED) {
-            processPaymentFailure(order);
-            return;
-        }
-
-        processPaymentCancel(order);
     }
 
     private void processPaymentSuccess(Order order, BigDecimal depositAmount) {
@@ -226,7 +220,7 @@ public class OrderService implements OrderUseCase {
         productClient.updateReservation(
             order.getProductScheduleId(),
             order.getUserId(),
-            ProductReservationStatus.CANCEL,
+            ProductReservationStatus.CANCELLED,
             productUserId,
             order.getQuantity()
         );

--- a/service/order/src/main/java/jabaclass/order/order/domain/model/Order.java
+++ b/service/order/src/main/java/jabaclass/order/order/domain/model/Order.java
@@ -92,7 +92,7 @@ public class Order {
 	}
 
 	public void cancel() {
-		this.status = OrderStatus.CANCELED;
+		this.status = OrderStatus.CANCELLED;
 	}
 
 	public void pay() {

--- a/service/order/src/main/java/jabaclass/order/order/domain/model/OrderStatus.java
+++ b/service/order/src/main/java/jabaclass/order/order/domain/model/OrderStatus.java
@@ -3,7 +3,7 @@ package jabaclass.order.order.domain.model;
 public enum OrderStatus {
     PENDING,
     PAID,
-    CANCELED,
+    CANCELLED,
 	FAILED,
     REFUNDED
 }

--- a/service/order/src/main/java/jabaclass/order/order/infrastructure/client/product/dto/ProductReservationStatus.java
+++ b/service/order/src/main/java/jabaclass/order/order/infrastructure/client/product/dto/ProductReservationStatus.java
@@ -4,5 +4,5 @@ public enum ProductReservationStatus {
     PENDING,
     SUCCESS,
     FAILED,
-    CANCEL
+    CANCELLED
 }

--- a/service/order/src/test/java/jabaclass/order/order/application/service/OrderServiceTest.java
+++ b/service/order/src/test/java/jabaclass/order/order/application/service/OrderServiceTest.java
@@ -246,8 +246,8 @@ class OrderServiceTest {
         OrderResponseDto actual = orderService.cancel(order.getId(), userId);
 
         // then
-        assertThat(actual.status()).isEqualTo(OrderStatus.CANCELED);
-        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
+        assertThat(actual.status()).isEqualTo(OrderStatus.CANCELLED);
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
     }
 
     @Test
@@ -396,11 +396,11 @@ class OrderServiceTest {
         orderService.updatePaymentStatus(order.getId(), requestDto);
 
         // then
-        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
         then(productClient).should().updateReservation(
             order.getProductScheduleId(),
             order.getUserId(),
-            ProductReservationStatus.CANCEL,
+            ProductReservationStatus.CANCELLED,
             productUserId,
             order.getQuantity()
         );

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/request/ReservationRequestStatus.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/request/ReservationRequestStatus.java
@@ -4,5 +4,5 @@ public enum ReservationRequestStatus {
 	PENDING,
 	SUCCESS,
 	FAILED,
-	CANCEL
+	CANCELLED
 }

--- a/service/product/src/test/java/jabaclass/product/ScheduleTest.java
+++ b/service/product/src/test/java/jabaclass/product/ScheduleTest.java
@@ -473,7 +473,7 @@ class ScheduleTest {
 		OrderRequestDto request = new OrderRequestDto(
 			SCHEDULE_ID,
 			USER_ID,
-			ReservationRequestStatus.CANCEL,
+			ReservationRequestStatus.CANCELLED,
 			product.getSellerId(),
 			2
 		);


### PR DESCRIPTION
## 관련 이슈
- Close #69 

## 변경 요약
- Products 예약/복구 API 연동 형식 수정
- 주문 생성 시 상품 소유자 ID 저장 및 취소 상태 표기 통일

## 주요 변경점
- 예약 요청/응답에 `userId`, `status`, `productUserId` 반영
- 결제 성공/실패/취소 시 동일한 형식으로 Products에 전달
- 취소 상태를 `CANCELLED`로 통일

## 테스트
- [x] 로컬 실행 확인
- [x] 테스트 통과

## 리뷰 포인트
- `productUserId` 타입이 실제 API 계약과 일치하는지 확인 부탁드립니다.
