### PR TITLE
fix: user 모듈에서 common 모듈 잔해 제거 완료

### DIFF
--- a/service/user/build.gradle
+++ b/service/user/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // Jwt
-    implementation project(':common')
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import jabaclass.user.user.domain.model.UserRole;
-import jabaclass.auth.jwt.JwtProvider;
+import jabaclass.user.auth.infrastructure.jwt.JwtProvider;
 import jabaclass.user.auth.application.exception.AuthErrorCode;
 import jabaclass.user.auth.application.exception.AuthException;
 import jabaclass.user.auth.application.usecase.LoginUseCase;

--- a/service/user/src/main/java/jabaclass/user/auth/infrastructure/jwt/JwtProvider.java
+++ b/service/user/src/main/java/jabaclass/user/auth/infrastructure/jwt/JwtProvider.java
@@ -1,0 +1,54 @@
+package jabaclass.user.auth.infrastructure.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.UUID;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import jabaclass.user.auth.application.exception.AuthErrorCode;
+import jabaclass.user.auth.application.exception.AuthException;
+
+@Component
+public class JwtProvider {
+
+	private static final String CLAIM_USER_ID = "userId";
+	private static final String CLAIM_TYPE = "type";
+	private static final String CLAIM_ROLE = "role";
+
+	private final Key key;
+
+	public JwtProvider(@Value("${jwt.secret}") String secret) {
+		this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+	}
+
+	public Claims parseClaims(String token) {
+		try {
+			return Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+		} catch (JwtException | IllegalArgumentException e) {
+			throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+		}
+	}
+
+	public UUID getUserId(Claims claims) {
+		return UUID.fromString(claims.get(CLAIM_USER_ID, String.class));
+	}
+
+	public boolean isRefreshToken(Claims claims) {
+		return TokenType.REFRESH.name().equals(claims.get(CLAIM_TYPE, String.class));
+	}
+
+	public String getRole(Claims claims) {
+		return claims.get(CLAIM_ROLE, String.class);
+	}
+}

--- a/service/user/src/main/java/jabaclass/user/auth/infrastructure/jwt/JwtProvider.java
+++ b/service/user/src/main/java/jabaclass/user/auth/infrastructure/jwt/JwtProvider.java
@@ -25,6 +25,9 @@ public class JwtProvider {
 	private final Key key;
 
 	public JwtProvider(@Value("${jwt.secret}") String secret) {
+		if (secret.length() < 32) {
+			throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+		}
 		this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
 	}
 

--- a/service/user/src/main/java/jabaclass/user/auth/infrastructure/jwt/TokenProvider.java
+++ b/service/user/src/main/java/jabaclass/user/auth/infrastructure/jwt/TokenProvider.java
@@ -12,6 +12,8 @@ import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import jabaclass.user.auth.application.exception.AuthErrorCode;
+import jabaclass.user.auth.application.exception.AuthException;
 import jabaclass.user.user.domain.model.UserRole;
 
 @Component
@@ -31,7 +33,7 @@ public class TokenProvider {
             @Value("${jwt.refresh-token-validity}") long refreshTokenValidity
     ) {
         if (secret.length() < 32) {
-            throw new IllegalArgumentException("JWT secret은 최소 32자 이상이어야 합니다.");
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
         }
         this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
         this.accessTokenValidity = accessTokenValidity;

--- a/service/user/src/main/java/jabaclass/user/auth/infrastructure/jwt/TokenProvider.java
+++ b/service/user/src/main/java/jabaclass/user/auth/infrastructure/jwt/TokenProvider.java
@@ -12,7 +12,6 @@ import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import jabaclass.auth.jwt.TokenType;
 import jabaclass.user.user.domain.model.UserRole;
 
 @Component

--- a/service/user/src/main/java/jabaclass/user/auth/infrastructure/jwt/TokenType.java
+++ b/service/user/src/main/java/jabaclass/user/auth/infrastructure/jwt/TokenType.java
@@ -1,0 +1,5 @@
+package jabaclass.user.auth.infrastructure.jwt;
+
+public enum TokenType {
+	ACCESS, REFRESH
+}

--- a/service/user/src/main/java/jabaclass/user/common/config/SecurityConfig.java
+++ b/service/user/src/main/java/jabaclass/user/common/config/SecurityConfig.java
@@ -13,12 +13,8 @@ import org.springframework.security.web.SecurityFilterChain;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import jabaclass.auth.jwt.JwtProperties;
-import jabaclass.auth.jwt.JwtProvider;
-
 @Configuration
 @EnableWebSecurity
-@EnableConfigurationProperties(JwtProperties.class)
 public class SecurityConfig {
 
 	@Bean
@@ -42,11 +38,6 @@ public class SecurityConfig {
 	@Bean
 	public ObjectMapper objectMapper() {
 		return new ObjectMapper();
-	}
-
-	@Bean
-	public JwtProvider jwtProvider(JwtProperties jwtProperties) {
-		return new JwtProvider(jwtProperties);
 	}
 
 	@Bean

--- a/service/user/src/main/java/jabaclass/user/common/error/GlobalExceptionHandler.java
+++ b/service/user/src/main/java/jabaclass/user/common/error/GlobalExceptionHandler.java
@@ -6,7 +6,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import jabaclass.auth.exception.JwtAuthException;
 import jabaclass.user.auth.application.exception.AuthException;
 import jabaclass.user.common.dto.ApiResponseDto;
 import lombok.extern.slf4j.Slf4j;
@@ -37,16 +36,6 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ApiResponseDto<Void>> handleBusinessException(BusinessException ex) {
 		return ResponseEntity.status(ex.getStatus())
 			.body(ApiResponseDto.fail(ex.getStatus(), ex.getMessage()));
-	}
-
-	/**
-	 * JwtAuthException 처리
-	 * JWT 인증 관련 예외를 처리합니다.
-	 */
-	@ExceptionHandler(JwtAuthException.class)
-	public ResponseEntity<ApiResponseDto<Void>> handleJwtAuthException(JwtAuthException ex) {
-		return ResponseEntity.status(ex.getErrorCode().getStatus())
-			.body(ApiResponseDto.fail(ex.getErrorCode().getStatus(), ex.getErrorCode().getMessage()));
 	}
 
 	/**


### PR DESCRIPTION
## 관련 이슈
- Close #236 

## 변경 요약
- `user` 모듈에 남아있는 `common` 모듈 의존성 전부 제거

## 주요 변경점
- `common` 모듈에 있는 JwtProvider, TokenType 클래스 -> `user` 모듈로 이동
- `user` 모듈 build.gradle에 common 의존성 제거

## 테스트
- [x] 로컬 실행 확인
- [x] 테스트 통과
- [x] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트
- `user` 서비스 실행 후 회원가입, 로그인, redis 블랙리스트, refreshtoken 값 제대로 들어오는 지 확인 부탁드립니다.