### PR TITLE
feat: 결제 만료 처리 스케줄러 및 Kafka 이벤트 기반 주문 상태 연동 구현

### DIFF
--- a/order-payment.html
+++ b/order-payment.html
@@ -49,7 +49,9 @@
             },
             body: JSON.stringify({
                 orderId: currentOrderId,
+                userId: crypto.randomUUID(),
                 productId: "11111111-1111-1111-1111-111111111111",
+                productUserId: crypto.randomUUID(),
                 paymentAmount: 10000,
                 depositAmount: 0,
                 paymentMethod: "TOSS"

--- a/service/order/src/main/java/jabaclass/order/order/domain/model/Order.java
+++ b/service/order/src/main/java/jabaclass/order/order/domain/model/Order.java
@@ -132,4 +132,11 @@ public class Order {
 			throw new IllegalArgumentException("주문 가격은 0 이상이어야 합니다.");
 		}
 	}
+
+	public void expire() {
+		if (this.status != OrderStatus.PENDING) {
+			throw new IllegalStateException("PENDING 상태만 만료 가능합니다.");
+		}
+		this.status = OrderStatus.EXPIRED;
+	}
 }

--- a/service/order/src/main/java/jabaclass/order/order/domain/model/OrderStatus.java
+++ b/service/order/src/main/java/jabaclass/order/order/domain/model/OrderStatus.java
@@ -5,5 +5,6 @@ public enum OrderStatus {
     PAID,
     CANCELLED,
 	FAILED,
-    REFUNDED
+    REFUNDED,
+	EXPIRED
 }

--- a/service/order/src/main/java/jabaclass/order/order/infrastructure/kafka/PaymentExpiredEvent.java
+++ b/service/order/src/main/java/jabaclass/order/order/infrastructure/kafka/PaymentExpiredEvent.java
@@ -1,0 +1,9 @@
+package jabaclass.order.order.infrastructure.kafka;
+
+import java.util.UUID;
+
+public record PaymentExpiredEvent(
+	UUID paymentId,
+	UUID orderId
+) {
+}

--- a/service/order/src/main/java/jabaclass/order/order/infrastructure/kafka/PaymentExpiredEventConsumer.java
+++ b/service/order/src/main/java/jabaclass/order/order/infrastructure/kafka/PaymentExpiredEventConsumer.java
@@ -1,0 +1,58 @@
+package jabaclass.order.order.infrastructure.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jabaclass.order.order.domain.model.Order;
+import jabaclass.order.order.domain.model.OrderStatus;
+import jabaclass.order.order.domain.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentExpiredEventConsumer {
+	private final OrderRepository orderRepository;
+	private final ObjectMapper objectMapper;
+
+	@KafkaListener(
+		topics = "payment.expired",
+		groupId = "order-service"
+	)
+	@Transactional
+	public void consume(String message) {
+
+		try {
+			// 1. JSON → 객체 변환
+			PaymentExpiredEvent event =
+				objectMapper.readValue(message, PaymentExpiredEvent.class);
+
+			log.info("payment.expired 이벤트 수신. orderId={}", event.orderId());
+
+			// 2. Order 조회
+			Order order = orderRepository.findById(event.orderId())
+				.orElseThrow(() ->
+					new IllegalArgumentException("주문 없음: " + event.orderId())
+				);
+
+			// 3. 중복 처리 방지
+			if (order.getStatus() == OrderStatus.EXPIRED) {
+				log.info("이미 만료된 주문. orderId={}", event.orderId());
+				return;
+			}
+
+			// 4. 상태 변경
+			order.expire();
+
+			log.info("주문 만료 완료. orderId={}", event.orderId());
+
+		} catch (Exception e) {
+			log.error("payment.expired 처리 실패. message={}", message, e);
+			throw new RuntimeException(e); // Kafka 재시도 유도
+		}
+	}
+}

--- a/service/payment/src/main/java/jabaclass/payment/application/service/ExpirePaymentService.java
+++ b/service/payment/src/main/java/jabaclass/payment/application/service/ExpirePaymentService.java
@@ -1,0 +1,55 @@
+package jabaclass.payment.application.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import jabaclass.payment.application.usecase.ExpirePaymentUseCase;
+import jabaclass.payment.domain.model.Payment;
+import jabaclass.payment.domain.model.PaymentStatus;
+import jabaclass.payment.domain.repository.PaymentRepository;
+import jabaclass.payment.infrastructure.kafka.PaymentExpiredEvent;
+import jabaclass.payment.infrastructure.kafka.PaymentExpiredEventPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ExpirePaymentService implements ExpirePaymentUseCase {
+
+	private static final long EXPIRE_HOURS = 1L;
+
+	private final PaymentRepository paymentRepository;
+	private final PaymentExpiredEventPublisher paymentExpiredEventPublisher;
+
+	@Override
+	@Transactional
+	public void execute() {
+		LocalDateTime threshold = LocalDateTime.now().minusHours(EXPIRE_HOURS);
+
+		List<Payment> expiredTargets = paymentRepository.findByStatusAndCreatedAtBefore(
+			PaymentStatus.READY,
+			threshold
+		);
+
+		log.info("결제 만료 대상 수: {}", expiredTargets.size());
+
+		for (Payment payment : expiredTargets) {
+			try {
+				payment.expire();
+
+				paymentExpiredEventPublisher.publish(
+					new PaymentExpiredEvent(payment.getId(), payment.getOrderId())
+				);
+
+				log.info("결제 만료 처리 완료. paymentId={}, orderId={}",
+					payment.getId(), payment.getOrderId());
+
+			} catch (Exception e) {
+				log.error("결제 만료 처리 실패. paymentId={}, orderId={}",
+					payment.getId(), payment.getOrderId(), e);
+			}
+		}
+	}
+}

