### PR TITLE
feat: token 재발급 로직 작성

### DIFF
--- a/service/frontend/src/main/java/jabaclass/frontend/config/RestTemplateConfig.java
+++ b/service/frontend/src/main/java/jabaclass/frontend/config/RestTemplateConfig.java
@@ -1,15 +1,23 @@
 package jabaclass.frontend.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class RestTemplateConfig {
+
+    private final TokenRefreshInterceptor tokenRefreshInterceptor;
 
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+        RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+        restTemplate.setInterceptors(List.of(tokenRefreshInterceptor));
+        return restTemplate;
     }
 }

--- a/service/frontend/src/main/java/jabaclass/frontend/config/SecurityConfig.java
+++ b/service/frontend/src/main/java/jabaclass/frontend/config/SecurityConfig.java
@@ -6,6 +6,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 
 @Configuration
 @RequiredArgsConstructor
@@ -15,8 +17,14 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        CsrfTokenRequestAttributeHandler requestHandler = new CsrfTokenRequestAttributeHandler();
+
         http
-            .csrf(csrf -> csrf.disable())
+            .csrf(csrf -> csrf
+                // XSRF-TOKEN 쿠키로 토큰 관리 (JS에서 읽어 X-XSRF-TOKEN 헤더로 전송)
+                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                .csrfTokenRequestHandler(requestHandler)
+            )
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/login", "/signup", "/signup/send-code", "/signup/verify-code", "/error", "/css/**", "/js/**").permitAll()
                 .anyRequest().authenticated()

--- a/service/frontend/src/main/java/jabaclass/frontend/config/TokenRefreshInterceptor.java
+++ b/service/frontend/src/main/java/jabaclass/frontend/config/TokenRefreshInterceptor.java
@@ -44,8 +44,9 @@ public class TokenRefreshInterceptor implements ClientHttpRequestInterceptor {
         }
 
         response.close();
-        String oldToken = (String) httpServletRequest.getSession(false) != null
-                ? (String) httpServletRequest.getSession(false).getAttribute("accessToken") : "none";
+        HttpSession currentSession = httpServletRequest.getSession(false);
+        String oldToken = currentSession != null
+                ? (String) currentSession.getAttribute("accessToken") : "none";
         log.debug("401 감지 — 토큰 재발급 시도 [uri={}, oldToken={}...]",
                 request.getURI(), oldToken != null && oldToken.length() > 10 ? oldToken.substring(0, 10) : oldToken);
 

--- a/service/frontend/src/main/java/jabaclass/frontend/config/TokenRefreshInterceptor.java
+++ b/service/frontend/src/main/java/jabaclass/frontend/config/TokenRefreshInterceptor.java
@@ -1,0 +1,100 @@
+package jabaclass.frontend.config;
+
+import jabaclass.frontend.exception.SessionExpiredException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.support.HttpRequestWrapper;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenRefreshInterceptor implements ClientHttpRequestInterceptor {
+
+    private final HttpServletRequest httpServletRequest;
+
+    @Value("${services.user-url}")
+    private String userUrl;
+
+    // reissue 호출 전용 RestTemplate — 이 인터셉터를 거치지 않아 무한 루프 방지
+    private final RestTemplate reissueTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body,
+                                        ClientHttpRequestExecution execution) throws IOException {
+        ClientHttpResponse response = execution.execute(request, body);
+
+        if (response.getStatusCode().value() != 401) {
+            return response;
+        }
+
+        response.close();
+        String oldToken = (String) httpServletRequest.getSession(false) != null
+                ? (String) httpServletRequest.getSession(false).getAttribute("accessToken") : "none";
+        log.debug("401 감지 — 토큰 재발급 시도 [uri={}, oldToken={}...]",
+                request.getURI(), oldToken != null && oldToken.length() > 10 ? oldToken.substring(0, 10) : oldToken);
+
+        HttpSession session = httpServletRequest.getSession(false);
+        if (session == null || session.getAttribute("refreshToken") == null) {
+            throw new SessionExpiredException();
+        }
+
+        String refreshToken = (String) session.getAttribute("refreshToken");
+
+        try {
+            HttpHeaders reissueHeaders = new HttpHeaders();
+            reissueHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+            @SuppressWarnings("unchecked")
+            ResponseEntity<Map> reissueResponse = reissueTemplate.postForEntity(
+                    userUrl + "/api/v1/auth/reissue",
+                    new org.springframework.http.HttpEntity<>(Map.of("refreshToken", refreshToken), reissueHeaders),
+                    Map.class
+            );
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> data = (Map<String, Object>) reissueResponse.getBody().get("data");
+            String newAccessToken = (String) data.get("accessToken");
+            String newRefreshToken = (String) data.get("refreshToken");
+
+            session.setAttribute("accessToken", newAccessToken);
+            session.setAttribute("refreshToken", newRefreshToken);
+            log.debug("토큰 재발급 성공 — newToken={}... 원래 요청 재시도",
+                    newAccessToken.length() > 10 ? newAccessToken.substring(0, 10) : newAccessToken);
+
+            // 새 토큰으로 원래 요청 재시도
+            HttpRequest retryRequest = new HttpRequestWrapper(request) {
+                @Override
+                public HttpHeaders getHeaders() {
+                    HttpHeaders headers = new HttpHeaders();
+                    headers.putAll(super.getHeaders());
+                    headers.setBearerAuth(newAccessToken);
+                    return headers;
+                }
+            };
+            return execution.execute(retryRequest, body);
+
+        } catch (Exception e) {
+            log.warn("토큰 재발급 실패 — 세션 만료 처리: {}", e.getMessage());
+            if (session != null) {
+                try { session.invalidate(); } catch (IllegalStateException ignored) {}
+            }
+            throw new SessionExpiredException();
+        }
+    }
+}

--- a/service/frontend/src/main/java/jabaclass/frontend/exception/GlobalExceptionHandler.java
+++ b/service/frontend/src/main/java/jabaclass/frontend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package jabaclass.frontend.exception;
+
+import jakarta.servlet.http.HttpSession;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(SessionExpiredException.class)
+    public String handleSessionExpired(HttpSession session) {
+        try {
+            session.invalidate();
+        } catch (IllegalStateException ignored) {
+            // 이미 무효화된 세션
+        }
+        return "redirect:/login";
+    }
+}

--- a/service/frontend/src/main/java/jabaclass/frontend/exception/SessionExpiredException.java
+++ b/service/frontend/src/main/java/jabaclass/frontend/exception/SessionExpiredException.java
@@ -1,0 +1,8 @@
+package jabaclass.frontend.exception;
+
+public class SessionExpiredException extends RuntimeException {
+
+    public SessionExpiredException() {
+        super("세션이 만료되었습니다. 다시 로그인해주세요.");
+    }
+}

--- a/service/frontend/src/main/resources/application.yml
+++ b/service/frontend/src/main/resources/application.yml
@@ -1,5 +1,11 @@
 server:
   port: 9006
+  servlet:
+    session:
+      timeout: 60m          # 비활성 60분 후 세션 만료 (accessToken 30분 + 여유분)
+      cookie:
+        http-only: true     # JS에서 세션 쿠키 직접 접근 차단
+        same-site: strict   # 크로스 사이트 요청에 쿠키 미포함
 
 spring:
   application:
@@ -17,6 +23,10 @@ services:
 internal:
   api:
     key: ${INTERNAL_KEY:test-internal-key}
+
+logging:
+  level:
+    jabaclass.frontend.config.TokenRefreshInterceptor: DEBUG
 
 toss:
   client-key: ${TOSS_CLIENT_KEY:test_ck_yL0qZ4G1VOj211Mwom2v3oWb2MQY}

--- a/service/frontend/src/main/resources/templates/deposit/charge.html
+++ b/service/frontend/src/main/resources/templates/deposit/charge.html
@@ -85,7 +85,7 @@
         if (!amount || amount < 1000) { showError('충전 금액은 최소 1,000원 이상이어야 합니다.'); return; }
         const res = await fetch('/deposit/prepare', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'application/json', ...getCsrfHeaders() },
             body: JSON.stringify({ userId, amount })
         });
         const data = await res.json().catch(() => ({}));

--- a/service/frontend/src/main/resources/templates/fragments/common-head.html
+++ b/service/frontend/src/main/resources/templates/fragments/common-head.html
@@ -9,5 +9,14 @@
     <script>tailwind.config={darkMode:'class'}</script>
     <script th:src="@{/js/theme.js}"></script>
     <style>body{font-family:'Pretendard',sans-serif;}</style>
+    <script>
+        // CSRF 토큰을 XSRF-TOKEN 쿠키에서 읽어 fetch() 헤더에 포함시키는 헬퍼
+        function getCsrfHeaders() {
+            const cookie = document.cookie.split(';').map(c => c.trim());
+            const xsrf = cookie.find(c => c.startsWith('XSRF-TOKEN='));
+            if (!xsrf) return {};
+            return { 'X-XSRF-TOKEN': decodeURIComponent(xsrf.split('=')[1]) };
+        }
+    </script>
 </head>
 </html>

--- a/service/frontend/src/main/resources/templates/payment/checkout.html
+++ b/service/frontend/src/main/resources/templates/payment/checkout.html
@@ -72,7 +72,7 @@
     async function startDepositPayment() {
         const res = await fetch('/payment/prepare', {
             method: 'POST',
-            headers: {'Content-Type': 'application/json'},
+            headers: {'Content-Type': 'application/json', ...getCsrfHeaders()},
             body: JSON.stringify({
                 userId: buyerId,
                 orderId: orderId,
@@ -96,7 +96,7 @@
     async function startPayment() {
         const res = await fetch('/payment/prepare', {
             method: 'POST',
-            headers: {'Content-Type': 'application/json'},
+            headers: {'Content-Type': 'application/json', ...getCsrfHeaders()},
             body: JSON.stringify({
                 userId: buyerId,
                 orderId: orderId,

--- a/service/frontend/src/main/resources/templates/product.html
+++ b/service/frontend/src/main/resources/templates/product.html
@@ -145,7 +145,7 @@
             <p class="text-xs text-gray-400 dark:text-gray-500 mt-1">0 입력 시 전액 카드로 결제됩니다.</p>
         </div>
 
-        <form id="modal-order-form" action="/orders" method="post">
+        <form id="modal-order-form" th:action="@{/orders}" method="post">
             <input type="hidden" name="productId" id="modal-product-id"/>
             <input type="hidden" name="scheduleId" id="modal-schedule-id"/>
             <!-- 추가 부분 -->

--- a/service/frontend/src/main/resources/templates/seller/product-form.html
+++ b/service/frontend/src/main/resources/templates/seller/product-form.html
@@ -159,7 +159,7 @@
     async function uploadFile(file) {
         const res = await fetch('/api/files/upload-request', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'application/json', ...getCsrfHeaders() },
             body: JSON.stringify({ originalName: file.name })
         });
         if (!res.ok) throw new Error('업로드 URL 발급 실패');
@@ -171,7 +171,7 @@
         });
         if (!s3Res.ok) throw new Error('S3 업로드 실패');
 
-        const completeRes = await fetch(`/api/files/${data.fileId}/complete`, { method: 'PATCH' });
+        const completeRes = await fetch(`/api/files/${data.fileId}/complete`, { method: 'PATCH', headers: { ...getCsrfHeaders() } });
         if (!completeRes.ok) throw new Error('업로드 확정 실패');
 
         return data.fileId;

--- a/service/frontend/src/main/resources/templates/signup.html
+++ b/service/frontend/src/main/resources/templates/signup.html
@@ -103,7 +103,7 @@
         try {
             const res = await fetch('/signup/send-code', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: { 'Content-Type': 'application/json', ...getCsrfHeaders() },
                 body: JSON.stringify({ email })
             });
             const data = await res.json().catch(() => ({}));
@@ -127,7 +127,7 @@
         try {
             const res = await fetch('/signup/verify-code', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: { 'Content-Type': 'application/json', ...getCsrfHeaders() },
                 body: JSON.stringify({ email, code })
             });
             const data = await res.json().catch(() => ({}));
@@ -158,7 +158,7 @@
         try {
             const res = await fetch('/signup', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: { 'Content-Type': 'application/json', ...getCsrfHeaders() },
                 body: JSON.stringify({ name, email, password, phone, verifiedToken })
             });
             const data = await res.json().catch(() => ({}));

--- a/service/order/src/main/resources/application.yml
+++ b/service/order/src/main/resources/application.yml
@@ -12,9 +12,7 @@ spring:
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
 jwt:
-  secret: ${JWT_SECRET:abcdefghijklmnopqrstuvwxyz123456}
-  access-token-validity: 3600000
-  refresh-token-validity: 604800000
+  secret: ${JWT_SECRET}
 
 management:
   endpoints:


### PR DESCRIPTION
## 관련 이슈
- Close #163 

## 변경 요약
- frontend에 access토큰 유효시간이 만료되었을 때 재발급 해주는 로직 작성
- session 유효 시간 설정

## 주요 변경점
- 현재 session에 유효 시간을 설정하지 않아 default로 동작하던 방식에서 유효 시간을 설정하며 동작하도록 변경
- frontend 모듈에 access 토큰 유효시간 만료 시 재발급 되도록 구현 완료

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트

- 