### PR TITLE
refactor: SecurityUtil 위치 변경

### DIFF
--- a/common/src/main/java/jabaclass/auth/exception/JwtErrorCode.java
+++ b/common/src/main/java/jabaclass/auth/exception/JwtErrorCode.java
@@ -8,7 +8,9 @@ public enum JwtErrorCode implements ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰 형식입니다."),
     MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰 형식이 올바르지 않습니다."),
-    EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다.");
+    EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
+    AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+	INVALID_AUTHENTICATION(HttpStatus.UNAUTHORIZED,"인증 정보가 올바르지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/common/src/main/java/jabaclass/auth/util/SecurityUtil.java
+++ b/common/src/main/java/jabaclass/auth/util/SecurityUtil.java
@@ -1,7 +1,7 @@
-package jabaclass.user.common.util;
+package jabaclass.auth.util;
 
-import jabaclass.user.auth.application.exception.AuthErrorCode;
-import jabaclass.user.auth.application.exception.AuthException;
+import jabaclass.auth.exception.JwtAuthException;
+import jabaclass.auth.exception.JwtErrorCode;
 import org.springframework.security.core.context.SecurityContextHolder;
 import java.util.UUID;
 
@@ -15,13 +15,13 @@ public class SecurityUtil {
         if (authentication == null
                 || !authentication.isAuthenticated()
                 || "anonymousUser".equals(authentication.getPrincipal())) {
-            throw new AuthException(AuthErrorCode.AUTHENTICATION_REQUIRED);
+            throw new JwtAuthException(JwtErrorCode.AUTHENTICATION_REQUIRED);
         }
 
         Object principal = authentication.getPrincipal();
 
         if (!(principal instanceof UUID userId)) {
-            throw new AuthException(AuthErrorCode.INVALID_AUTHENTICATION);
+            throw new JwtAuthException(JwtErrorCode.INVALID_AUTHENTICATION);
         }
 
         return userId;

--- a/service/user/src/main/java/jabaclass/user/auth/application/exception/AuthErrorCode.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/exception/AuthErrorCode.java
@@ -10,9 +10,7 @@ public enum AuthErrorCode implements ErrorCode {
 	INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다."),
 	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 refresh token입니다."),
 	REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "refresh token이 일치하지 않습니다."),
-	ALREADY_LOGGED_OUT(HttpStatus.UNAUTHORIZED, "이미 로그아웃된 유저입니다."),
-	AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
-	INVALID_AUTHENTICATION(HttpStatus.UNAUTHORIZED,"인증 정보가 올바르지 않습니다.");
+	ALREADY_LOGGED_OUT(HttpStatus.UNAUTHORIZED, "이미 로그아웃된 유저입니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/service/user/src/main/java/jabaclass/user/auth/presentation/controller/AuthController.java
+++ b/service/user/src/main/java/jabaclass/user/auth/presentation/controller/AuthController.java
@@ -7,7 +7,7 @@ import jabaclass.user.auth.presentation.dto.request.LoginRequestDto;
 import jabaclass.user.auth.presentation.dto.request.ReissueRequestDto;
 import jabaclass.user.auth.presentation.dto.response.LoginResponseDto;
 import jabaclass.user.common.dto.ApiResponseDto;
-import jabaclass.user.common.util.SecurityUtil;
+import jabaclass.auth.util.SecurityUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/service/user/src/main/java/jabaclass/user/user/presentation/controller/UserController.java
+++ b/service/user/src/main/java/jabaclass/user/user/presentation/controller/UserController.java
@@ -1,7 +1,5 @@
 package jabaclass.user.user.presentation.controller;
 
-
-import jabaclass.user.common.util.SecurityUtil;
 import java.util.List;
 import java.util.UUID;
 
@@ -15,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jabaclass.auth.util.SecurityUtil;
 import jabaclass.user.user.application.usercase.UserUseCase;
 import jabaclass.user.user.presentation.dto.request.ChangeMyEmailRequestDto;
 import jabaclass.user.user.presentation.dto.request.EmailCheckRequestDto;


### PR DESCRIPTION
## 관련 이슈
- Close #102 

## 변경 요약
- 각 모듈과 user모듈의 의존성을 끊어내기 위해 SecurityUtil클래스 위치를 common 모듈로 옮겼습니다.

## 주요 변경점
- SecurityUtil을 수정하면서 import해서 사용하고 있는 클래스들을 수정했습니다. 
- 관련 예외 코드들을 패키지 위치에 맞게 수정했습니다.

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트

- 변경 후에도 postman을 통해 회원가입 로그인 관련 기능 이상 없음 확인했습니다. merge한 이후에 통합테스트에 문제가 없는지 확인 부탁드립니다.