--- a/service/payment/src/main/java/jabaclass/payment/application/service/PaymentCleanupScheduler.java
+++ b/service/payment/src/main/java/jabaclass/payment/application/service/PaymentCleanupScheduler.java
@@ -1,0 +1,22 @@
+package jabaclass.payment.application.service;
+
+import jabaclass.payment.application.usecase.ExpirePaymentUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentCleanupScheduler {
+
+	private final ExpirePaymentUseCase expirePaymentUseCase;
+
+	@Scheduled(cron = "0 */5 * * * *")
+	public void cleanupExpiredPayments() {
+		log.info("결제 만료 스케줄러 시작");
+		expirePaymentUseCase.execute();
+		log.info("결제 만료 스케줄러 종료");
+	}
+}

--- a/service/payment/src/main/java/jabaclass/payment/application/usecase/ExpirePaymentUseCase.java
+++ b/service/payment/src/main/java/jabaclass/payment/application/usecase/ExpirePaymentUseCase.java
@@ -1,0 +1,5 @@
+package jabaclass.payment.application.usecase;
+
+public interface ExpirePaymentUseCase {
+	void execute();
+}

--- a/service/payment/src/main/java/jabaclass/payment/config/JpaAuditingConfig.java
+++ b/service/payment/src/main/java/jabaclass/payment/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package jabaclass.payment.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/service/payment/src/main/java/jabaclass/payment/config/SchedulingConfig.java
+++ b/service/payment/src/main/java/jabaclass/payment/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package jabaclass.payment.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/service/payment/src/main/java/jabaclass/payment/domain/model/BaseEntity.java
+++ b/service/payment/src/main/java/jabaclass/payment/domain/model/BaseEntity.java
@@ -1,0 +1,26 @@
+package jabaclass.payment.domain.model;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+	@CreatedDate
+	@Column(name = "created_at", updatable = false, nullable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+}

--- a/service/payment/src/main/java/jabaclass/payment/domain/model/Payment.java
+++ b/service/payment/src/main/java/jabaclass/payment/domain/model/Payment.java
@@ -145,11 +145,19 @@ public class Payment extends BaseEntity{
 
 		this.status = PaymentStatus.FAILED;
 	}
+
 	public void markCancelled() {
 		if (this.status != PaymentStatus.PAID) {
 			throw new IllegalStateException("완료된 결제만 취소할 수 있습니다.");
 		}
 
 		this.status = PaymentStatus.CANCELLED;
+	}
+
+	public void expire() {
+		if (this.status != PaymentStatus.READY) {
+			throw new IllegalStateException("만료 가능한 상태가 아닙니다.");
+		}
+		this.status = PaymentStatus.EXPIRED;
 	}
 }

--- a/service/payment/src/main/java/jabaclass/payment/domain/model/Payment.java
+++ b/service/payment/src/main/java/jabaclass/payment/domain/model/Payment.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 @Entity
 @Table(name = "payments")
 @Getter
