### PR TITLE
fix: 예치금 100% 결제 시 prepare 단계에서 즉시 PAID 처리

### DIFF
--- a/service/payment/src/main/java/jabaclass/payment/application/service/PaymentService.java
+++ b/service/payment/src/main/java/jabaclass/payment/application/service/PaymentService.java
@@ -50,6 +50,24 @@ public class PaymentService implements PaymentUseCase {
 			request.depositAmount()
 		);
 
+		if (payment.getPaymentAmount().compareTo(BigDecimal.ZERO) == 0) {
+
+			log.info("예치금 100% 결제 - 즉시 완료 처리 orderId={}", payment.getOrderId());
+
+			payment.markDone("DEPOSIT_ONLY");
+
+			try {
+				orderPort.updatePaymentStatus(
+					payment.getOrderId(),
+					payment.getId(),
+					payment.getDepositAmount().intValue(),
+					"PAID"
+				);
+			} catch (Exception ex) {
+				log.error("Order 상태 업데이트 실패 (deposit only)", ex);
+			}
+		}
+
 		Payment savedPayment = paymentRepository.save(payment);
 
 		return PaymentResponseDto.from(savedPayment);


### PR DESCRIPTION
## 관련 이슈
- Close #124 

## 변경 요약
- 예치금 100% 결제(paymentAmount = 0) 케이스에 대한 처리 로직 추가
- prepare 단계에서 즉시 결제 완료(PAID) 처리하도록 개선
- 외부 PG(Toss) 호출 없이 결제가 완료되는 흐름 지원
- 결제 완료 시 Order 상태 업데이트 로직 포함

## 문제 상황

기존 구조에서는 예치금 100% 결제의 경우, 외부 결제(PG)가 없기 때문에 confirm 단계가 호출되지 않음

## 해결 방법
prepare 단계에서 paymentAmount == 0인 경우, 즉시 PAID 상태로 설정 +  Order 상태를 PAID로 업데이트
외부 결제가 필요한 경우만 confirm을 통해 처리하도록 분기

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트
