### PR TITLE
feat: Payment 예외 처리 및 API 응답 구조 통합 개선

### DIFF
--- a/service/payment/src/main/java/jabaclass/payment/application/service/DepositPaymentService.java
+++ b/service/payment/src/main/java/jabaclass/payment/application/service/DepositPaymentService.java
@@ -85,7 +85,7 @@ public class DepositPaymentService implements DepositPaymentUseCase {
 			// 실패 처리
 			depositPayment.markFailed();
 
-			throw new PaymentException(PaymentErrorCode.DEPOSIT_PAYMENT_CONFIRM_FAILED);
+			throw new PaymentException(PaymentErrorCode.DEPOSIT_PAYMENT_CONFIRM_FAILED, e);
 		}
 
 		return new ConfirmDepositPaymentResponseDto(true);

--- a/service/payment/src/main/java/jabaclass/payment/application/service/DepositPaymentService.java
+++ b/service/payment/src/main/java/jabaclass/payment/application/service/DepositPaymentService.java
@@ -3,6 +3,8 @@ package jabaclass.payment.application.service;
 import jabaclass.payment.application.port.external.PaymentGatewayPort;
 import jabaclass.payment.application.port.external.UserPort;
 import jabaclass.payment.application.usecase.DepositPaymentUseCase;
+import jabaclass.payment.common.exception.PaymentErrorCode;
+import jabaclass.payment.common.exception.PaymentException;
 import jabaclass.payment.domain.model.DepositPayment;
 import jabaclass.payment.domain.repository.DepositPaymentRepository;
 import jabaclass.payment.presentation.dto.request.ConfirmDepositPaymentRequestDto;
