### PR TITLE
feature : 상품 위치 저장 추가

### DIFF
--- a/service/product/src/main/java/jabaclass/product/application/service/ProductService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/ProductService.java
@@ -53,7 +53,6 @@ public class ProductService implements ProductUseCase {
 	@Override
 	@Transactional
 	public ProductResponseDto create(CreateProductRequestDto requestDto, UUID sellerId) {
-		log.info("userID ::: {}", sellerId);
 		List<ProductImageItem> images = List.of();
 		if (requestDto.imageIds() != null && !requestDto.imageIds().isEmpty()) {
 			List<FileConfirmResponse> confirmed =
@@ -70,6 +69,11 @@ public class ProductService implements ProductUseCase {
 			.description(requestDto.description())
 			.price(requestDto.price())
 			.status(requestDto.status())
+			.roadAddress(requestDto.roadAddress())
+			.detailAddress(requestDto.detailAddress())
+			.zonecode(requestDto.zonecode())
+			.latitude(requestDto.latitude())
+			.longitude(requestDto.longitude())
 			.build();
 
 		product.changeImages(images);
@@ -94,6 +98,11 @@ public class ProductService implements ProductUseCase {
 		product.changeDescription(requestDto.description());
 		product.changePrice(requestDto.price());
 		product.changeStatus(requestDto.status());
+		product.changeRoadAddress(requestDto.roadAddress());
+		product.changeDetailAddress(requestDto.detailAddress());
+		product.changeZonecode(requestDto.zonecode());
+		product.changeLatitude(requestDto.latitude());
+		product.changeLongitude(requestDto.longitude());
 
 		// 이미지 수정 — null이면 기존 이미지 유지
 		if (requestDto.imageIds() != null) {

--- a/service/product/src/main/java/jabaclass/product/domain/model/Product.java
+++ b/service/product/src/main/java/jabaclass/product/domain/model/Product.java
@@ -63,6 +63,21 @@ public class Product extends EntityBase {
 	@Column(nullable = false, length = 20)
 	private ProductStatus status;
 
+	@Column(nullable = false, length = 255)
+	private String roadAddress;
+
+	@Column(length = 255)
+	private String detailAddress;
+
+	@Column(length = 10)
+	private String zonecode;
+
+	@Column(nullable = false, precision = 10, scale = 7)
+	private BigDecimal latitude;
+
+	@Column(nullable = false, precision = 10, scale = 7)
+	private BigDecimal longitude;
+
 	@PrePersist
 	public void prePersist() {
 		if (this.status == null) {
@@ -105,6 +120,26 @@ public class Product extends EntityBase {
 
 	public void changeStatus(ProductStatus status) {
 		this.status = status;
+	}
+
+	public void changeRoadAddress(String roadAddress) {
+		this.roadAddress = roadAddress;
+	}
+
+	public void changeDetailAddress(String detailAddress) {
+		this.detailAddress = detailAddress;
+	}
+
+	public void changeZonecode(String zonecode) {
+		this.zonecode = zonecode;
+	}
+
+	public void changeLatitude(BigDecimal latitude) {
+		this.latitude = latitude;
+	}
+
+	public void changeLongitude(BigDecimal longitude) {
+		this.longitude = longitude;
 	}
 
 }

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/request/CreateProductRequestDto.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/request/CreateProductRequestDto.java
@@ -38,6 +38,21 @@ public record CreateProductRequestDto(
 	BigDecimal price,
 
 	@Schema(description = "상태", example = "ENABLE")
-	ProductStatus status
+	ProductStatus status,
+
+	@Schema(description = "도로명 주소", example = "경기 성남시 분당구 판교역로 166")
+	String roadAddress,
+
+	@Schema(description = "상세 주소", example = "카카오 판교 아지트 1층")
+	String detailAddress,
+
+	@Schema(description = "우편 번호", example = "13529")
+	String zonecode,
+
+	@Schema(description = "위도", example = "37.3952")
+	BigDecimal latitude,
+
+	@Schema(description = "경도", example = "127.1110")
+	BigDecimal longitude
 ) {
 }

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/request/CreateProductRequestDto.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/request/CreateProductRequestDto.java
@@ -40,6 +40,7 @@ public record CreateProductRequestDto(
 	@Schema(description = "상태", example = "ENABLE")
 	ProductStatus status,
 
+	@NotBlank(message = "도로명 주소를 입력해주세요.")
 	@Schema(description = "도로명 주소", example = "경기 성남시 분당구 판교역로 166")
 	String roadAddress,
 
@@ -49,9 +50,11 @@ public record CreateProductRequestDto(
 	@Schema(description = "우편 번호", example = "13529")
 	String zonecode,
 
+	@NotNull(message = "위도를 입력해주세요.")
 	@Schema(description = "위도", example = "37.3952")
 	BigDecimal latitude,
 
+	@NotNull(message = "경도를 입력해주세요.")
 	@Schema(description = "경도", example = "127.1110")
 	BigDecimal longitude
 ) {

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/request/UpdateProductRequestDto.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/request/UpdateProductRequestDto.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jabaclass.product.domain.model.status.ProductStatus;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @Schema(description = "상품 수정")
@@ -35,6 +36,7 @@ public record UpdateProductRequestDto(
 	@Schema(description = "상태", example = "ENABLE")
 	ProductStatus status,
 
+	@NotBlank(message = "도로명 주소를 입력해주세요.")
 	@Schema(description = "도로명 주소", example = "경기 성남시 분당구 판교역로 166")
 	String roadAddress,
 
@@ -44,9 +46,11 @@ public record UpdateProductRequestDto(
 	@Schema(description = "우편 번호", example = "13529")
 	String zonecode,
 
+	@NotNull(message = "위도를 입력해주세요.")
 	@Schema(description = "위도", example = "37.3952")
 	BigDecimal latitude,
 
+	@NotNull(message = "경도를 입력해주세요.")
 	@Schema(description = "경도", example = "127.1110")
 	BigDecimal longitude
 ) {

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/request/UpdateProductRequestDto.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/request/UpdateProductRequestDto.java
@@ -33,6 +33,21 @@ public record UpdateProductRequestDto(
 	BigDecimal price,
 
 	@Schema(description = "상태", example = "ENABLE")
-	ProductStatus status
+	ProductStatus status,
+
+	@Schema(description = "도로명 주소", example = "경기 성남시 분당구 판교역로 166")
+	String roadAddress,
+
+	@Schema(description = "상세 주소", example = "카카오 판교 아지트 1층")
+	String detailAddress,
+
+	@Schema(description = "우편 번호", example = "13529")
+	String zonecode,
+
+	@Schema(description = "위도", example = "37.3952")
+	BigDecimal latitude,
+
+	@Schema(description = "경도", example = "127.1110")
+	BigDecimal longitude
 ) {
 }

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/respose/ProductResponseDto.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/respose/ProductResponseDto.java
@@ -3,7 +3,6 @@ package jabaclass.product.presentation.dto.respose;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -45,7 +44,22 @@ public record ProductResponseDto(
 	LocalDateTime regDt,
 
 	@Schema(description = "수정일시", example = "2026-03-04T18:12:00")
-	LocalDateTime modifyDt
+	LocalDateTime modifyDt,
+
+	@Schema(description = "도로명 주소", example = "경기 성남시 분당구 판교역로 166")
+	String roadAddress,
+
+	@Schema(description = "상세 주소", example = "카카오 판교 아지트 1층")
+	String detailAddress,
+
+	@Schema(description = "우편 번호", example = "13529")
+	String zonecode,
+
+	@Schema(description = "위도", example = "37.3952")
+	BigDecimal latitude,
+
+	@Schema(description = "경도", example = "127.1110")
+	BigDecimal longitude
 ) {
 
 	public static ProductResponseDto from(Product product, String sellerName) {
@@ -64,7 +78,12 @@ public record ProductResponseDto(
 			product.getPrice(),
 			product.getStatus().getStatusName(),
 			product.getRegDt(),
-			product.getModifyDt()
+			product.getModifyDt(),
+			product.getRoadAddress(),
+			product.getDetailAddress(),
+			product.getZonecode(),
+			product.getLatitude(),
+			product.getLongitude()
 		);
 	}
 
@@ -80,27 +99,13 @@ public record ProductResponseDto(
 			document.getPrice(),
 			ProductStatus.valueOf(document.getStatus()).getStatusName(),
 			document.getRegDt(),
+			null,
+			null,
+			null,
+			null,
+			null,
 			null
 		);
 	}
 
-	public static ProductResponseDto listFrom(Product product, Map<UUID, String> map) {
-		List<ProductImageItem> images = product.getDescriptionImages();
-		List<String> imagePaths = images == null ? List.of()
-			: images.stream().map(ProductImageItem::storagePath).toList();
-
-		return new ProductResponseDto(
-			product.getId(),
-			map.getOrDefault(product.getSellerId(), "사용자 이름이 지정되지 않았습니다."),
-			product.getTitle(),
-			product.getMaxCapacity(),
-			product.getDescription(),
-			product.getThumbnailPath(),
-			imagePaths,
-			product.getPrice(),
-			product.getStatus().getStatusName(),
-			product.getRegDt(),
-			product.getModifyDt()
-		);
-	}
 }

--- a/service/product/src/test/java/jabaclass/product/ProductCUDTest.java
+++ b/service/product/src/test/java/jabaclass/product/ProductCUDTest.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -26,6 +27,7 @@ import jabaclass.product.application.exception.BusinessException;
 import jabaclass.product.application.service.ProductService;
 import jabaclass.product.common.exception.CommonErrorCode;
 import jabaclass.product.domain.model.Product;
+import jabaclass.product.domain.model.ProductImageItem;
 import jabaclass.product.domain.model.status.ProductStatus;
 import jabaclass.product.domain.repository.ProductRepository;
 import jabaclass.product.domain.repository.ProductSearchRepository;
@@ -66,6 +68,8 @@ class ProductCUDTest {
 	private static final UUID SELLER_ID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
 	private static final UUID PRODUCT_ID = UUID.fromString("223e4567-e89b-12d3-a456-426614174000");
 	private static final BigDecimal PRICE = new BigDecimal("1000.50");
+	private static final BigDecimal LATITUDE = new BigDecimal("37.3952000");
+	private static final BigDecimal LONGITUDE = new BigDecimal("127.1110000");
 
 	private Validator validator;
 	private Product product;
@@ -81,12 +85,17 @@ class ProductCUDTest {
 			.description("테스트 상품")
 			.price(PRICE)
 			.status(ProductStatus.ENABLE)
+			.roadAddress("경기 성남시 분당구 판교역로 166")
+			.detailAddress("카카오 판교 아지트 1층")
+			.zonecode("13529")
+			.latitude(LATITUDE)
+			.longitude(LONGITUDE)
 			.build();
 		ReflectionTestUtils.setField(product, "id", PRODUCT_ID);
 	}
 
 	@Test
-	void 상품_생성에_성공한다() {
+	void 상품_생성시_추가된_주소와_좌표_컬럼까지_저장한다() {
 		CreateProductRequestDto request = new CreateProductRequestDto(
 			SELLER_ID,
 			"테스트상품",
@@ -94,7 +103,12 @@ class ProductCUDTest {
 			"테스트 상품입니다.",
 			List.of(UUID.randomUUID()),
 			PRICE,
-			ProductStatus.ENABLE
+			ProductStatus.ENABLE,
+			"경기 성남시 분당구 판교역로 166",
+			"카카오 판교 아지트 1층",
+			"13529",
+			LATITUDE,
+			LONGITUDE
 		);
 		UUID fileId = UUID.randomUUID();
 		given(fileConfirmClient.confirmBulk(any())).willReturn(List.of(new FileConfirmResponse(fileId, "user/file/image.jpg")));
@@ -108,11 +122,24 @@ class ProductCUDTest {
 
 		ProductResponseDto saved = productService.create(request, SELLER_ID);
 
+		ArgumentCaptor<Product> captor = ArgumentCaptor.forClass(Product.class);
+		then(productRepository).should().save(captor.capture());
+		Product captured = captor.getValue();
+
+		assertThat(captured.getRoadAddress()).isEqualTo("경기 성남시 분당구 판교역로 166");
+		assertThat(captured.getDetailAddress()).isEqualTo("카카오 판교 아지트 1층");
+		assertThat(captured.getZonecode()).isEqualTo("13529");
+		assertThat(captured.getLatitude()).isEqualByComparingTo(LATITUDE);
+		assertThat(captured.getLongitude()).isEqualByComparingTo(LONGITUDE);
+
 		assertThat(saved.id()).isEqualTo(PRODUCT_ID);
 		assertThat(saved.title()).isEqualTo("테스트상품");
 		assertThat(saved.thumbnailPath()).isEqualTo("user/file/image.jpg");
-		assertThat(saved.price()).isEqualByComparingTo(PRICE);
-		then(productRepository).should().save(any(Product.class));
+		assertThat(saved.roadAddress()).isEqualTo("경기 성남시 분당구 판교역로 166");
+		assertThat(saved.detailAddress()).isEqualTo("카카오 판교 아지트 1층");
+		assertThat(saved.zonecode()).isEqualTo("13529");
+		assertThat(saved.latitude()).isEqualByComparingTo(LATITUDE);
+		assertThat(saved.longitude()).isEqualByComparingTo(LONGITUDE);
 		then(publisher).should().publishEvent(any(ProductEventResponseDto.class));
 		then(publisher).should().publishEvent(any(ProductEsSaveEvent.class));
 	}
@@ -126,7 +153,12 @@ class ProductCUDTest {
 			"테스트 상품입니다.",
 			List.of(UUID.randomUUID()),
 			PRICE,
-			ProductStatus.ENABLE
+			ProductStatus.ENABLE,
+			"경기 성남시 분당구 판교역로 166",
+			"카카오 판교 아지트 1층",
+			"13529",
+			LATITUDE,
+			LONGITUDE
 		);
 
 		Set<ConstraintViolation<CreateProductRequestDto>> violations = validator.validate(request);
@@ -144,7 +176,12 @@ class ProductCUDTest {
 			"테스트 상품입니다.",
 			List.of(UUID.randomUUID()),
 			PRICE,
-			ProductStatus.ENABLE
+			ProductStatus.ENABLE,
+			"경기 성남시 분당구 판교역로 166",
+			"카카오 판교 아지트 1층",
+			"13529",
+			LATITUDE,
+			LONGITUDE
 		);
 
 		Set<ConstraintViolation<CreateProductRequestDto>> violations = validator.validate(request);
@@ -162,7 +199,12 @@ class ProductCUDTest {
 			"테스트 상품입니다.",
 			List.of(UUID.randomUUID()),
 			PRICE,
-			ProductStatus.ENABLE
+			ProductStatus.ENABLE,
+			"경기 성남시 분당구 판교역로 166",
+			"카카오 판교 아지트 1층",
+			"13529",
+			LATITUDE,
+			LONGITUDE
 		);
 
 		Set<ConstraintViolation<CreateProductRequestDto>> violations = validator.validate(request);
@@ -180,7 +222,12 @@ class ProductCUDTest {
 			"테스트 상품입니다.",
 			List.of(UUID.randomUUID()),
 			BigDecimal.ZERO,
-			ProductStatus.ENABLE
+			ProductStatus.ENABLE,
+			"경기 성남시 분당구 판교역로 166",
+			"카카오 판교 아지트 1층",
+			"13529",
+			LATITUDE,
+			LONGITUDE
 		);
 
 		Set<ConstraintViolation<CreateProductRequestDto>> violations = validator.validate(request);
@@ -198,7 +245,12 @@ class ProductCUDTest {
 			"테스트 상품입니다.",
 			List.of(UUID.randomUUID()),
 			PRICE,
-			ProductStatus.ENABLE
+			ProductStatus.ENABLE,
+			"경기 성남시 분당구 판교역로 166",
+			"카카오 판교 아지트 1층",
+			"13529",
+			LATITUDE,
+			LONGITUDE
 		);
 		given(sellerRepository.findSeller(SELLER_ID)).willReturn(Optional.empty());
 
@@ -208,14 +260,19 @@ class ProductCUDTest {
 	}
 
 	@Test
-	void 상품_수정에_성공한다() {
+	void 상품_수정시_추가된_주소와_좌표_컬럼도_변경한다() {
 		UpdateProductRequestDto request = new UpdateProductRequestDto(
 			"수정상품",
 			10,
 			"수정 설명",
 			List.of(UUID.randomUUID()),
 			new BigDecimal("1200.00"),
-			ProductStatus.ENABLE
+			ProductStatus.ENABLE,
+			"서울 강남구 테헤란로 123",
+			"3층",
+			"06234",
+			new BigDecimal("37.1234567"),
+			new BigDecimal("127.7654321")
 		);
 		UUID fileId = UUID.randomUUID();
 		given(fileConfirmClient.confirmBulk(any())).willReturn(List.of(new FileConfirmResponse(fileId, "user/file/image.jpg")));
@@ -226,8 +283,18 @@ class ProductCUDTest {
 
 		ProductResponseDto updated = productService.update(request, PRODUCT_ID, SELLER_ID);
 
+		assertThat(product.getRoadAddress()).isEqualTo("서울 강남구 테헤란로 123");
+		assertThat(product.getDetailAddress()).isEqualTo("3층");
+		assertThat(product.getZonecode()).isEqualTo("06234");
+		assertThat(product.getLatitude()).isEqualByComparingTo("37.1234567");
+		assertThat(product.getLongitude()).isEqualByComparingTo("127.7654321");
+
 		assertThat(updated.title()).isEqualTo("수정상품");
-		assertThat(updated.price()).isEqualByComparingTo(request.price());
+		assertThat(updated.roadAddress()).isEqualTo("서울 강남구 테헤란로 123");
+		assertThat(updated.detailAddress()).isEqualTo("3층");
+		assertThat(updated.zonecode()).isEqualTo("06234");
+		assertThat(updated.latitude()).isEqualByComparingTo("37.1234567");
+		assertThat(updated.longitude()).isEqualByComparingTo("127.7654321");
 		then(publisher).should().publishEvent(any(ProductEsSaveEvent.class));
 	}
 
@@ -239,7 +306,12 @@ class ProductCUDTest {
 			"수정 설명",
 			List.of(UUID.randomUUID()),
 			new BigDecimal("1200.00"),
-			ProductStatus.ENABLE
+			ProductStatus.ENABLE,
+			"서울 강남구 테헤란로 123",
+			"3층",
+			"06234",
+			new BigDecimal("37.1234567"),
+			new BigDecimal("127.7654321")
 		);
 		given(productRepository.findById(PRODUCT_ID)).willReturn(Optional.empty());
 
@@ -277,7 +349,12 @@ class ProductCUDTest {
 			"수정 설명",
 			List.of(UUID.randomUUID()),
 			new BigDecimal("1200.00"),
-			ProductStatus.ENABLE
+			ProductStatus.ENABLE,
+			"서울 강남구 테헤란로 123",
+			"3층",
+			"06234",
+			new BigDecimal("37.1234567"),
+			new BigDecimal("127.7654321")
 		);
 		given(productRepository.findById(PRODUCT_ID)).willReturn(Optional.of(product));
 		given(productRepository.findByIdAndSellerId(PRODUCT_ID, SELLER_ID)).willReturn(Optional.empty());

--- a/service/product/src/test/java/jabaclass/product/ProductRestControllerTest.java
+++ b/service/product/src/test/java/jabaclass/product/ProductRestControllerTest.java
@@ -62,7 +62,12 @@ class ProductRestControllerTest {
 			"설명",
 			List.of(UUID.randomUUID()),
 			new BigDecimal("10000"),
-			ProductStatus.ENABLE
+			ProductStatus.ENABLE,
+			"경기 성남시 분당구 판교역로 166",
+			"카카오 판교 아지트 1층",
+			"13529",
+			new BigDecimal("37.3952000"),
+			new BigDecimal("127.1110000")
 		);
 
 		updateRequest = new UpdateProductRequestDto(
@@ -71,7 +76,12 @@ class ProductRestControllerTest {
 			"수정설명",
 			List.of(UUID.randomUUID()),
 			new BigDecimal("20000"),
-			ProductStatus.DISABLE
+			ProductStatus.DISABLE,
+			"서울 강남구 테헤란로 123",
+			"3층",
+			"06234",
+			new BigDecimal("37.1234567"),
+			new BigDecimal("127.7654321")
 		);
 
 		productResponse = new ProductResponseDto(
@@ -85,7 +95,12 @@ class ProductRestControllerTest {
 			new BigDecimal("10000"),
 			"활성",
 			LocalDateTime.now(),
-			LocalDateTime.now()
+			LocalDateTime.now(),
+			"경기 성남시 분당구 판교역로 166",
+			"카카오 판교 아지트 1층",
+			"13529",
+			new BigDecimal("37.3952000"),
+			new BigDecimal("127.1110000")
 		);
 	}
 


### PR DESCRIPTION
## 관련 이슈
- Close #226 

## 변경 요약
-  Product 주소 저장을 위한 컬럼 추가에 맞춰 테스트를 현재 코드 기준으로 테스트 코드 작성


## 주요 변경점
- 새로 추가된 roadAddress, detailAddress, zonecode, latitude, longitude가 생성/수정  시 반영 및 상세보기 시 주소 검색

## 테스트
- [x] 로컬 실행 확인
- [x] 테스트 통과
- [x] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트

- 위도, 경도를 등록해 지도로 뿌려주고 있지만 불필요하다 싶으면 말씀해주세요