### PR TITLE
feat: S3 기반 2단계 파일 업로드 기능 구현

### DIFF
--- a/service/file/build.gradle
+++ b/service/file/build.gradle
@@ -24,7 +24,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0'
+//    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0'
+
+    implementation platform('software.amazon.awssdk:bom:2.25.0')
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:s3-transfer-manager'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 

--- a/service/file/build.gradle
+++ b/service/file/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'jabastore'
+group = 'jabaclass'
 version = '0.0.1-SNAPSHOT'
 description = 'file'
 
@@ -19,11 +19,23 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
+    implementation project(':common')
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+//    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/service/file/build.gradle
+++ b/service/file/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-//    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0'
 
     implementation platform('software.amazon.awssdk:bom:2.25.0')
     implementation 'software.amazon.awssdk:s3'
@@ -32,8 +31,9 @@ dependencies {
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
-//    runtimeOnly 'com.h2database:h2'
-    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+//    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    runtimeOnly 'com.h2database:h2'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/service/file/src/main/java/jabaclass/file/FileApplication.java
+++ b/service/file/src/main/java/jabaclass/file/FileApplication.java
@@ -3,8 +3,12 @@ package jabaclass.file;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
+@EnableJpaAuditing
 @ConfigurationPropertiesScan
 public class FileApplication {
 

--- a/service/file/src/main/java/jabaclass/file/FileApplication.java
+++ b/service/file/src/main/java/jabaclass/file/FileApplication.java
@@ -2,8 +2,10 @@ package jabaclass.file;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class FileApplication {
 
     public static void main(String[] args) {

--- a/service/file/src/main/java/jabaclass/file/application/service/FileCleanupEvent.java
+++ b/service/file/src/main/java/jabaclass/file/application/service/FileCleanupEvent.java
@@ -1,0 +1,3 @@
+package jabaclass.file.application.service;
+
+public record FileCleanupEvent(String storagePath) {}

--- a/service/file/src/main/java/jabaclass/file/application/service/FileUploadService.java
+++ b/service/file/src/main/java/jabaclass/file/application/service/FileUploadService.java
@@ -1,0 +1,109 @@
+package jabaclass.file.application.service;
+
+import jabaclass.file.application.usecase.CompleteUploadUseCase;
+import jabaclass.file.application.usecase.RequestUploadUseCase;
+import jabaclass.file.application.usecase.ValidateFileUseCase;
+import jabaclass.file.common.exception.FileErrorCode;
+import jabaclass.file.common.exception.FileException;
+import jabaclass.file.domain.model.File;
+import jabaclass.file.domain.model.status.FileStatus;
+import jabaclass.file.domain.repository.FileRepository;
+import jabaclass.file.infrastructure.s3.S3Uploader;
+import jabaclass.file.presentation.dto.request.UploadRequestDto;
+import jabaclass.file.presentation.dto.response.UploadResponseDto;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FileUploadService implements RequestUploadUseCase, CompleteUploadUseCase, ValidateFileUseCase {
+
+    private final FileRepository fileRepository;
+    private final S3Uploader s3Uploader;
+
+    @Override
+    @Transactional
+    public UploadResponseDto requestUpload(UUID userId, UploadRequestDto request) {
+
+        // 1. storagePath 생성 (userId/fileId/originalName 구조)
+        UUID fileId = UUID.randomUUID();
+        String storagePath = userId + "/" + fileId + "/" + request.getOriginalName();
+
+        // 2. PENDING 상태로 DB 저장
+        File file = File.builder()
+                .userId(userId)
+                .originalName(request.getOriginalName())
+                .storagePath(storagePath)
+                .build();
+
+        fileRepository.save(file);
+
+        // 3. Pre-signed URL 생성
+        String uploadUrl = s3Uploader.generatePresignedUrl(storagePath);
+
+        return new UploadResponseDto(file.getId(), uploadUrl, storagePath);
+    }
+
+    @Override
+    @Transactional
+    public void completeUpload(UUID fileId) {
+
+        File file = fileRepository.findById(fileId)
+                .orElseThrow(() -> new FileException(FileErrorCode.FILE_NOT_FOUND));
+
+        // 이미 처리된 파일이면 예외
+        if (file.getStatus() != FileStatus.PENDING) {
+            throw new FileException(FileErrorCode.FILE_ALREADY_CONFIRMED);
+        }
+
+        // S3 실체 확인
+        if (!s3Uploader.doesObjectExist(file.getStoragePath())) {
+            file.confirmFail();
+            throw new FileException(FileErrorCode.FILE_NOT_UPLOADED);
+        }
+
+        file.confirmSuccess();
+    }
+
+    @Override
+    @Transactional
+    public void validateAndConfirm(UUID fileId) {
+
+        File file = fileRepository.findById(fileId)
+                .orElseThrow(() -> new FileException(FileErrorCode.FILE_NOT_FOUND));
+
+        // SUCCESS 상태면 바로 통과
+        if (file.getStatus() == FileStatus.SUCCESS) {
+            return;
+        }
+
+        // PENDING이면 S3 재확인
+        if (file.getStatus() == FileStatus.PENDING) {
+            if (!s3Uploader.doesObjectExist(file.getStoragePath())) {
+                throw new FileException(FileErrorCode.FILE_NOT_UPLOADED);
+            }
+            file.confirmSuccess();
+            return;
+        }
+
+        // FAIL이면 에러
+        throw new FileException(FileErrorCode.FILE_NOT_UPLOADED);
+    }
+
+    // 24시간 이상 PENDING 상태 파일 정리 (매일 새벽 3시)
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void cleanupPendingFiles() {
+        LocalDateTime threshold = LocalDateTime.now().minusHours(24);
+        fileRepository.findByStatusAndCreatedAtBefore(FileStatus.PENDING, threshold)
+                .forEach(file -> {
+                    s3Uploader.deleteObject(file.getStoragePath());
+                    // DB에서는 삭제하지 않고 FAIL로 마킹
+                    file.confirmFail();
+                });
+    }
+}

--- a/service/file/src/main/java/jabaclass/file/application/service/FileUploadService.java
+++ b/service/file/src/main/java/jabaclass/file/application/service/FileUploadService.java
@@ -29,11 +29,9 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
     @Transactional
     public UploadResponseDto requestUpload(UUID userId, UploadRequestDto request) {
 
-        // 1. storagePath 생성 (userId/fileId/originalName 구조)
         UUID fileId = UUID.randomUUID();
         String storagePath = userId + "/" + fileId + "/" + request.getOriginalName();
 
-        // 2. PENDING 상태로 DB 저장
         File file = File.builder()
                 .userId(userId)
                 .originalName(request.getOriginalName())
@@ -42,7 +40,6 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
 
         fileRepository.save(file);
 
-        // 3. Pre-signed URL 생성
         String uploadUrl = s3Uploader.generatePresignedUrl(storagePath);
 
         return new UploadResponseDto(file.getId(), uploadUrl, storagePath);
@@ -55,13 +52,11 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
         File file = fileRepository.findById(fileId)
                 .orElseThrow(() -> new FileException(FileErrorCode.FILE_NOT_FOUND));
 
-        // 이미 처리된 파일이면 예외
         if (file.getStatus() != FileStatus.PENDING) {
             throw new FileException(FileErrorCode.FILE_ALREADY_CONFIRMED);
         }
 
-        // S3 실체 확인
-        if (!s3Uploader.doesObjectExist(file.getStoragePath())) {
+        if (!s3Uploader.existsInS3(file.getStoragePath())) {
             file.confirmFail();
             throw new FileException(FileErrorCode.FILE_NOT_UPLOADED);
         }
@@ -76,21 +71,18 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
         File file = fileRepository.findById(fileId)
                 .orElseThrow(() -> new FileException(FileErrorCode.FILE_NOT_FOUND));
 
-        // SUCCESS 상태면 바로 통과
         if (file.getStatus() == FileStatus.SUCCESS) {
             return;
         }
 
-        // PENDING이면 S3 재확인
         if (file.getStatus() == FileStatus.PENDING) {
-            if (!s3Uploader.doesObjectExist(file.getStoragePath())) {
+            if (!s3Uploader.existsInS3(file.getStoragePath())) {
                 throw new FileException(FileErrorCode.FILE_NOT_UPLOADED);
             }
             file.confirmSuccess();
             return;
         }
 
-        // FAIL이면 에러
         throw new FileException(FileErrorCode.FILE_NOT_UPLOADED);
     }
 

--- a/service/file/src/main/java/jabaclass/file/application/service/FileUploadService.java
+++ b/service/file/src/main/java/jabaclass/file/application/service/FileUploadService.java
@@ -93,7 +93,7 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
     }
 
     // 24시간 이상 PENDING 상태 파일 정리 (매일 새벽 3시)
-    \@Scheduled(cron = "0 0 3 * * *")
+    @Scheduled(cron = "0 0 3 * * *")
     @Transactional
     public void cleanupPendingFiles() {
         LocalDateTime threshold = LocalDateTime.now().minusHours(24);

--- a/service/file/src/main/java/jabaclass/file/application/service/FileUploadService.java
+++ b/service/file/src/main/java/jabaclass/file/application/service/FileUploadService.java
@@ -108,6 +108,6 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleFileCleanup(FileCleanupEvent event) {
-        s3Uploader.deleteObject(event.getStoragePath());  // DB 커밋 후 S3 삭제
+        s3Uploader.deleteObject(event.storagePath());
     }
 }

--- a/service/file/src/main/java/jabaclass/file/application/service/FileUploadService.java
+++ b/service/file/src/main/java/jabaclass/file/application/service/FileUploadService.java
@@ -33,6 +33,7 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
         String storagePath = userId + "/" + fileId + "/" + request.getOriginalName();
 
         File file = File.builder()
+                .id(fileId)
                 .userId(userId)
                 .originalName(request.getOriginalName())
                 .storagePath(storagePath)

--- a/service/file/src/main/java/jabaclass/file/application/service/FileUploadService.java
+++ b/service/file/src/main/java/jabaclass/file/application/service/FileUploadService.java
@@ -13,10 +13,14 @@ import jabaclass.file.presentation.dto.request.UploadRequestDto;
 import jabaclass.file.presentation.dto.response.UploadResponseDto;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +28,7 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
 
     private final FileRepository fileRepository;
     private final S3Uploader s3Uploader;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -88,15 +93,21 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
     }
 
     // 24시간 이상 PENDING 상태 파일 정리 (매일 새벽 3시)
-    @Scheduled(cron = "0 0 3 * * *")
+    \@Scheduled(cron = "0 0 3 * * *")
     @Transactional
     public void cleanupPendingFiles() {
         LocalDateTime threshold = LocalDateTime.now().minusHours(24);
-        fileRepository.findByStatusAndCreatedAtBefore(FileStatus.PENDING, threshold)
-                .forEach(file -> {
-                    s3Uploader.deleteObject(file.getStoragePath());
-                    // DB에서는 삭제하지 않고 FAIL로 마킹
-                    file.confirmFail();
-                });
+
+        try (Stream<File> files = fileRepository.streamByStatusAndCreatedAtBefore(FileStatus.PENDING, threshold)) {
+            files.forEach(file -> {
+                file.confirmFail();  // DB 상태 변경
+                eventPublisher.publishEvent(new FileCleanupEvent(file.getStoragePath()));
+            });
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleFileCleanup(FileCleanupEvent event) {
+        s3Uploader.deleteObject(event.getStoragePath());  // DB 커밋 후 S3 삭제
     }
 }

--- a/service/file/src/main/java/jabaclass/file/application/usecase/CompleteUploadUseCase.java
+++ b/service/file/src/main/java/jabaclass/file/application/usecase/CompleteUploadUseCase.java
@@ -1,0 +1,7 @@
+package jabaclass.file.application.usecase;
+
+import java.util.UUID;
+
+public interface CompleteUploadUseCase {
+    void completeUpload(UUID fileId);
+}

--- a/service/file/src/main/java/jabaclass/file/application/usecase/RequestUploadUseCase.java
+++ b/service/file/src/main/java/jabaclass/file/application/usecase/RequestUploadUseCase.java
@@ -1,0 +1,9 @@
+package jabaclass.file.application.usecase;
+
+import jabaclass.file.presentation.dto.request.UploadRequestDto;
+import jabaclass.file.presentation.dto.response.UploadResponseDto;
+import java.util.UUID;
+
+public interface RequestUploadUseCase {
+    UploadResponseDto requestUpload(UUID userId, UploadRequestDto requestDto);
+}

--- a/service/file/src/main/java/jabaclass/file/application/usecase/ValidateFileUseCase.java
+++ b/service/file/src/main/java/jabaclass/file/application/usecase/ValidateFileUseCase.java
@@ -1,0 +1,7 @@
+package jabaclass.file.application.usecase;
+
+import java.util.UUID;
+
+public interface ValidateFileUseCase {
+    void validateAndConfirm(UUID fileId);
+}

--- a/service/file/src/main/java/jabaclass/file/common/config/S3Config.java
+++ b/service/file/src/main/java/jabaclass/file/common/config/S3Config.java
@@ -15,12 +15,6 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 @EnableConfigurationProperties(S3Properties.class)
 public class S3Config {
 
-    @Value("${spring.cloud.aws.credentials.access-key}")
-    private String accessKey;
-
-    @Value("${spring.cloud.aws.credentials.secret-key}")
-    private String secretKey;
-
     @Value("${spring.cloud.aws.region.static}")
     private String region;
 
@@ -28,9 +22,6 @@ public class S3Config {
     public S3Client s3Client() {
         return S3Client.builder()
                 .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKey, secretKey)
-                ))
                 .build();
     }
 
@@ -38,9 +29,6 @@ public class S3Config {
     public S3Presigner s3Presigner() {
         return S3Presigner.builder()
                 .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKey, secretKey)
-                ))
                 .build();
     }
 }

--- a/service/file/src/main/java/jabaclass/file/common/config/S3Config.java
+++ b/service/file/src/main/java/jabaclass/file/common/config/S3Config.java
@@ -1,6 +1,8 @@
 package jabaclass.file.common.config;
 
+import jabaclass.file.infrastructure.s3.S3Properties;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -10,6 +12,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
+@EnableConfigurationProperties(S3Properties.class)
 public class S3Config {
 
     @Value("${spring.cloud.aws.credentials.access-key}")

--- a/service/file/src/main/java/jabaclass/file/common/config/S3Config.java
+++ b/service/file/src/main/java/jabaclass/file/common/config/S3Config.java
@@ -1,0 +1,43 @@
+package jabaclass.file.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)
+                ))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)
+                ))
+                .build();
+    }
+}

