### PR TITLE
fix: 로그인 관련 로직 수정

### DIFF
--- a/common/src/main/java/jabaclass/auth/jwt/JwtProvider.java
+++ b/common/src/main/java/jabaclass/auth/jwt/JwtProvider.java
@@ -50,6 +50,10 @@ public class JwtProvider {
         );
     }
 
+    public boolean isRefreshToken(Claims claims) {
+        return TokenType.REFRESH.name().equals(claims.get(CLAIM_TYPE, String.class));
+    }
+
     // filter에서 parseClaims 중복 호출 방지용
     public boolean isAccessToken(Claims claims) {
         return TokenType.ACCESS.name().equals(claims.get(CLAIM_TYPE, String.class));

--- a/service/user/build.gradle
+++ b/service/user/build.gradle
@@ -51,7 +51,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // DB Driver
-    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    testRuntimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'com.h2database:h2'
 
     // Swagger / OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'

--- a/service/user/build.gradle
+++ b/service/user/build.gradle
@@ -51,9 +51,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // DB Driver
-    testRuntimeOnly 'com.h2database:h2'
-    runtimeOnly 'org.postgresql:postgresql'
-    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
     // Swagger / OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -1,5 +1,6 @@
 package jabaclass.user.auth.application.service;
 
+import io.jsonwebtoken.Claims;
 import jabaclass.auth.jwt.JwtProvider;
 import jabaclass.user.auth.application.exception.AuthErrorCode;
 import jabaclass.user.auth.application.exception.AuthException;
@@ -50,7 +51,14 @@ public class AuthService implements LoginUseCase, LogoutUseCase, ReissueUseCase 
     @Transactional
     public LoginResponseDto reissue(ReissueRequestDto request) {
 
-        UUID userId = jwtProvider.getUserId(request.getRefreshToken());
+        Claims claims = jwtProvider.parseClaims(request.getRefreshToken());
+
+        String tokenType = claims.get("type", String.class);
+        if (!"REFRESH".equals(tokenType)) {
+            throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        UUID userId = jwtProvider.getUserId(claims);
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -42,7 +42,10 @@ public class AuthService implements LoginUseCase, LogoutUseCase, ReissueUseCase 
         String accessToken = tokenProvider.generateAccessToken(user.getId());
         String refreshToken = tokenProvider.generateRefreshToken(user.getId());
 
-        user.updateRefreshToken(refreshToken);
+        User lockedUser = userRepository.findByIdWithLock(user.getId())
+                        .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+        lockedUser.updateRefreshToken(refreshToken);
 
         return new LoginResponseDto(accessToken, refreshToken);
     }
@@ -53,8 +56,7 @@ public class AuthService implements LoginUseCase, LogoutUseCase, ReissueUseCase 
 
         Claims claims = jwtProvider.parseClaims(request.getRefreshToken());
 
-        String tokenType = claims.get("type", String.class);
-        if (!"REFRESH".equals(tokenType)) {
+        if (!jwtProvider.isRefreshToken(claims)) {
             throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 

--- a/service/user/src/main/java/jabaclass/user/auth/infrastructure/jwt/TokenProvider.java
+++ b/service/user/src/main/java/jabaclass/user/auth/infrastructure/jwt/TokenProvider.java
@@ -27,6 +27,9 @@ public class TokenProvider {
             @Value("${jwt.access-token-validity}") long accessTokenValidity,
             @Value("${jwt.refresh-token-validity}") long refreshTokenValidity
     ) {
+        if (secret.length() < 32) {
+            throw new IllegalArgumentException("JWT secret은 최소 32자 이상이어야 합니다.");
+        }
         this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
         this.accessTokenValidity = accessTokenValidity;
         this.refreshTokenValidity = refreshTokenValidity;

--- a/service/user/src/main/java/jabaclass/user/common/config/SecurityConfig.java
+++ b/service/user/src/main/java/jabaclass/user/common/config/SecurityConfig.java
@@ -38,11 +38,11 @@ public class SecurityConfig {
 			);
 
 		http.authorizeHttpRequests(auth -> auth
-			.requestMatchers("/api/v1/auth/**").permitAll()
-			.requestMatchers("/api/v1/users/**").permitAll()
-			.requestMatchers("/api/v1/email/**").permitAll()
 			.requestMatchers("/api/v1/auth/login").permitAll()
 			.requestMatchers("/api/v1/auth/reissue").permitAll()
+			.requestMatchers("/api/v1/users/register").permitAll()
+			.requestMatchers("/api/v1/users/email-check").permitAll()
+			.requestMatchers("/api/v1/email/**").permitAll()
 			.requestMatchers("/api/v1/deposits/validate").permitAll()
 			.requestMatchers("/api/v1/deposits/use").permitAll()
 			.requestMatchers("/swagger-ui/**").permitAll()

--- a/service/user/src/main/java/jabaclass/user/common/error/GlobalExceptionHandler.java
+++ b/service/user/src/main/java/jabaclass/user/common/error/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package jabaclass.user.common.error;
 
-import jakarta.security.auth.message.AuthException;
+import jabaclass.user.auth.application.exception.AuthException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;

--- a/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserJpaRepository.java
+++ b/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserJpaRepository.java
@@ -18,6 +18,5 @@ public interface UserJpaRepository extends JpaRepository<User, UUID> {
 	@Query("SELECT u FROM User u WHERE u.id = :id")
 	Optional<User> findByIdWithLock(UUID id);
 
-	@Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<User> findByEmail(String email);
 }

--- a/service/user/src/main/resources/application.yml
+++ b/service/user/src/main/resources/application.yml
@@ -6,10 +6,16 @@ spring:
     name: user
   profiles:
     active: dev
+
   datasource:
-    url: jdbc:mariadb://localhost:3306/jabaclass
-    username: root
-    password: mariadb
+    url: jdbc:h2:mem:userdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
   jpa:
     hibernate:
       ddl-auto: create-drop
@@ -17,7 +23,7 @@ spring:
       hibernate:
         format_sql: true
     show-sql: true
-    database-platform: org.hibernate.dialect.MariaDBDialect
+    database-platform: org.hibernate.dialect.H2Dialect
 
   mail:
     host: ${MAIL_HOST:localhost}

--- a/service/user/src/main/resources/application.yml
+++ b/service/user/src/main/resources/application.yml
@@ -6,16 +6,10 @@ spring:
     name: user
   profiles:
     active: dev
-
   datasource:
-    url: jdbc:h2:mem:userdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+    url: jdbc:mariadb://localhost:3306/jabaclass
+    username: root
+    password: mariadb
   jpa:
     hibernate:
       ddl-auto: create-drop
@@ -23,7 +17,7 @@ spring:
       hibernate:
         format_sql: true
     show-sql: true
-    database-platform: org.hibernate.dialect.H2Dialect
+    database-platform: org.hibernate.dialect.MariaDBDialect
 
   mail:
     host: ${MAIL_HOST:localhost}
@@ -47,5 +41,5 @@ payment:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-validity: 3600000
+  access-token-validity: 1800000
   refresh-token-validity: 604800000


### PR DESCRIPTION
## 관련 이슈
- Close #86 

## 변경 요약
- permitAll() 보안 문제 및 중복  코드 수정
- reissue에 refresh token 타입 검증 추가
- GlobalExceptionHandler의 잘못된 imoort 수정
- findByEmail에 비관적 Lock 제거
- TokenProvider에 secret 길이 검증 로직 추가

## 주요 변경점
- 인증 및 User 모듈에 회원가입 로그인 관련 보완 사항 및 에러 야기할 수 있는 잘못된 코드들 수정하였습니다.

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트

- 전에 올렸던 login 기능 구현 로직들과 비교하여 잘못되었거나 잘못을 야기할 수 있는 코드들을 수정해놓은 pr입니다. 확인 부탁드리겠습니다.