@@ -45,7 +47,7 @@ public class DepositPaymentService implements DepositPaymentUseCase {
 
 		// DepositPayment 조회
 		DepositPayment depositPayment = depositPaymentRepository.findById(request.depositPaymentsId())
-			.orElseThrow(() -> new IllegalStateException("예치금 결제 정보를 찾을 수 없습니다."));
+			.orElseThrow(() -> new PaymentException(PaymentErrorCode.DEPOSIT_PAYMENT_NOT_FOUND));
 
 		// 멱등성 체크
 		if (depositPayment.isDone()) {
@@ -54,7 +56,7 @@ public class DepositPaymentService implements DepositPaymentUseCase {
 
 		// 충전 금액 검증
 		if (depositPayment.getAmount().intValue() != request.amount()) {
-			throw new IllegalStateException("결제 금액이 일치하지 않습니다.");
+			throw new PaymentException(PaymentErrorCode.INVALID_PAYMENT_AMOUNT);
 		}
 
 		try {
@@ -83,7 +85,7 @@ public class DepositPaymentService implements DepositPaymentUseCase {
 			// 실패 처리
 			depositPayment.markFailed();
 
-			throw new IllegalStateException("예치금 결제 승인에 실패했습니다.", e);
+			throw new PaymentException(PaymentErrorCode.DEPOSIT_PAYMENT_CONFIRM_FAILED);
 		}
 
 		return new ConfirmDepositPaymentResponseDto(true);

--- a/service/payment/src/main/java/jabaclass/payment/application/service/PaymentService.java
+++ b/service/payment/src/main/java/jabaclass/payment/application/service/PaymentService.java
@@ -4,6 +4,8 @@ import jabaclass.payment.application.port.external.OrderPort;
 import jabaclass.payment.application.port.external.PaymentGatewayPort;
 import jabaclass.payment.application.port.external.UserPort;
 import jabaclass.payment.application.usecase.PaymentUseCase;
+import jabaclass.payment.common.exception.PaymentErrorCode;
+import jabaclass.payment.common.exception.PaymentException;
 import jabaclass.payment.domain.model.Payment;
 import jabaclass.payment.domain.model.Refund;
 import jabaclass.payment.domain.repository.PaymentRepository;
@@ -62,7 +64,7 @@ public class PaymentService implements PaymentUseCase {
 		UUID orderId = request.orderId();
 
 		Payment payment = paymentRepository.findByOrderId(orderId)
-			.orElseThrow(() -> new IllegalStateException("결제 정보를 찾을 수 없습니다."));
+			.orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
 		log.info("[confirm] validate 호출 전 orderId={}, requestAmount={}, totalAmount={}",
 			payment.getOrderId(), request.amount(), payment.getTotalAmount());
@@ -81,13 +83,13 @@ public class PaymentService implements PaymentUseCase {
 			log.warn("Order 금액 검증 실패. orderId={}, totalAmount={}, requestAmount={}",
 				payment.getOrderId(), payment.getTotalAmount(), request.amount());
 
-			throw new IllegalStateException("주문 금액이 일치하지 않습니다.");
+			throw new PaymentException(PaymentErrorCode.INVALID_ORDER_AMOUNT);
 		}
 
 		// Payment 내부 금액 검증
 		if (payment.getPaymentAmount()
 			.compareTo(BigDecimal.valueOf(request.amount())) != 0) {
-			throw new IllegalStateException("결제 금액이 일치하지 않습니다.");
+			throw new PaymentException(PaymentErrorCode.INVALID_PAYMENT_AMOUNT);
 		}
 
 		try {
@@ -134,7 +136,7 @@ public class PaymentService implements PaymentUseCase {
 					payment.getOrderId(), ex);
 			}
 
-			throw new IllegalStateException("결제 승인에 실패했습니다.", e);
+			throw new PaymentException(PaymentErrorCode.PAYMENT_CONFIRM_FAILED);
 		}
 
 
@@ -146,10 +148,12 @@ public class PaymentService implements PaymentUseCase {
 	@Transactional
 	public RefundPaymentResponseDto refund(RefundPaymentRequestDto request) {
 		Payment payment = paymentRepository.findByOrderId(request.orderId())
-			.orElseThrow(() -> new IllegalStateException("결제 정보를 찾을 수 없습니다."));
+			.orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
 		if (!payment.isDone()) {
-			throw new IllegalStateException("완료된 결제만 환불할 수 있습니다.");
+			if (!payment.isDone()) {
+				throw new PaymentException(PaymentErrorCode.PAYMENT_NOT_COMPLETED);
+			}
 		}
 
 		Refund refund = Refund.create(
@@ -189,7 +193,7 @@ public class PaymentService implements PaymentUseCase {
 		} catch (Exception e) {
 			refund.markFailed();
 			log.error("환불 실패. orderId={}, paymentId={}", payment.getOrderId(), payment.getId(), e);
-			throw new IllegalStateException("환불 처리에 실패했습니다.", e);
+			throw new PaymentException(PaymentErrorCode.PAYMENT_REFUND_FAILED);
 		}
 
 		return RefundPaymentResponseDto.from(refund, payment.getOrderId());

--- a/service/payment/src/main/java/jabaclass/payment/application/service/PaymentService.java
+++ b/service/payment/src/main/java/jabaclass/payment/application/service/PaymentService.java
@@ -136,7 +136,7 @@ public class PaymentService implements PaymentUseCase {
 					payment.getOrderId(), ex);
 			}
 
-			throw new PaymentException(PaymentErrorCode.PAYMENT_CONFIRM_FAILED);
+			throw new PaymentException(PaymentErrorCode.PAYMENT_CONFIRM_FAILED, e);
 		}
 
 
@@ -151,9 +151,7 @@ public class PaymentService implements PaymentUseCase {
 			.orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
 		if (!payment.isDone()) {
-			if (!payment.isDone()) {
-				throw new PaymentException(PaymentErrorCode.PAYMENT_NOT_COMPLETED);
-			}
+			throw new PaymentException(PaymentErrorCode.PAYMENT_NOT_COMPLETED);
 		}
 
 		Refund refund = Refund.create(
@@ -193,7 +191,8 @@ public class PaymentService implements PaymentUseCase {
 		} catch (Exception e) {
 			refund.markFailed();
 			log.error("환불 실패. orderId={}, paymentId={}", payment.getOrderId(), payment.getId(), e);
-			throw new PaymentException(PaymentErrorCode.PAYMENT_REFUND_FAILED);
+
+			throw new PaymentException(PaymentErrorCode.PAYMENT_REFUND_FAILED, e);
 		}
 
 		return RefundPaymentResponseDto.from(refund, payment.getOrderId());

--- a/service/payment/src/main/java/jabaclass/payment/common/dto/ApiResponseDto.java
+++ b/service/payment/src/main/java/jabaclass/payment/common/dto/ApiResponseDto.java
@@ -1,0 +1,29 @@
+package jabaclass.payment.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
+public class ApiResponseDto<T> {
+
+	private final HttpStatus status;
+	private final String message;
+	private final T data;
+
+	private ApiResponseDto(HttpStatus status, String message, T data) {
+		this.status = status;
+		this.message = message;
+		this.data = data;
+	}
+
+	public static <T> ApiResponseDto<T> success(HttpStatus status, String message, T data) {
+		return new ApiResponseDto<>(status, message, data);
+	}
+
+	public static ApiResponseDto<Void> fail(HttpStatus status, String message) {
+		return new ApiResponseDto<>(status, message, null);
+	}
+}
+

--- a/service/payment/src/main/java/jabaclass/payment/common/exception/GlobalExceptionHandler.java
+++ b/service/payment/src/main/java/jabaclass/payment/common/exception/GlobalExceptionHandler.java
@@ -16,10 +16,10 @@ public class GlobalExceptionHandler {
 
 		PaymentErrorCode errorCode = ex.getErrorCode();
 
-		log.warn("[PaymentException] code={}, message={}, cause={}",
+		log.warn("[PaymentException] code={}, message={}",
 			errorCode.name(),
 			errorCode.getMessage(),
-			ex.getMessage()
+			ex
 		);
 
 		return ResponseEntity

--- a/service/payment/src/main/java/jabaclass/payment/common/exception/GlobalExceptionHandler.java
+++ b/service/payment/src/main/java/jabaclass/payment/common/exception/GlobalExceptionHandler.java
@@ -16,6 +16,12 @@ public class GlobalExceptionHandler {
 
 		PaymentErrorCode errorCode = ex.getErrorCode();
 
+		log.warn("[PaymentException] code={}, message={}, cause={}",
+			errorCode.name(),
+			errorCode.getMessage(),
+			ex.getMessage()
+		);
+
 		return ResponseEntity
 			.status(errorCode.getStatus())
 			.body(ApiResponseDto.fail(
@@ -26,7 +32,9 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ApiResponseDto<Void>> handleServerError(Exception ex) {
-		log.error("Internal server error occurred", ex);
+
+		log.error("[Unhandled Exception]", ex);
+
 		return ResponseEntity
 			.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(ApiResponseDto.fail(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다."));

--- a/service/payment/src/main/java/jabaclass/payment/common/exception/GlobalExceptionHandler.java
+++ b/service/payment/src/main/java/jabaclass/payment/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,34 @@
+package jabaclass.payment.common.exception;
+
+import jabaclass.payment.common.dto.ApiResponseDto;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(PaymentException.class)
+	public ResponseEntity<ApiResponseDto<Void>> handlePaymentException(PaymentException ex) {
+
+		PaymentErrorCode errorCode = ex.getErrorCode();
+
+		return ResponseEntity
+			.status(errorCode.getStatus())
+			.body(ApiResponseDto.fail(
+				errorCode.getStatus(),
+				errorCode.getMessage()
+			));
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ApiResponseDto<Void>> handleServerError(Exception ex) {
+		log.error("Internal server error occurred", ex);
+		return ResponseEntity
+			.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(ApiResponseDto.fail(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다."));
+	}
+}

--- a/service/payment/src/main/java/jabaclass/payment/common/exception/PaymentErrorCode.java
+++ b/service/payment/src/main/java/jabaclass/payment/common/exception/PaymentErrorCode.java
@@ -1,0 +1,41 @@
+package jabaclass.payment.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum PaymentErrorCode {
+
+	PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
+	INVALID_ORDER_AMOUNT(HttpStatus.BAD_REQUEST, "주문 금액이 일치하지 않습니다."),
+	INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "결제 금액이 일치하지 않습니다."),
+	PAYMENT_CONFIRM_FAILED(HttpStatus.BAD_GATEWAY, "결제 승인에 실패했습니다."),
+	PAYMENT_REFUND_FAILED(HttpStatus.BAD_GATEWAY, "환불 처리에 실패했습니다."),
+	PAYMENT_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 완료된 결제입니다."),
+	PAYMENT_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "완료된 결제만 처리할 수 있습니다."),
+	PAYMENT_INVALID_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 상태입니다."),
+	INVALID_AMOUNT(HttpStatus.BAD_REQUEST, "금액은 null일 수 없습니다."),
+	INVALID_PRODUCT_USER(HttpStatus.BAD_REQUEST, "productUserId는 null일 수 없습니다."),
+	INVALID_NEGATIVE_AMOUNT(HttpStatus.BAD_REQUEST, "금액은 0 이상이어야 합니다."),
+	DEPOSIT_PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "예치금 결제 정보를 찾을 수 없습니다."),
+	DEPOSIT_PAYMENT_CONFIRM_FAILED(HttpStatus.BAD_GATEWAY, "예치금 결제 승인에 실패했습니다."),
+	ORDER_VALIDATION_FAILED(HttpStatus.BAD_GATEWAY, "Order 검증에 실패했습니다."),
+	ORDER_RESPONSE_INVALID(HttpStatus.BAD_GATEWAY, "Order 응답이 올바르지 않습니다."),
+	ORDER_UPDATE_FAILED(HttpStatus.BAD_GATEWAY, "Order 상태 업데이트에 실패했습니다."),
+	USER_DEPOSIT_INCREASE_FAILED(HttpStatus.BAD_GATEWAY, "유저 예치금 증가에 실패했습니다."),
+	USER_DEPOSIT_REFUND_FAILED(HttpStatus.BAD_GATEWAY, "유저 예치금 환불에 실패했습니다.");
+
+	private final HttpStatus status;
+	private final String message;
+
+	PaymentErrorCode(HttpStatus status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+
+	public HttpStatus getStatus() {
+		return status;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+}

--- a/service/payment/src/main/java/jabaclass/payment/common/exception/PaymentException.java
+++ b/service/payment/src/main/java/jabaclass/payment/common/exception/PaymentException.java
@@ -18,4 +18,9 @@ public class PaymentException extends RuntimeException {
 	public HttpStatus getStatus() {
 		return errorCode.getStatus();
 	}
+
+	public PaymentException(PaymentErrorCode errorCode, Throwable cause) {
+		super(errorCode.getMessage(), cause);
+		this.errorCode = errorCode;
+	}
 }

--- a/service/payment/src/main/java/jabaclass/payment/common/exception/PaymentException.java
+++ b/service/payment/src/main/java/jabaclass/payment/common/exception/PaymentException.java
@@ -1,0 +1,21 @@
+package jabaclass.payment.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class PaymentException extends RuntimeException {
+
+	private final PaymentErrorCode errorCode;
+
+	public PaymentException(PaymentErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+
+	public PaymentErrorCode getErrorCode() {
+		return errorCode;
+	}
+
+	public HttpStatus getStatus() {
+		return errorCode.getStatus();
+	}
+}

--- a/service/payment/src/main/java/jabaclass/payment/domain/model/Payment.java
+++ b/service/payment/src/main/java/jabaclass/payment/domain/model/Payment.java
@@ -1,5 +1,7 @@
 package jabaclass.payment.domain.model;
 
+import jabaclass.payment.common.exception.PaymentErrorCode;
+import jabaclass.payment.common.exception.PaymentException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -113,19 +115,19 @@ public class Payment extends BaseEntity{
 		UUID productUserId
 	) {
 		if (paymentAmount == null || depositAmount == null) {
-			throw new IllegalArgumentException("금액은 null일 수 없습니다");
+			throw new PaymentException(PaymentErrorCode.INVALID_AMOUNT);
 		}
 
 		if (productUserId == null) {
-			throw new IllegalArgumentException("productUserId는 null일 수 없습니다");
+			throw new PaymentException(PaymentErrorCode.INVALID_PRODUCT_USER);
 		}
 
 		if (paymentAmount.compareTo(BigDecimal.ZERO) < 0) {
-			throw new IllegalArgumentException("paymentAmount는 0 이상이어야 합니다");
+			throw new PaymentException(PaymentErrorCode.INVALID_NEGATIVE_AMOUNT);
 		}
 
 		if (depositAmount.compareTo(BigDecimal.ZERO) < 0) {
-			throw new IllegalArgumentException("depositAmount는 0 이상이어야 합니다");
+			throw new PaymentException(PaymentErrorCode.INVALID_NEGATIVE_AMOUNT);
 		}
 	}
 
@@ -140,7 +142,7 @@ public class Payment extends BaseEntity{
 
 	public void markFailed() {
 		if (this.status == PaymentStatus.PAID) {
-			throw new IllegalStateException("이미 완료된 결제는 실패 처리할 수 없습니다.");
+			throw new PaymentException(PaymentErrorCode.PAYMENT_ALREADY_COMPLETED);
 		}
 
 		this.status = PaymentStatus.FAILED;
@@ -148,7 +150,7 @@ public class Payment extends BaseEntity{
 
 	public void markCancelled() {
 		if (this.status != PaymentStatus.PAID) {
-			throw new IllegalStateException("완료된 결제만 취소할 수 있습니다.");
+			throw new PaymentException(PaymentErrorCode.PAYMENT_NOT_COMPLETED);
 		}
 
 		this.status = PaymentStatus.CANCELLED;
@@ -156,7 +158,7 @@ public class Payment extends BaseEntity{
 
 	public void expire() {
 		if (this.status != PaymentStatus.READY) {
-			throw new IllegalStateException("만료 가능한 상태가 아닙니다.");
+			throw new PaymentException(PaymentErrorCode.PAYMENT_INVALID_STATUS);
 		}
 		this.status = PaymentStatus.EXPIRED;
 	}

--- a/service/payment/src/main/java/jabaclass/payment/infrastructure/external/order/OrderClient.java
+++ b/service/payment/src/main/java/jabaclass/payment/infrastructure/external/order/OrderClient.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 import jabaclass.payment.application.port.external.OrderPort;
+import jabaclass.payment.common.exception.PaymentErrorCode;
+import jabaclass.payment.common.exception.PaymentException;
 import jabaclass.payment.domain.model.PaymentResultStatus;
 import jabaclass.payment.infrastructure.external.order.dto.request.OrderStatusUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
@@ -42,12 +44,12 @@ public class OrderClient implements OrderPort {
 			);
 
 		if (!response.getStatusCode().is2xxSuccessful()) {
-			throw new IllegalStateException("주문 금액이 일치하지 않습니다.");
+			throw new PaymentException(PaymentErrorCode.INVALID_ORDER_AMOUNT);
 		}
 
 		OrderValidationResponse body = response.getBody();
 		if (body == null) {
-			throw new IllegalStateException("Order 검증 응답이 비어있습니다.");
+			throw new PaymentException(PaymentErrorCode.ORDER_RESPONSE_INVALID);
 		}
 
 		return body.valid();
@@ -85,9 +87,7 @@ public class OrderClient implements OrderPort {
 			);
 
 		if (!response.getStatusCode().is2xxSuccessful()) {
-			throw new IllegalStateException(
-				"Order 상태 업데이트 실패. status=" + response.getStatusCode()
-			);
+			throw new PaymentException(PaymentErrorCode.ORDER_UPDATE_FAILED);
 		}
 	}
 

--- a/service/payment/src/main/java/jabaclass/payment/infrastructure/external/user/UserClient.java
+++ b/service/payment/src/main/java/jabaclass/payment/infrastructure/external/user/UserClient.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 import jabaclass.payment.application.port.external.UserPort;
+import jabaclass.payment.common.exception.PaymentErrorCode;
+import jabaclass.payment.common.exception.PaymentException;
 import jabaclass.payment.infrastructure.external.user.dto.request.IncreaseDepositRequestDto;
 import lombok.RequiredArgsConstructor;
 
@@ -44,9 +46,7 @@ public class UserClient implements UserPort {
 			);
 
 		if (!response.getStatusCode().is2xxSuccessful()) {
-			throw new IllegalStateException(
-				"유저 예치금 증가 실패. status=" + response.getStatusCode()
-			);
+			throw new PaymentException(PaymentErrorCode.USER_DEPOSIT_INCREASE_FAILED);
 		}
 	}
 
@@ -73,9 +73,7 @@ public class UserClient implements UserPort {
 			);
 
 		if (!response.getStatusCode().is2xxSuccessful()) {
-			throw new IllegalStateException(
-				"유저 예치금 환불 실패. status=" + response.getStatusCode()
-			);
+			throw new PaymentException(PaymentErrorCode.USER_DEPOSIT_REFUND_FAILED);
 		}
 	}
 }

--- a/service/payment/src/main/java/jabaclass/payment/presentation/controller/DepositPaymentApi.java
+++ b/service/payment/src/main/java/jabaclass/payment/presentation/controller/DepositPaymentApi.java
@@ -2,6 +2,7 @@ package jabaclass.payment.presentation.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jabaclass.payment.common.dto.ApiResponseDto;
 import jabaclass.payment.presentation.dto.request.ConfirmDepositPaymentRequestDto;
 import jabaclass.payment.presentation.dto.request.PrepareDepositPaymentRequestDto;
 import jabaclass.payment.presentation.dto.response.ConfirmDepositPaymentResponseDto;
@@ -12,8 +13,8 @@ import org.springframework.http.ResponseEntity;
 public interface DepositPaymentApi {
 
 	@Operation(summary = "예치금 결제 준비", description = "예치금 충전을 위한 결제를 생성하고 READY 상태로 만듭니다.")
-	ResponseEntity<PrepareDepositPaymentResponseDto> prepareDepositPayment(PrepareDepositPaymentRequestDto request);
+	ResponseEntity<ApiResponseDto<PrepareDepositPaymentResponseDto>> prepareDepositPayment(PrepareDepositPaymentRequestDto request);
 
 	@Operation(summary = "예치금 결제 확정", description = "예치금 결제를 DONE 상태로 확정합니다.")
-	ResponseEntity<ConfirmDepositPaymentResponseDto> confirmDepositPayment(ConfirmDepositPaymentRequestDto request);
+	ResponseEntity<ApiResponseDto<ConfirmDepositPaymentResponseDto>> confirmDepositPayment(ConfirmDepositPaymentRequestDto request);
 }

--- a/service/payment/src/main/java/jabaclass/payment/presentation/controller/DepositPaymentController.java
+++ b/service/payment/src/main/java/jabaclass/payment/presentation/controller/DepositPaymentController.java
@@ -1,6 +1,7 @@
 package jabaclass.payment.presentation.controller;
 
 import jabaclass.payment.application.usecase.DepositPaymentUseCase;
+import jabaclass.payment.common.dto.ApiResponseDto;
 import jabaclass.payment.presentation.dto.request.ConfirmDepositPaymentRequestDto;
 import jabaclass.payment.presentation.dto.request.PrepareDepositPaymentRequestDto;
 import jabaclass.payment.presentation.dto.response.ConfirmDepositPaymentResponseDto;
@@ -22,19 +23,32 @@ public class DepositPaymentController implements DepositPaymentApi {
 
 	@Override
 	@PostMapping("/prepare")
-	public ResponseEntity<PrepareDepositPaymentResponseDto> prepareDepositPayment(
+	public ResponseEntity<ApiResponseDto<PrepareDepositPaymentResponseDto>> prepareDepositPayment(
 		@RequestBody PrepareDepositPaymentRequestDto request
 	) {
 		PrepareDepositPaymentResponseDto response = depositPaymentUseCase.prepare(request);
-		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(ApiResponseDto.success(
+				HttpStatus.CREATED,
+				"예치금 결제 생성 성공",
+				response
+			));
 	}
 
 	@Override
 	@PostMapping("/confirm")
-	public ResponseEntity<ConfirmDepositPaymentResponseDto> confirmDepositPayment(
+	public ResponseEntity<ApiResponseDto<ConfirmDepositPaymentResponseDto>> confirmDepositPayment(
 		@RequestBody ConfirmDepositPaymentRequestDto request
 	) {
 		ConfirmDepositPaymentResponseDto response = depositPaymentUseCase.confirm(request);
-		return ResponseEntity.ok(response);
+
+		return ResponseEntity.ok(
+			ApiResponseDto.success(
+				HttpStatus.OK,
+				"예치금 결제 승인 성공",
+				response
+			)
+		);
 	}
 }

--- a/service/payment/src/main/java/jabaclass/payment/presentation/controller/PaymentApi.java
+++ b/service/payment/src/main/java/jabaclass/payment/presentation/controller/PaymentApi.java
@@ -2,6 +2,7 @@ package jabaclass.payment.presentation.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jabaclass.payment.common.dto.ApiResponseDto;
 import jabaclass.payment.presentation.dto.request.ConfirmPaymentRequestDto;
 import jabaclass.payment.presentation.dto.request.PreparePaymentRequestDto;
 import jabaclass.payment.presentation.dto.request.RefundPaymentRequestDto;
@@ -21,7 +22,7 @@ public interface PaymentApi {
 			- 총 금액 = paymentAmount + depositAmount
 			"""
 	)
-	ResponseEntity<PaymentResponseDto> preparePayment(
+	ResponseEntity<ApiResponseDto<PaymentResponseDto>> preparePayment(
 		PreparePaymentRequestDto request
 	);
 
@@ -35,7 +36,7 @@ public interface PaymentApi {
             - 주문 상태 업데이트
             """
 	)
-	ResponseEntity<PaymentResponseDto> confirmPayment(
+	ResponseEntity<ApiResponseDto<PaymentResponseDto>> confirmPayment(
 		ConfirmPaymentRequestDto request
 	);
 
@@ -48,7 +49,7 @@ public interface PaymentApi {
 			- 완료 후 payment.refund.completed 이벤트를 발행합니다.
 			"""
 	)
-	ResponseEntity<RefundPaymentResponseDto> refundPayment(
+	ResponseEntity<ApiResponseDto<RefundPaymentResponseDto>> refundPayment(
 		RefundPaymentRequestDto request
 	);
 }

--- a/service/payment/src/main/java/jabaclass/payment/presentation/controller/PaymentController.java
+++ b/service/payment/src/main/java/jabaclass/payment/presentation/controller/PaymentController.java
@@ -1,6 +1,7 @@
 package jabaclass.payment.presentation.controller;
 
 import jabaclass.payment.application.usecase.PaymentUseCase;
+import jabaclass.payment.common.dto.ApiResponseDto;
 import jabaclass.payment.presentation.dto.request.ConfirmPaymentRequestDto;
 import jabaclass.payment.presentation.dto.request.PreparePaymentRequestDto;
 import jabaclass.payment.presentation.dto.request.RefundPaymentRequestDto;
@@ -22,23 +23,40 @@ public class PaymentController implements PaymentApi {
 
 	@Override
 	@PostMapping("/api/v1/payments/prepare")
-	public ResponseEntity<PaymentResponseDto> preparePayment(@RequestBody PreparePaymentRequestDto request) {
+	public ResponseEntity<ApiResponseDto<PaymentResponseDto>> preparePayment(@RequestBody PreparePaymentRequestDto request) {
 		PaymentResponseDto response = paymentUseCase.create(request);
 
-		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(ApiResponseDto.success(
+				HttpStatus.CREATED,
+				"결제 생성 성공",
+				response
+			));
 	}
 
 	@Override
 	@PostMapping("/api/v1/payments/confirm")
-	public ResponseEntity<PaymentResponseDto> confirmPayment(@RequestBody ConfirmPaymentRequestDto request) {
+	public ResponseEntity<ApiResponseDto<PaymentResponseDto>> confirmPayment(@RequestBody ConfirmPaymentRequestDto request) {
 		PaymentResponseDto response = paymentUseCase.confirm(request);
 
-		return ResponseEntity.ok(response);
+		return ResponseEntity.ok(
+			ApiResponseDto.success(
+				HttpStatus.OK,
+				"결제 성공",
+				response
+			)
+		);
 	}
 
 	@Override
 	@PostMapping("/api/v1/refunds")
-	public ResponseEntity<RefundPaymentResponseDto> refundPayment(@RequestBody RefundPaymentRequestDto request) {
-		return ResponseEntity.ok(paymentUseCase.refund(request));
+	public ResponseEntity<ApiResponseDto<RefundPaymentResponseDto>> refundPayment(@RequestBody RefundPaymentRequestDto request) {
+		return ResponseEntity.ok(
+			ApiResponseDto.success(
+				HttpStatus.OK,
+				"환불 성공",
+				paymentUseCase.refund(request)
+			)
+		);
 	}
 }

--- a/service/payment/src/test/java/jabaclass/payment/application/PaymentServiceTest.java
+++ b/service/payment/src/test/java/jabaclass/payment/application/PaymentServiceTest.java
@@ -4,6 +4,8 @@ import jabaclass.payment.application.port.external.OrderPort;
 import jabaclass.payment.application.port.external.PaymentGatewayPort;
 import jabaclass.payment.application.port.external.UserPort;
 import jabaclass.payment.application.service.PaymentService;
+import jabaclass.payment.common.exception.PaymentErrorCode;
+import jabaclass.payment.common.exception.PaymentException;
 import jabaclass.payment.domain.model.Payment;
 import jabaclass.payment.domain.model.PaymentMethod;
 import jabaclass.payment.domain.model.Refund;
@@ -114,8 +116,8 @@ class PaymentServiceTest {
 
 		// when & then
 		assertThatThrownBy(() -> paymentService.confirm(request))
-			.isInstanceOf(IllegalStateException.class)
-			.hasMessage("결제 정보를 찾을 수 없습니다.");
+			.isInstanceOf(PaymentException.class)
+			.hasMessage(PaymentErrorCode.PAYMENT_NOT_FOUND.getMessage());
 	}
 
 	@Test
@@ -147,8 +149,8 @@ class PaymentServiceTest {
 
 		// when & then
 		assertThatThrownBy(() -> paymentService.confirm(request))
-			.isInstanceOf(IllegalStateException.class)
-			.hasMessage("주문 금액이 일치하지 않습니다.");
+			.isInstanceOf(PaymentException.class)
+			.hasMessage(PaymentErrorCode.INVALID_ORDER_AMOUNT.getMessage());
 
 		verify(paymentGatewayPort, never()).confirm(any(), any(), anyInt());
 		verify(orderPort, never())
@@ -184,8 +186,8 @@ class PaymentServiceTest {
 
 		// when & then
 		assertThatThrownBy(() -> paymentService.confirm(request))
-			.isInstanceOf(IllegalStateException.class)
-			.hasMessage("결제 금액이 일치하지 않습니다.");
+			.isInstanceOf(PaymentException.class)
+			.hasMessage(PaymentErrorCode.INVALID_PAYMENT_AMOUNT.getMessage());
 
 		verify(paymentGatewayPort, never()).confirm(any(), any(), anyInt());
 		verify(orderPort, never())

--- a/service/payment/src/test/java/jabaclass/payment/domain/PaymentTest.java
+++ b/service/payment/src/test/java/jabaclass/payment/domain/PaymentTest.java
@@ -1,5 +1,7 @@
 package jabaclass.payment.domain;
 
+import jabaclass.payment.common.exception.PaymentErrorCode;
+import jabaclass.payment.common.exception.PaymentException;
 import jabaclass.payment.domain.model.Payment;
 import jabaclass.payment.domain.model.PaymentStatus;
 import jabaclass.payment.domain.model.PaymentMethod;
@@ -62,8 +64,8 @@ class PaymentTest {
 			null,
 			BigDecimal.valueOf(500)
 		))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("금액은 null일 수 없습니다");
+			.isInstanceOf(PaymentException.class)
+			.hasMessage(PaymentErrorCode.INVALID_AMOUNT.getMessage());
 	}
 
 	@Test
@@ -83,8 +85,8 @@ class PaymentTest {
 			BigDecimal.valueOf(1000),
 			null
 		))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("금액은 null일 수 없습니다");
+			.isInstanceOf(PaymentException.class)
+			.hasMessage(PaymentErrorCode.INVALID_AMOUNT.getMessage());
 	}
 
 	@Test
@@ -104,8 +106,8 @@ class PaymentTest {
 			BigDecimal.valueOf(-1),
 			BigDecimal.valueOf(500)
 		))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("paymentAmount는 0 이상이어야 합니다");
+			.isInstanceOf(PaymentException.class)
+			.hasMessage(PaymentErrorCode.INVALID_NEGATIVE_AMOUNT.getMessage());
 	}
 
 	@Test
@@ -125,8 +127,8 @@ class PaymentTest {
 			BigDecimal.valueOf(1000),
 			BigDecimal.valueOf(-1)
 		))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("depositAmount는 0 이상이어야 합니다");
+			.isInstanceOf(PaymentException.class)
+			.hasMessage(PaymentErrorCode.INVALID_NEGATIVE_AMOUNT.getMessage());
 	}
 
 	@Test
@@ -140,7 +142,7 @@ class PaymentTest {
 			BigDecimal.valueOf(1000),
 			BigDecimal.ZERO
 		))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("productUserId는 null일 수 없습니다");
+			.isInstanceOf(PaymentException.class)
+			.hasMessage(PaymentErrorCode.INVALID_PRODUCT_USER.getMessage());
 	}
 }


### PR DESCRIPTION
## 관련 이슈
- Close #115 

## 변경 요약
- 결제 도메인에 예외 처리 구조 도입
- GlobalExceptionHandler 기반 공통 에러 처리 및 로깅을 적용
- API 응답 ApiResponseDto로 통일

## 주요 변경점
- PaymentException, PaymentErrorCode 등 커스텀 예외 구조 추가
- GlobalExceptionHandler 도입 및 예외 응답 처리 로직 구현
- 비즈니스 예외(warn) / 시스템 예외(error) 로그 레벨 분리
- Payment 및 Deposit 도메인 서비스/로직에 예외 처리 적용
- 테스트 코드에 예외 케이스 반영
- Controller 응답을 ApiResponseDto로 래핑하여 success/fail 구조 통일

## 테스트
- [x] 로컬 실행 확인
- [x] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트