-public class Payment {
+public class Payment extends BaseEntity{
 
 	@Id
 	@Column(name = "id", nullable = false, updatable = false)

--- a/service/payment/src/main/java/jabaclass/payment/domain/model/PaymentStatus.java
+++ b/service/payment/src/main/java/jabaclass/payment/domain/model/PaymentStatus.java
@@ -4,5 +4,6 @@ public enum PaymentStatus {
 	READY,
 	PAID,
 	CANCELLED,
-	FAILED
+	FAILED,
+	EXPIRED
 }

--- a/service/payment/src/main/java/jabaclass/payment/domain/repository/PaymentRepository.java
+++ b/service/payment/src/main/java/jabaclass/payment/domain/repository/PaymentRepository.java
@@ -1,7 +1,10 @@
 package jabaclass.payment.domain.repository;
 
 import jabaclass.payment.domain.model.Payment;
+import jabaclass.payment.domain.model.PaymentStatus;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,4 +15,6 @@ public interface PaymentRepository {
 	Optional<Payment> findById(UUID paymentId);
 
 	Optional<Payment> findByOrderId(UUID orderId);
+
+	List<Payment> findByStatusAndCreatedAtBefore(PaymentStatus status, LocalDateTime threshold);
 }

--- a/service/payment/src/main/java/jabaclass/payment/infrastructure/kafka/PaymentExpiredEvent.java
+++ b/service/payment/src/main/java/jabaclass/payment/infrastructure/kafka/PaymentExpiredEvent.java
@@ -1,0 +1,9 @@
+package jabaclass.payment.infrastructure.kafka;
+
+import java.util.UUID;
+
+public record PaymentExpiredEvent(
+	UUID paymentId,
+	UUID orderId
+) {
+}

--- a/service/payment/src/main/java/jabaclass/payment/infrastructure/kafka/PaymentExpiredEventPublisher.java
+++ b/service/payment/src/main/java/jabaclass/payment/infrastructure/kafka/PaymentExpiredEventPublisher.java
@@ -1,0 +1,25 @@
+package jabaclass.payment.infrastructure.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentExpiredEventPublisher {
+
+	public static final String TOPIC = "payment.expired";
+
+	private final KafkaTemplate<String, String> kafkaTemplate;
+	private final ObjectMapper objectMapper;
+
+	public void publish(PaymentExpiredEvent event) {
+		try {
+			String payload = objectMapper.writeValueAsString(event);
+			kafkaTemplate.send(TOPIC, event.orderId().toString(), payload);
+		} catch (Exception e) {
+			throw new RuntimeException("결제 만료 이벤트 발행 실패", e);
+		}
+	}
+}

--- a/service/payment/src/main/java/jabaclass/payment/infrastructure/persistence/PaymentJpaRepository.java
+++ b/service/payment/src/main/java/jabaclass/payment/infrastructure/persistence/PaymentJpaRepository.java
@@ -1,12 +1,20 @@
 package jabaclass.payment.infrastructure.persistence;
 
 import jabaclass.payment.domain.model.Payment;
+import jabaclass.payment.domain.model.PaymentStatus;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface PaymentJpaRepository extends JpaRepository<Payment, UUID> {
 	Optional<Payment> findByOrderId(UUID orderId);
+
+	List<Payment> findByStatusAndCreatedAtBefore(
+		PaymentStatus status,
+		LocalDateTime threshold
+	);
 }

--- a/service/payment/src/main/java/jabaclass/payment/infrastructure/persistence/PaymentRepositoryAdapter.java
+++ b/service/payment/src/main/java/jabaclass/payment/infrastructure/persistence/PaymentRepositoryAdapter.java
@@ -1,11 +1,14 @@
 package jabaclass.payment.infrastructure.persistence;
 
 import jabaclass.payment.domain.model.Payment;
+import jabaclass.payment.domain.model.PaymentStatus;
 import jabaclass.payment.domain.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -27,4 +30,12 @@ public class PaymentRepositoryAdapter implements PaymentRepository {
 
 	@Override
 	public Optional<Payment> findByOrderId(UUID orderId) { return paymentJpaRepository.findByOrderId(orderId); }
+
+	@Override
+	public List<Payment> findByStatusAndCreatedAtBefore(PaymentStatus status, LocalDateTime threshold) {
+		return paymentJpaRepository.findByStatusAndCreatedAtBefore(
+			status,
+			threshold
+		);
+	}
 }


### PR DESCRIPTION
## 관련 이슈
- Close #114 

## 변경 요약
- 결제 만료 처리 기능 구현 (스케줄러 기반)
- Kafka 이벤트를 통한 주문 상태 연동 추가

## 주요 변경점
- Payment 도메인에 expire() 메서드 추가 및 상태 전이 로직 정의
- ExpirePaymentUseCase / Service를 통해 결제 만료 처리 구현
- PaymentCleanupScheduler를 통해 주기적 만료 처리
- Kafka를 이용한 PaymentExpiredEvent 발행 및 Order 서비스 연동
- PaymentRepository 및 JPA 어댑터 구조 추가
- Order 상태(EXPIRED) 반영 로직 추가
- 동작 흐름
  ```
  결제 생성 (READY)
      ↓
  일정 시간 경과
      ↓
  스케줄러 실행
      ↓
  Payment → EXPIRED
      ↓
  Kafka 이벤트 발행
      ↓
  Order 서비스에서 이벤트 수신
      ↓
  Order → EXPIRED
  ```

## 테스트
- [x] 로컬 실행 확인
- [x] 테스트 통과
- [x] Postman/Swagger로 API 확인

## 리뷰 포인트
- Payment에 created_at, updated_at 컬럼 추가하였고, NOT NULL 제약으로 인해 기존 데이터에 null 값이 존재할 경우 오류가 발생할 수 있습니다! 초기에는 nullable = true로 적용 후 데이터 보정 이후 NOT NULL로 변경하도록 처리해야 합니다. 