--- a/service/file/src/main/java/jabaclass/file/common/config/S3Config.java
+++ b/service/file/src/main/java/jabaclass/file/common/config/S3Config.java
@@ -5,8 +5,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;

--- a/service/file/src/main/java/jabaclass/file/common/config/SecurityConfig.java
+++ b/service/file/src/main/java/jabaclass/file/common/config/SecurityConfig.java
@@ -42,6 +42,11 @@ public class SecurityConfig {
     }
 
     @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtProvider(), tokenResolver(), objectMapper());
+    }
+
+    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
@@ -58,11 +63,11 @@ public class SecurityConfig {
 
         http.addFilterBefore(
                 internalApiFilter,
-                JwtAuthenticationFilter.class
+                UsernamePasswordAuthenticationFilter.class
         );
 
         http.addFilterBefore(
-                new JwtAuthenticationFilter(jwtProvider(), tokenResolver(), objectMapper()),
+                jwtAuthenticationFilter(),
                 UsernamePasswordAuthenticationFilter.class
         );
 

--- a/service/file/src/main/java/jabaclass/file/common/config/SecurityConfig.java
+++ b/service/file/src/main/java/jabaclass/file/common/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import jabaclass.file.common.filter.InternalApiFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -23,6 +24,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtProperties jwtProperties;
+    private final InternalApiFilter internalApiFilter;
 
     @Bean
     public JwtProvider jwtProvider() {
@@ -50,9 +52,13 @@ public class SecurityConfig {
                 );
 
         http.authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/internal/**").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                 .anyRequest().authenticated()
+        );
+
+        http.addFilterBefore(
+                internalApiFilter,
+                JwtAuthenticationFilter.class
         );
 
         http.addFilterBefore(

--- a/service/file/src/main/java/jabaclass/file/common/config/SecurityConfig.java
+++ b/service/file/src/main/java/jabaclass/file/common/config/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http,
+                                           JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
@@ -61,15 +62,8 @@ public class SecurityConfig {
                 .anyRequest().authenticated()
         );
 
-        http.addFilterBefore(
-                internalApiFilter,
-                UsernamePasswordAuthenticationFilter.class
-        );
-
-        http.addFilterBefore(
-                jwtAuthenticationFilter(),
-                UsernamePasswordAuthenticationFilter.class
-        );
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(internalApiFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/service/file/src/main/java/jabaclass/file/common/config/SecurityConfig.java
+++ b/service/file/src/main/java/jabaclass/file/common/config/SecurityConfig.java
@@ -23,7 +23,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtProperties jwtProperties;
-    // private final ObjectMapper objectMapper; // 1. 이 줄을 삭제하세요.
 
     @Bean
     public JwtProvider jwtProvider() {
@@ -35,7 +34,6 @@ public class SecurityConfig {
         return new JwtTokenResolver();
     }
 
-    // 2. ObjectMapper를 다시 빈으로 등록합니다.
     @Bean
     public ObjectMapper objectMapper() {
         return new ObjectMapper();
@@ -57,7 +55,6 @@ public class SecurityConfig {
                 .anyRequest().authenticated()
         );
 
-        // 3. 필터에 넣을 때 직접 호출하거나, 메서드 파라미터로 받은 objectMapper()를 사용합니다.
         http.addFilterBefore(
                 new JwtAuthenticationFilter(jwtProvider(), tokenResolver(), objectMapper()),
                 UsernamePasswordAuthenticationFilter.class

--- a/service/file/src/main/java/jabaclass/file/common/config/SecurityConfig.java
+++ b/service/file/src/main/java/jabaclass/file/common/config/SecurityConfig.java
@@ -59,6 +59,7 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .requestMatchers("/api/internal/**").permitAll()
                 .anyRequest().authenticated()
         );
 

--- a/service/file/src/main/java/jabaclass/file/common/config/SecurityConfig.java
+++ b/service/file/src/main/java/jabaclass/file/common/config/SecurityConfig.java
@@ -1,0 +1,68 @@
+package jabaclass.file.common.config;
+
+import jabaclass.auth.filter.JwtAuthenticationFilter;
+import jabaclass.auth.jwt.JwtProperties;
+import jabaclass.auth.jwt.JwtProvider;
+import jabaclass.auth.jwt.JwtTokenResolver;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@EnableConfigurationProperties(JwtProperties.class)
+public class SecurityConfig {
+
+    private final JwtProperties jwtProperties;
+    // private final ObjectMapper objectMapper; // 1. 이 줄을 삭제하세요.
+
+    @Bean
+    public JwtProvider jwtProvider() {
+        return new JwtProvider(jwtProperties);
+    }
+
+    @Bean
+    public JwtTokenResolver tokenResolver() {
+        return new JwtTokenResolver();
+    }
+
+    // 2. ObjectMapper를 다시 빈으로 등록합니다.
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                );
+
+        http.authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/internal/**").permitAll()
+                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .anyRequest().authenticated()
+        );
+
+        // 3. 필터에 넣을 때 직접 호출하거나, 메서드 파라미터로 받은 objectMapper()를 사용합니다.
+        http.addFilterBefore(
+                new JwtAuthenticationFilter(jwtProvider(), tokenResolver(), objectMapper()),
+                UsernamePasswordAuthenticationFilter.class
+        );
+
+        return http.build();
+    }
+}

--- a/service/file/src/main/java/jabaclass/file/common/dto/ApiResponseDto.java
+++ b/service/file/src/main/java/jabaclass/file/common/dto/ApiResponseDto.java
@@ -1,0 +1,28 @@
+package jabaclass.file.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
+public class ApiResponseDto<T> {
+
+    private final HttpStatus status;
+    private final String message;
+    private final T data;
+
+    private ApiResponseDto(HttpStatus status, String message, T data) {
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponseDto<T> success(HttpStatus status, String message, T data) {
+        return new ApiResponseDto<>(status, message, data);
+    }
+
+    public static ApiResponseDto<Void> fail(HttpStatus status, String message) {
+        return new ApiResponseDto<>(status, message, null);
+    }
+}

--- a/service/file/src/main/java/jabaclass/file/common/exception/FileErrorCode.java
+++ b/service/file/src/main/java/jabaclass/file/common/exception/FileErrorCode.java
@@ -1,0 +1,26 @@
+package jabaclass.file.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum FileErrorCode {
+
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
+    FILE_NOT_UPLOADED(HttpStatus.BAD_REQUEST, "S3에 파일이 존재하지 않습니다."),
+    FILE_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "이미 처리된 파일입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    FileErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/service/file/src/main/java/jabaclass/file/common/exception/FileException.java
+++ b/service/file/src/main/java/jabaclass/file/common/exception/FileException.java
@@ -1,0 +1,21 @@
+package jabaclass.file.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class FileException extends RuntimeException {
+
+    private final FileErrorCode errorCode;
+
+    public FileException(FileErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public FileErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public HttpStatus getStatus() {
+        return errorCode.getStatus();
+    }
+}

--- a/service/file/src/main/java/jabaclass/file/common/exception/GlobalExceptionHandler.java
+++ b/service/file/src/main/java/jabaclass/file/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,45 @@
+package jabaclass.file.common.exception;
+
+import jabaclass.file.common.dto.ApiResponseDto;
+import jabaclass.auth.exception.JwtAuthException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.http.HttpStatus;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleValidationException(
+            MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult()
+                .getFieldError()
+                .getDefaultMessage();
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponseDto.fail(HttpStatus.BAD_REQUEST, message));
+    }
+
+    @ExceptionHandler(FileException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleFileException(FileException ex) {
+        return ResponseEntity
+                .status(ex.getStatus())
+                .body(ApiResponseDto.fail(ex.getStatus(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(JwtAuthException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleJwtAuthException(JwtAuthException ex) {
+        return ResponseEntity
+                .status(ex.getErrorCode().getStatus())
+                .body(ApiResponseDto.fail(ex.getErrorCode().getStatus(), ex.getErrorCode().getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleServerError(Exception ex) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponseDto.fail(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다."));
+    }
+}

--- a/service/file/src/main/java/jabaclass/file/common/exception/GlobalExceptionHandler.java
+++ b/service/file/src/main/java/jabaclass/file/common/exception/GlobalExceptionHandler.java
@@ -2,12 +2,14 @@ package jabaclass.file.common.exception;
 
 import jabaclass.file.common.dto.ApiResponseDto;
 import jabaclass.auth.exception.JwtAuthException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.http.HttpStatus;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -38,6 +40,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponseDto<Void>> handleServerError(Exception ex) {
+        log.error("Internal server error occurred", ex);
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponseDto.fail(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다."));

--- a/service/file/src/main/java/jabaclass/file/common/filter/InternalApiFilter.java
+++ b/service/file/src/main/java/jabaclass/file/common/filter/InternalApiFilter.java
@@ -1,0 +1,39 @@
+package jabaclass.file.common.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class InternalApiFilter extends OncePerRequestFilter {
+
+    @Value("${internal.api.key")
+    private String internalKey;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String uri = request.getRequestURI();
+
+        // internal API만 검사
+        if (uri.startsWith("/api/internal/")) {
+
+            String headerKey = request.getHeader("X-INTERNAL-KEY");
+
+            if (headerKey == null || !headerKey.equals(internalKey)) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("Invalid internal API key");
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/service/file/src/main/java/jabaclass/file/common/filter/InternalApiFilter.java
+++ b/service/file/src/main/java/jabaclass/file/common/filter/InternalApiFilter.java
@@ -12,7 +12,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Component
 public class InternalApiFilter extends OncePerRequestFilter {
 
-    @Value("${internal.api.key")
+    @Value("${internal.api.key}")
     private String internalKey;
 
     @Override

--- a/service/file/src/main/java/jabaclass/file/common/model/BaseEntity.java
+++ b/service/file/src/main/java/jabaclass/file/common/model/BaseEntity.java
@@ -1,0 +1,24 @@
+package jabaclass.file.common.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/service/file/src/main/java/jabaclass/file/domain/model/File.java
+++ b/service/file/src/main/java/jabaclass/file/domain/model/File.java
@@ -22,10 +22,10 @@ import lombok.NoArgsConstructor;
 public class File extends BaseEntity {
 
     @Id
-    @Column(columnDefinition = "BINARY(16)")
+    @Column(name = "id", nullable = false, length = 50)
     private UUID id;
 
-    @Column(name = "user_id", nullable = false, columnDefinition = "Binary(16)")
+    @Column(name = "user_id", nullable = false, length = 50)
     private UUID userId;
 
     @Column(name = "storage_path", nullable = false, length = 512)

--- a/service/file/src/main/java/jabaclass/file/domain/model/File.java
+++ b/service/file/src/main/java/jabaclass/file/domain/model/File.java
@@ -1,5 +1,6 @@
 package jabaclass.file.domain.model;
 
+import jabaclass.file.common.model.BaseEntity;
 import jabaclass.file.domain.model.status.FileStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "files")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class File {
+public class File extends BaseEntity {
 
     @Id
     @Column(columnDefinition = "BINARY(16)")

--- a/service/file/src/main/java/jabaclass/file/domain/model/File.java
+++ b/service/file/src/main/java/jabaclass/file/domain/model/File.java
@@ -1,0 +1,60 @@
+package jabaclass.file.domain.model;
+
+import jabaclass.file.domain.model.status.FileStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "files")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class File {
+
+    @Id
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false, columnDefinition = "Binary(16)")
+    private UUID userId;
+
+    @Column(name = "storage_path", nullable = false, length = 512)
+    private String storagePath;
+
+    @Column(name = "original_name", length = 255)
+    private String originalName;
+
+    @Column(name = "size")
+    private Long size;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private FileStatus status;
+
+    @Builder
+    public File(UUID userId, String originalName, String storagePath, Long size) {
+        this.id = UUID.randomUUID();
+        this.userId = userId;
+        this.originalName = originalName;
+        this.storagePath = storagePath;
+        this.size = size;
+        this.status = FileStatus.PENDING;
+    }
+
+    public void confirmSuccess() {
+        this.status = FileStatus.SUCCESS;
+    }
+
+    public void confirmFail() {
+        this.status = FileStatus.FAIL;
+    }
+}

--- a/service/file/src/main/java/jabaclass/file/domain/model/File.java
+++ b/service/file/src/main/java/jabaclass/file/domain/model/File.java
@@ -42,8 +42,8 @@ public class File extends BaseEntity {
     private FileStatus status;
 
     @Builder
-    public File(UUID userId, String originalName, String storagePath, Long size) {
-        this.id = UUID.randomUUID();
+    public File(UUID id, UUID userId, String originalName, String storagePath, Long size) {
+        this.id = id;
         this.userId = userId;
         this.originalName = originalName;
         this.storagePath = storagePath;

--- a/service/file/src/main/java/jabaclass/file/domain/model/status/FileStatus.java
+++ b/service/file/src/main/java/jabaclass/file/domain/model/status/FileStatus.java
@@ -1,0 +1,7 @@
+package jabaclass.file.domain.model.status;
+
+public enum FileStatus {
+    PENDING,
+    SUCCESS,
+    FAIL
+}

--- a/service/file/src/main/java/jabaclass/file/domain/repository/FileRepository.java
+++ b/service/file/src/main/java/jabaclass/file/domain/repository/FileRepository.java
@@ -1,11 +1,16 @@
 package jabaclass.file.domain.repository;
 
+import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
+
 import jabaclass.file.domain.model.File;
 import jabaclass.file.domain.model.status.FileStatus;
+import jakarta.persistence.QueryHint;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
+import org.springframework.data.jpa.repository.QueryHints;
 
 public interface FileRepository {
 
@@ -14,4 +19,7 @@ public interface FileRepository {
     Optional<File> findById(UUID fileId);
 
     List<File> findByStatusAndCreatedAtBefore(FileStatus status, LocalDateTime threshold);
+
+    @QueryHints(@QueryHint(name = HINT_FETCH_SIZE, value = "1000"))
+    Stream<File> streamByStatusAndCreatedAtBefore(FileStatus status, LocalDateTime threshold);
 }

--- a/service/file/src/main/java/jabaclass/file/domain/repository/FileRepository.java
+++ b/service/file/src/main/java/jabaclass/file/domain/repository/FileRepository.java
@@ -1,0 +1,17 @@
+package jabaclass.file.domain.repository;
+
+import jabaclass.file.domain.model.File;
+import jabaclass.file.domain.model.status.FileStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface FileRepository {
+
+    File save(File file);
+
+    Optional<File> findById(UUID fileId);
+
+    List<File> findByStatusAndCreatedAtBefore(FileStatus status, LocalDateTime threshold);
+}

--- a/service/file/src/main/java/jabaclass/file/infrastructure/persistence/FileJpaRepository.java
+++ b/service/file/src/main/java/jabaclass/file/infrastructure/persistence/FileJpaRepository.java
@@ -1,0 +1,13 @@
+package jabaclass.file.infrastructure.persistence;
+
+import jabaclass.file.domain.model.File;
+import jabaclass.file.domain.model.status.FileStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileJpaRepository extends JpaRepository<File, UUID> {
+
+    List<File> findByStatusAndCreatedAtBefore(FileStatus status, LocalDateTime threshold);
+}

--- a/service/file/src/main/java/jabaclass/file/infrastructure/persistence/FileJpaRepository.java
+++ b/service/file/src/main/java/jabaclass/file/infrastructure/persistence/FileJpaRepository.java
@@ -2,12 +2,18 @@ package jabaclass.file.infrastructure.persistence;
 
 import jabaclass.file.domain.model.File;
 import jabaclass.file.domain.model.status.FileStatus;
+import jakarta.persistence.QueryHint;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.QueryHints;
 
 public interface FileJpaRepository extends JpaRepository<File, UUID> {
 
     List<File> findByStatusAndCreatedAtBefore(FileStatus status, LocalDateTime threshold);
+
+    @QueryHints(@QueryHint(name = org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE, value = "1000"))
+    Stream<File> streamByStatusAndCreatedAtBefore(FileStatus status, LocalDateTime threshold);
 }

--- a/service/file/src/main/java/jabaclass/file/infrastructure/persistence/FileRepositoryAdapter.java
+++ b/service/file/src/main/java/jabaclass/file/infrastructure/persistence/FileRepositoryAdapter.java
@@ -1,0 +1,33 @@
+package jabaclass.file.infrastructure.persistence;
+
+import jabaclass.file.domain.model.File;
+import jabaclass.file.domain.model.status.FileStatus;
+import jabaclass.file.domain.repository.FileRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class FileRepositoryAdapter implements FileRepository {
+
+    private final FileJpaRepository fileJpaRepository;
+
+    @Override
+    public File save(File file) {
+        return fileJpaRepository.save(file);
+    }
+
+    @Override
+    public Optional<File> findById(UUID fileId) {
+        return fileJpaRepository.findById(fileId);
+    }
+
+    @Override
+    public List<File> findByStatusAndCreatedAtBefore(FileStatus status, LocalDateTime threshold) {
+        return fileJpaRepository.findByStatusAndCreatedAtBefore(status, threshold);
+    }
+}

--- a/service/file/src/main/java/jabaclass/file/infrastructure/persistence/FileRepositoryAdapter.java
+++ b/service/file/src/main/java/jabaclass/file/infrastructure/persistence/FileRepositoryAdapter.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -29,5 +30,10 @@ public class FileRepositoryAdapter implements FileRepository {
     @Override
     public List<File> findByStatusAndCreatedAtBefore(FileStatus status, LocalDateTime threshold) {
         return fileJpaRepository.findByStatusAndCreatedAtBefore(status, threshold);
+    }
+
+    @Override
+    public Stream<File> streamByStatusAndCreatedAtBefore(FileStatus status, LocalDateTime threshold) {
+        return fileJpaRepository.streamByStatusAndCreatedAtBefore(status, threshold);
     }
 }

--- a/service/file/src/main/java/jabaclass/file/infrastructure/s3/S3Properties.java
+++ b/service/file/src/main/java/jabaclass/file/infrastructure/s3/S3Properties.java
@@ -1,0 +1,17 @@
+package jabaclass.file.infrastructure.s3;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
+
+@Getter
+@ConfigurationProperties(prefix = "cloud.aws.s3")
+public class S3Properties {
+
+    private final String bucket;
+
+    @ConstructorBinding
+    public S3Properties(String bucket) {
+        this.bucket = bucket;
+    }
+}

--- a/service/file/src/main/java/jabaclass/file/infrastructure/s3/S3Properties.java
+++ b/service/file/src/main/java/jabaclass/file/infrastructure/s3/S3Properties.java
@@ -5,7 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 @Getter
-@ConfigurationProperties(prefix = "cloud.aws.s3")
+@ConfigurationProperties(prefix = "spring.cloud.aws.s3")
 public class S3Properties {
 
     private final String bucket;

--- a/service/file/src/main/java/jabaclass/file/infrastructure/s3/S3Properties.java
+++ b/service/file/src/main/java/jabaclass/file/infrastructure/s3/S3Properties.java
@@ -7,11 +7,12 @@ import org.springframework.boot.context.properties.bind.ConstructorBinding;
 @Getter
 @ConfigurationProperties(prefix = "spring.cloud.aws.s3")
 public class S3Properties {
-
     private final String bucket;
+    private final long presignedUrlExpiration;
 
     @ConstructorBinding
-    public S3Properties(String bucket) {
+    public S3Properties(String bucket, Long presignedUrlExpiration) {
         this.bucket = bucket;
+        this.presignedUrlExpiration = presignedUrlExpiration;
     }
 }

--- a/service/file/src/main/java/jabaclass/file/infrastructure/s3/S3Uploader.java
+++ b/service/file/src/main/java/jabaclass/file/infrastructure/s3/S3Uploader.java
@@ -1,11 +1,7 @@
 package jabaclass.file.infrastructure.s3;
 
-import jabaclass.file.domain.model.File;
 import java.time.Duration;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.BadRequestException;
-import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;

--- a/service/file/src/main/java/jabaclass/file/infrastructure/s3/S3Uploader.java
+++ b/service/file/src/main/java/jabaclass/file/infrastructure/s3/S3Uploader.java
@@ -1,0 +1,54 @@
+package jabaclass.file.infrastructure.s3;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
+    private final S3Properties s3Properties;
+
+    // 유효시간 5분
+    public String generatePresignedUrl(String storagePath) {
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(5))
+                .putObjectRequest(req -> req
+                        .bucket(s3Properties.getBucket())
+                        .key(storagePath)
+                )
+                .build();
+
+        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
+        return presignedRequest.url().toString();
+    }
+
+    public boolean doesObjectExist(String storagePath) {
+        try {
+            s3Client.headObject(HeadObjectRequest.builder()
+                    .bucket(s3Properties.getBucket())
+                    .key(storagePath)
+                    .build());
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
+        }
+    }
+
+    public void deleteObject(String storagePath) {
+        s3Client.deleteObject(req -> req
+                .bucket(s3Properties.getBucket())
+                .key(storagePath)
+        );
+    }
+}

--- a/service/file/src/main/java/jabaclass/file/infrastructure/s3/S3Uploader.java
+++ b/service/file/src/main/java/jabaclass/file/infrastructure/s3/S3Uploader.java
@@ -1,7 +1,11 @@
 package jabaclass.file.infrastructure.s3;
 
+import jabaclass.file.domain.model.File;
 import java.time.Duration;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.BadRequestException;
+import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
@@ -33,11 +37,11 @@ public class S3Uploader {
         return presignedRequest.url().toString();
     }
 
-    public boolean doesObjectExist(String storagePath) {
+    public boolean existsInS3(String key) {
         try {
             s3Client.headObject(HeadObjectRequest.builder()
                     .bucket(s3Properties.getBucket())
-                    .key(storagePath)
+                    .key(key)
                     .build());
             return true;
         } catch (NoSuchKeyException e) {

--- a/service/file/src/main/java/jabaclass/file/infrastructure/s3/S3Uploader.java
+++ b/service/file/src/main/java/jabaclass/file/infrastructure/s3/S3Uploader.java
@@ -19,10 +19,9 @@ public class S3Uploader {
     private final S3Client s3Client;
     private final S3Properties s3Properties;
 
-    // 유효시간 5분
     public String generatePresignedUrl(String storagePath) {
         PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
-                .signatureDuration(Duration.ofMinutes(5))
+                .signatureDuration(Duration.ofMinutes(s3Properties.getPresignedUrlExpiration()))
                 .putObjectRequest(req -> req
                         .bucket(s3Properties.getBucket())
                         .key(storagePath)

--- a/service/file/src/main/java/jabaclass/file/presentation/controller/FileController.java
+++ b/service/file/src/main/java/jabaclass/file/presentation/controller/FileController.java
@@ -5,7 +5,7 @@ import jabaclass.file.application.usecase.RequestUploadUseCase;
 import jabaclass.file.common.dto.ApiResponseDto;
 import jabaclass.file.presentation.dto.request.UploadRequestDto;
 import jabaclass.file.presentation.dto.response.UploadResponseDto;
-import jabastore.auth.util.SecurityUtil;
+import jabaclass.auth.util.SecurityUtil;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;

--- a/service/file/src/main/java/jabaclass/file/presentation/controller/FileController.java
+++ b/service/file/src/main/java/jabaclass/file/presentation/controller/FileController.java
@@ -1,0 +1,47 @@
+package jabaclass.file.presentation.controller;
+
+import jabaclass.file.application.usecase.CompleteUploadUseCase;
+import jabaclass.file.application.usecase.RequestUploadUseCase;
+import jabaclass.file.common.dto.ApiResponseDto;
+import jabaclass.file.presentation.dto.request.UploadRequestDto;
+import jabaclass.file.presentation.dto.response.UploadResponseDto;
+import jabastore.auth.util.SecurityUtil;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/files")
+@RequiredArgsConstructor
+public class FileController {
+
+    private final RequestUploadUseCase requestUploadUseCase;
+    private final CompleteUploadUseCase completeUploadUseCase;
+
+    @PostMapping("/upload-request")
+    public ResponseEntity<ApiResponseDto<UploadResponseDto>> requestUpload(
+            @Valid @RequestBody UploadRequestDto request) {
+        UUID userId = SecurityUtil.getCurrentUserId();
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponseDto.success(HttpStatus.OK, "업로드 URL 발급 성공",
+                        requestUploadUseCase.requestUpload(userId, request)));
+    }
+
+    @PatchMapping("/{fileId}/complete")
+    public ResponseEntity<ApiResponseDto<Void>> completeUpload(
+            @PathVariable UUID fileId) {
+        completeUploadUseCase.completeUpload(fileId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponseDto.success(HttpStatus.OK, "파일 업로드 확정 성공", null));
+    }
+}

--- a/service/file/src/main/java/jabaclass/file/presentation/controller/InternalFileController.java
+++ b/service/file/src/main/java/jabaclass/file/presentation/controller/InternalFileController.java
@@ -1,0 +1,29 @@
+package jabaclass.file.presentation.controller;
+
+import jabaclass.file.application.usecase.ValidateFileUseCase;
+import jabaclass.file.common.dto.ApiResponseDto;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/internal/files")
+@RequiredArgsConstructor
+public class InternalFileController {
+
+    private final ValidateFileUseCase validateFileUseCase;
+
+    @PostMapping("/{fileId}/validate")
+    public ResponseEntity<ApiResponseDto<Void>> validateFile(
+            @PathVariable UUID fileId) {
+        validateFileUseCase.validateAndConfirm(fileId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponseDto.success(HttpStatus.OK, "파일 검증 성공", null));
+    }
+}

--- a/service/file/src/main/java/jabaclass/file/presentation/dto/request/UploadRequestDto.java
+++ b/service/file/src/main/java/jabaclass/file/presentation/dto/request/UploadRequestDto.java
@@ -1,0 +1,11 @@
+package jabaclass.file.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class UploadRequestDto {
+
+    @NotBlank(message = "파일명을 입력해주세요")
+    private String originalName;
+}

--- a/service/file/src/main/java/jabaclass/file/presentation/dto/response/UploadResponseDto.java
+++ b/service/file/src/main/java/jabaclass/file/presentation/dto/response/UploadResponseDto.java
@@ -1,0 +1,14 @@
+package jabaclass.file.presentation.dto.response;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UploadResponseDto {
+
+    private UUID fileId;
+    private String uploadUrl;
+    private String storagePath;
+}

--- a/service/file/src/main/resources/application.yml
+++ b/service/file/src/main/resources/application.yml
@@ -5,24 +5,27 @@ spring:
   application:
     name: file
 
-  # 데이터베이스 설정
   datasource:
-    url: jdbc:mariadb://localhost:3306/jabaclass
-    username: root
-    password: ${DB_PASSWORD}
-    driver-class-name: org.mariadb.jdbc.Driver
+    url: jdbc:h2:tcp://localhost/~/test
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
 
-  # JPA 설정
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
   jpa:
+    defer-datasource-initialization: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true
     show-sql: true
-    database-platform: org.hibernate.dialect.MariaDBDialect
+    database-platform: org.hibernate.dialect.H2Dialect
 
-  # AWS S3 설정
   cloud:
     aws:
       s3:
@@ -33,21 +36,18 @@ spring:
         access-key: ${AWS_ACCESS_KEY}
         secret-key: ${AWS_SECRET_KEY}
 
-# JWT 설정
 jwt:
   secret: ${JWT_SECRET}
   access-token-validity: 1800000
   refresh-token-validity: 604800000
 
-# Swagger (SpringDoc) 설정
-#springdoc:
-#  swagger-ui:
-#    path: /swagger-ui.html
-#  api-docs:
-#    path: /v3/api-docs
-#    version: OPENAPI_3_0
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs
+    version: OPENAPI_3_0
 
-# 로깅 설정
 logging:
   level:
     jabaclass: DEBUG

--- a/service/file/src/main/resources/application.yml
+++ b/service/file/src/main/resources/application.yml
@@ -1,24 +1,18 @@
-server.port: 9008
+server:
+  port: 9000
+
 spring:
   application:
     name: file
 
-  #  datasource:
-  #    url: jdbc:h2:tcp://localhost/~/test
-  #    driver-class-name: org.h2.Driver
-  #    username: sa
-  #    password:
-
+  # 데이터베이스 설정
   datasource:
     url: jdbc:mariadb://localhost:3306/jabaclass
     username: root
     password: ${DB_PASSWORD}
+    driver-class-name: org.mariadb.jdbc.Driver
 
-  #  h2:
-  #    console:
-  #      enabled: true
-  #      path: /h2-console
-
+  # JPA 설정
   jpa:
     hibernate:
       ddl-auto: create-drop
@@ -28,30 +22,33 @@ spring:
     show-sql: true
     database-platform: org.hibernate.dialect.MariaDBDialect
 
+  # AWS S3 설정
+  cloud:
+    aws:
+      s3:
+        bucket: ${S3_BUCKET_NAME}
+      region:
+        static: ap-northeast-2
+      credentials:
+        access-key: ${AWS_ACCESS_KEY}
+        secret-key: ${AWS_SECRET_KEY}
 
+# JWT 설정
 jwt:
   secret: ${JWT_SECRET}
   access-token-validity: 1800000
   refresh-token-validity: 604800000
 
+# Swagger (SpringDoc) 설정
+#springdoc:
+#  swagger-ui:
+#    path: /swagger-ui.html
+#  api-docs:
+#    path: /v3/api-docs
+#    version: OPENAPI_3_0
+
+# 로깅 설정
 logging:
   level:
     jabaclass: DEBUG
     org.springframework.web: DEBUG
-
-  springdoc:
-    swagger-ui:
-      path: /swagger-ui.html
-    api-docs:
-      path: /v3/api-docs
-      version: OPENAPI_3_0
-
-cloud:
-  aws:
-    s3:
-      bucket: ${S3_BUCKET_NAME}
-    region:
-      static: ap-northeast-2
-    credentials:
-      access-key: ${AWS_ACCESS_KEY}
-      secret-key: ${AWS_SECRET_KEY}

--- a/service/file/src/main/resources/application.yml
+++ b/service/file/src/main/resources/application.yml
@@ -40,6 +40,10 @@ jwt:
   access-token-validity: 1800000
   refresh-token-validity: 604800000
 
+internal:
+  api:
+    key: test-internal-key
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html

--- a/service/file/src/main/resources/application.yml
+++ b/service/file/src/main/resources/application.yml
@@ -28,15 +28,15 @@ spring:
   cloud:
     aws:
       s3:
-        bucket: ${S3_BUCKET_NAME}
+        bucket: test-bucket
       region:
         static: ap-northeast-2
       credentials:
-        access-key: ${AWS_ACCESS_KEY}
-        secret-key: ${AWS_SECRET_KEY}
+        access-key: test-access-key
+        secret-key: test-secret-key
 
 jwt:
-  secret: ${JWT_SECRET}
+  secret: test-jwt-secret-key
   access-token-validity: 1800000
   refresh-token-validity: 604800000
 

--- a/service/file/src/main/resources/application.yml
+++ b/service/file/src/main/resources/application.yml
@@ -28,15 +28,14 @@ spring:
   cloud:
     aws:
       s3:
-        bucket: test-bucket
+        bucket: ${S3_BUCKET_NAME}
+        presigned-url-expiration: 5
       region:
         static: ap-northeast-2
-      credentials:
-        access-key: test-access-key
-        secret-key: test-secret-key
+      # credentials는 application-local.yml 또는 환경변수로 관리
 
 jwt:
-  secret: 3f2c9a1b7d4e8f6a9c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3 #random
+  secret: 3f2c9a1b7d4e8f6a9c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3
   access-token-validity: 1800000
   refresh-token-validity: 604800000
 

--- a/service/file/src/main/resources/application.yml
+++ b/service/file/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     name: file
 
   datasource:
-    url: jdbc:h2:tcp://localhost/~/test
+    url: jdbc:h2:mem:testdb
     driver-class-name: org.h2.Driver
     username: sa
     password:
@@ -17,7 +17,6 @@ spring:
       path: /h2-console
 
   jpa:
-    defer-datasource-initialization: true
     hibernate:
       ddl-auto: create
     properties:

--- a/service/file/src/main/resources/application.yml
+++ b/service/file/src/main/resources/application.yml
@@ -1,3 +1,57 @@
-server.port: 9000
+server.port: 9008
 spring:
-  application: name:file
+  application:
+    name: file
+
+  #  datasource:
+  #    url: jdbc:h2:tcp://localhost/~/test
+  #    driver-class-name: org.h2.Driver
+  #    username: sa
+  #    password:
+
+  datasource:
+    url: jdbc:mariadb://localhost:3306/jabaclass
+    username: root
+    password: ${DB_PASSWORD}
+
+  #  h2:
+  #    console:
+  #      enabled: true
+  #      path: /h2-console
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: true
+    database-platform: org.hibernate.dialect.MariaDBDialect
+
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-validity: 1800000
+  refresh-token-validity: 604800000
+
+logging:
+  level:
+    jabaclass: DEBUG
+    org.springframework.web: DEBUG
+
+  springdoc:
+    swagger-ui:
+      path: /swagger-ui.html
+    api-docs:
+      path: /v3/api-docs
+      version: OPENAPI_3_0
+
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET_NAME}
+    region:
+      static: ap-northeast-2
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}

--- a/service/file/src/main/resources/application.yml
+++ b/service/file/src/main/resources/application.yml
@@ -36,7 +36,7 @@ spring:
         secret-key: test-secret-key
 
 jwt:
-  secret: test-jwt-secret-key
+  secret: 3f2c9a1b7d4e8f6a9c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3 #random
   access-token-validity: 1800000
   refresh-token-validity: 604800000
 


### PR DESCRIPTION
## 관련 이슈
- Close #100

## 변경 요약
- S3 Presigned URL 기반 파일 업로드 모듈 구현
- 파일 상태 관리 (PENDING → SUCCESS / FAIL) 흐름 구현

## 주요 변경점
- `requestUpload` : S3 Presigned URL 생성 및 DB에 PENDING 상태로 파일 저장
- `completeUpload` : S3 업로드가 확인되지 않은 경우, 파일 상태를 FAIL로 즉시 마킹하여 더 이상 PENDING 상태로 남지 않도록 처리했습니다.
대신 스케줄러는 장시간 PENDING 상태로 남아있는 비정상 케이스만 정리하도록 유지했습니다.
- `validateAndConfirm` : 타 도메인에서 파일 유효성 검증 시 사용하는 UseCase 분리
- `cleanupPendingFiles` : 24시간 이상 PENDING 상태 파일을 매일 새벽 3시에 FAIL 마킹 및 S3 삭제
- `S3Uploader` : SDK v2 기준 `headObject` 방식으로 존재 체크 (`doesObjectExist` 제거)
- `FileStatus` : PENDING / SUCCESS / FAIL 3단계 상태 정의

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트
- `existsInS3`는 SDK v2 `headObject` + `NoSuchKeyException` catch 방식으로 구현했습니다
- 스케줄러 대상 쿼리(`status + created_at`) 인덱스 추가 여부는 추후 논의 필요합니다