### PR TITLE
fix: 예약자 꽉 찰시, 스케줄 상태 변경

### DIFF
--- a/service/product/build.gradle
+++ b/service/product/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.postgresql:postgresql:42.6.0'
 }
 
 tasks.named('test') {

--- a/service/product/src/main/java/jabaclass/product/application/service/ScheduleService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/ScheduleService.java
@@ -188,8 +188,11 @@ public class ScheduleService implements ScheduleUseCase {
 				requestDto.status()
 			);
 			saved = productUserUseCase.create(dto);
-			log.info(saved.id() + "");
 
+			// 재고가 끝일 경우
+			int count = maxCapacity - saved.guestCount();
+			if (count == 0)
+				schedule.changeStatus(ReservedStatus.FULL);
 		}
 
 		Product product = productUseCase.findByIdOrThrow(schedule.getProductId());


### PR DESCRIPTION
## 관련 이슈
- Close #104 

## 변경 요약
- 예약자가 최대 예약 가능인원수를 채우면 스케줄 상태값 변경

## 주요 변경점
- `SchduleService`

## 테스트
- [x] 로컬 실행 확인
- [x] 테스트 통과
- [x] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트

- 