### PR TITLE
refactor: product모듈에 storagePath를 넘겨주기 위해 로직 변경

### DIFF
--- a/service/file/src/main/java/jabaclass/file/application/service/FileUploadService.java
+++ b/service/file/src/main/java/jabaclass/file/application/service/FileUploadService.java
@@ -10,6 +10,7 @@ import jabaclass.file.domain.model.status.FileStatus;
 import jabaclass.file.domain.repository.FileRepository;
 import jabaclass.file.infrastructure.s3.S3Uploader;
 import jabaclass.file.presentation.dto.request.UploadRequestDto;
+import jabaclass.file.presentation.dto.response.FileConfirmResponse;
 import jabaclass.file.presentation.dto.response.UploadResponseDto;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -72,13 +73,13 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
 
     @Override
     @Transactional
-    public void validateAndConfirm(UUID fileId) {
+    public FileConfirmResponse validateAndConfirm(UUID fileId) {
 
         File file = fileRepository.findById(fileId)
                 .orElseThrow(() -> new FileException(FileErrorCode.FILE_NOT_FOUND));
 
         if (file.getStatus() == FileStatus.SUCCESS) {
-            return;
+            return new FileConfirmResponse(file.getId(), file.getStoragePath());
         }
 
         if (file.getStatus() == FileStatus.PENDING) {
@@ -86,7 +87,7 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
                 throw new FileException(FileErrorCode.FILE_NOT_UPLOADED);
             }
             file.confirmSuccess();
-            return;
+            return new FileConfirmResponse(file.getId(), file.getStoragePath());
         }
 
         throw new FileException(FileErrorCode.FILE_NOT_UPLOADED);

--- a/service/file/src/main/java/jabaclass/file/application/usecase/ValidateFileUseCase.java
+++ b/service/file/src/main/java/jabaclass/file/application/usecase/ValidateFileUseCase.java
@@ -1,7 +1,8 @@
 package jabaclass.file.application.usecase;
 
+import jabaclass.file.presentation.dto.response.FileConfirmResponse;
 import java.util.UUID;
 
 public interface ValidateFileUseCase {
-    void validateAndConfirm(UUID fileId);
+    FileConfirmResponse validateAndConfirm(UUID fileId);
 }

--- a/service/file/src/main/java/jabaclass/file/presentation/controller/InternalFileController.java
+++ b/service/file/src/main/java/jabaclass/file/presentation/controller/InternalFileController.java
@@ -2,12 +2,13 @@ package jabaclass.file.presentation.controller;
 
 import jabaclass.file.application.usecase.ValidateFileUseCase;
 import jabaclass.file.common.dto.ApiResponseDto;
+import jabaclass.file.presentation.dto.response.FileConfirmResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,12 +19,12 @@ public class InternalFileController {
 
     private final ValidateFileUseCase validateFileUseCase;
 
-    @PostMapping("/{fileId}/validate")
-    public ResponseEntity<ApiResponseDto<Void>> validateFile(
+    @GetMapping("/{fileId}/confirm")
+    public ResponseEntity<ApiResponseDto<FileConfirmResponse>> confirmFile(
             @PathVariable UUID fileId) {
-        validateFileUseCase.validateAndConfirm(fileId);
+        FileConfirmResponse response = validateFileUseCase.validateAndConfirm(fileId);
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(ApiResponseDto.success(HttpStatus.OK, "파일 검증 성공", null));
+                .body(ApiResponseDto.success(HttpStatus.OK, "파일 검증 성공", response));
     }
 }

--- a/service/file/src/main/java/jabaclass/file/presentation/dto/response/FileConfirmResponse.java
+++ b/service/file/src/main/java/jabaclass/file/presentation/dto/response/FileConfirmResponse.java
@@ -1,0 +1,14 @@
+package jabaclass.file.presentation.dto.response;
+
+import java.util.UUID;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class FileConfirmResponse {
+
+    private final UUID fileId;
+
+    private final String storagePath;
+}


### PR DESCRIPTION
## 관련 이슈
- Close #100 

## 변경 요약
- 내부 API `/api/internal/files/{fileId}/validate` (POST) → `/api/internal/files/{fileId}/confirm` (GET) 으로 교체
- 응답에 `storagePath` 포함하여 product-module이 단일 호출로 검증 + 경로 조회를 처리할 수 있도록 개선

## 주요 변경점
- `InternalFileController` : POST `/validate` 제거 → GET `/confirm` 추가, `FileConfirmResponse(fileId, storagePath)` 반환
- `ValidateFileUseCase` : 반환 타입 void → `FileConfirmResponse` 로 변경
- `FileUploadService` : `validateAndConfirm()` 성공 시 storagePath 포함하여 반환
- `FileConfirmResponse` : 내부 응답 DTO 신규 추가

## POST → GET 변경 이유

기존 POST `/validate`는 검증 결과만 반환(void)하고 있었고, product-module 연동 요구사항이 추가되면서 storagePath도 함께 받아야 하는 상황이 되었습니다.

이 API의 본질적인 역할은 **"이 fileId로 식별되는 파일을 사용해도 되는가?"** 를 확인하는 조회성 요청입니다. 클라이언트(product-module) 입장에서는 리소스를 생성하거나 삭제하는 것이 아니라, 특정 파일의 상태와 경로를 읽어가는 것이 목적입니다. 이 관점에서 GET이 의미적으로 더 적합하다고 판단했습니다.

## GET이지만 내부 상태 변경이 발생하는 것에 대하여

`validateAndConfirm()` 내부에서 파일 상태가 PENDING인 경우 S3 존재를 확인한 뒤 SUCCESS로 전환하는 로직이 있습니다. 이 부분이 RESTful 원칙의 **GET 멱등성**에 위배된다는 지적이 있을 수 있습니다.

이에 대한 저희 판단은 다음과 같습니다.

이 상태 전환은 클라이언트가 의도한 동작이 아니라, **파일의 실제 상태를 DB와 동기화하는 내부 보정 처리**입니다. PENDING은 "S3 업로드 완료 여부가 아직 확인되지 않은 상태"이며, S3에 파일이 존재함이 확인되는 순간 SUCCESS로 전환되는 것은 상태 변경이라기보다 **사실 반영**에 가깝습니다. 호출 결과로 반환되는 storagePath는 몇 번을 호출해도 동일하며, 두 번째 호출부터는 이미 SUCCESS이므로 상태 전환도 발생하지 않습니다. 즉 **결과 관점에서는 멱등성이 보장**됩니다.

또한 이 API는 외부에 노출되지 않는 내부 전용 엔드포인트(`/api/internal/**`)로, `X-INTERNAL-KEY` 인증을 통해 신뢰된 모듈만 호출할 수 있습니다. HTTP 메서드의 의미론적 엄밀함보다 **호출 측의 사용 패턴과 시스템 일관성**을 우선한 설계입니다.

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] Postman으로 GET `/api/internal/files/{fileId}/confirm` 호출 확인 (X-INTERNAL-KEY 헤더 포함)

## 리뷰 포인트
- GET에서 상태 변환이 발생하는 구조에 대해 다른 의견이 있으면 말씀해주세요. PATCH로 분리하고 GET은 순수 조회만 하는 방식도 검토했으나, product-module 입장에서 호출 수를 최소화하는 것을 우선했습니다.