### PR TITLE
fix: 사용자 중복 조회 수정

### DIFF
--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -32,7 +32,7 @@ public class AuthService implements LoginUseCase, LogoutUseCase, ReissueUseCase 
     @Transactional
     public LoginResponseDto login(LoginRequestDto request) {
 
-        User user = userRepository.findByEmail(request.getEmail())
+        User user = userRepository.findByEmailWithLock(request.getEmail())
                 .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
@@ -41,9 +41,6 @@ public class AuthService implements LoginUseCase, LogoutUseCase, ReissueUseCase 
 
         String accessToken = tokenProvider.generateAccessToken(user.getId());
         String refreshToken = tokenProvider.generateRefreshToken(user.getId());
-
-        userRepository.findByIdWithLock(user.getId())
-                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
 
         user.updateRefreshToken(refreshToken);
 

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -42,10 +42,10 @@ public class AuthService implements LoginUseCase, LogoutUseCase, ReissueUseCase 
         String accessToken = tokenProvider.generateAccessToken(user.getId());
         String refreshToken = tokenProvider.generateRefreshToken(user.getId());
 
-        User lockedUser = userRepository.findByIdWithLock(user.getId())
-                        .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+        userRepository.findByIdWithLock(user.getId())
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
 
-        lockedUser.updateRefreshToken(refreshToken);
+        user.updateRefreshToken(refreshToken);
 
         return new LoginResponseDto(accessToken, refreshToken);
     }

--- a/service/user/src/main/java/jabaclass/user/user/domain/repository/UserRepository.java
+++ b/service/user/src/main/java/jabaclass/user/user/domain/repository/UserRepository.java
@@ -23,4 +23,6 @@ public interface UserRepository {
 	List<User> findAllByIds(List<UUID> userIds);
 
 	Optional<User> findByEmail(String email);
+
+	Optional<User> findByEmailWithLock(String email);
 }

--- a/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserJpaRepository.java
+++ b/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserJpaRepository.java
@@ -19,4 +19,8 @@ public interface UserJpaRepository extends JpaRepository<User, UUID> {
 	Optional<User> findByIdWithLock(UUID id);
 
     Optional<User> findByEmail(String email);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT u FROM User u WHERE u.email = :email")
+	Optional<User> findByEmailWithLock(String email);
 }

--- a/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -55,4 +55,9 @@ public class UserRepositoryAdapter implements UserRepository {
 	public List<User> findAllByIds(List<UUID> userIds) {
 		return userJpaRepository.findAllById(userIds);
 	}
+
+	@Override
+	public Optional<User> findByEmailWithLock(String email) {
+		return userJpaRepository.findByEmailWithLock(email);
+	}
 }


### PR DESCRIPTION
## 관련 이슈
- Close #86 

## 변경 요약
- login 메서드에서 사용자를 중복 호출하고 있는 로직을 변경하였습니다.

## 주요 변경점
- user 객체를 중복으로 생성하는 대신 findByIdWithLock 사용했습니다.

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트

- 없습니다.