### PR TITLE
feat : api docs 버전 변경

### DIFF
--- a/service/file/build.gradle
+++ b/service/file/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:s3-transfer-manager'
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'
 
 //    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     runtimeOnly 'com.h2database:h2'


### PR DESCRIPTION
## 관련 이슈
- Close #59 

## 변경 요약
- springdoc 버전 변경

## 주요 변경점
- file 모듈만 다른 서비스보다 오래된 springdoc 2.5.0 을 쓰고 있던 점이었고, 
이걸 service/file/build.gradle 에서 3.0.0으로 올려서 다른 서비스와 맞췄습니다.


## 테스트
- [x] 로컬 실행 확인
- [x] 테스트 통과
- [x] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트

- 