### PR TITLE
feat: 관리자 상품 강제 삭제 시 product 서비스 Kafka 처리 및 ES 동기화 구현

### DIFF
--- a/docs/admin/admin.md
+++ b/docs/admin/admin.md
@@ -60,16 +60,44 @@ Admin은 보안 최상급 영역이므로 이중 검증 구조를 채택한다.
 ### 상품 강제 내리기 흐름
 
 ```
-Admin 서비스
-  1. Product soft delete (DB 직접)
-  2. @TransactionalEventListener(AFTER_COMMIT) → Kafka: ProductForceDownEvent 발행
+[Admin 서비스 — 동기, HTTP 응답 전]
 
-Product 서비스
-  3. ProductForceDownEvent 수신
-  4. 연관 Schedule 전체 soft delete
-  5. ES 인덱스 삭제
-  6. 실패 시 → 보상 트랜잭션으로 Product 상태 복구 이벤트 발행
+PATCH /api/v1/admins/products/{productId}/force-down
+  → AdminRoleInterceptor: X-User-Role == ADMIN 검증
+  → ProductAdminService.forceDownProduct()  @Transactional(productTransactionManager)
+      1. Admin DB products 조회 (없으면 404)
+      2. product.forceDown() → Admin DB: status=DISABLE, deleteDt=now()
+      3. applicationEventPublisher.publishEvent(AdminProductEvent)  ← Spring 내부 이벤트
+      ↓ DB 커밋
+  → AdminProductEventPublisher.publish()  @TransactionalEventListener(AFTER_COMMIT)
+      4. kafkaTemplate.send("admin.product", { type: "FORCE_DOWN", productId: "..." })
+  → HTTP 200 응답 반환
+
+[Product 서비스 — 비동기, Kafka]
+
+Kafka 토픽: admin.product
+  → AdminProductKafkaConsumer.consume()
+      ↓ type == "FORCE_DOWN"
+  → AdminProductEventHandler.processForceDown()  @Transactional
+      5. Product DB products 조회
+      6. product.changeStatus(DISABLE) + product.changeDelete()  → Product DB 반영
+      7. scheduleRepository.softDeleteByProductId()
+           UPDATE products_schedule SET delete_dt = NOW()
+           WHERE product_id = :id AND delete_dt IS NULL
+      ↓ DB 커밋
+  → productSearchRepository.deleteById()  ← ES 삭제 (트랜잭션 밖)
+      ↓ ES 실패 시
+  → AdminProductEventHandler.restoreProductStatus()  @Transactional  ← 보상 트랜잭션
+      8. product.changeStatus(ENABLE)  → Product DB 복구
+      RuntimeException 재던짐 → Kafka 재시도 (FixedBackOff 1s × 3회)
 ```
+
+| 처리 대상 | 시점 | 결과 |
+|-----------|------|------|
+| Admin DB `products` | HTTP 응답 전 (동기) | status=DISABLE, deleteDt=now() |
+| Product DB `products` | Kafka 소비 후 (비동기) | status=DISABLE, deleteDt=now() |
+| Product DB `products_schedule` | 위와 같은 트랜잭션 | delete_dt=now() (soft-delete) |
+| Elasticsearch | DB 커밋 직후 | 인덱스 삭제 |
 
 ### Multi-DataSource 구성
 
@@ -373,17 +401,47 @@ public void forceDownProduct(UUID productId) {
 ```
 
 ```java
-// Product 서비스 - AdminProductEventConsumer (product 서비스 담당자 구현)
-@KafkaListener(topics = AdminProductEventConsumer.TOPIC)
+// Product 서비스 - AdminProductKafkaConsumer
+// 위치: service/product/.../infrastructure/kafka/admin/
+@KafkaListener(topics = "admin.product", groupId = "product-admin-consumer")
 public void consume(String message) {
-    AdminProductEvent event = objectMapper.readValue(message, AdminProductEvent.class);
-    switch (event.type()) {
-        case "FORCE_DOWN" -> {
-            // 1. 연관 Schedule 전체 soft delete
-            // 2. ES 인덱스 삭제
-            // 실패 시 보상 트랜잭션으로 Product 상태 복구
+    try {
+        AdminProductMessage event = objectMapper.readValue(message, AdminProductMessage.class);
+        if ("FORCE_DOWN".equals(event.type())) {
+            handleForceDown(event);
+        } else {
+            log.warn("알 수 없는 admin.product type: {}", event.type());
         }
+    } catch (Exception e) {
+        throw new RuntimeException("admin.product 이벤트 처리 실패: " + e.getMessage(), e);
     }
+}
+
+private void handleForceDown(AdminProductMessage event) {
+    UUID productId = UUID.fromString(event.productId());
+    handler.processForceDown(productId);            // DB 트랜잭션
+    try {
+        productSearchRepository.deleteById(event.productId());  // ES 삭제
+    } catch (Exception esEx) {
+        handler.restoreProductStatus(productId);    // 보상 트랜잭션
+        throw new RuntimeException("FORCE_DOWN ES 처리 실패. productId=" + event.productId(), esEx);
+    }
+}
+
+// Product 서비스 - AdminProductEventHandler
+@Transactional
+public void processForceDown(UUID productId) {
+    Product product = productRepository.findById(productId)
+        .orElseThrow(() -> new BusinessException(CommonErrorCode.PRODUCT_NOT_FOUND));
+    product.changeStatus(ProductStatus.DISABLE);
+    product.changeDelete();
+    scheduleRepository.softDeleteByProductId(productId);  // bulk soft-delete
+}
+
+@Transactional
+public void restoreProductStatus(UUID productId) {
+    productRepository.findById(productId)
+        .ifPresent(p -> p.changeStatus(ProductStatus.ENABLE));
 }
 ```
 
@@ -395,8 +453,23 @@ Admin 기능에 필요한 필드만 포함한 **읽기 전용에 가까운 가�
 
 ---
 
-## 협의 필요 사항
+## 구현 현황
 
-| 항목 | 담당 서비스 | 내용 |
-|------|------------|------|
-| 상품 강제 내리기 Kafka Consumer 구현 | product 서비스 | `admin.product` 토픽 수신 후 type=FORCE_DOWN 처리 → schedule soft delete + ES 삭제 + 보상 트랜잭션 구현 필요 |
+| 항목 | 상태 | 브랜치 |
+|------|------|--------|
+| Admin 모듈 전체 구현 (유저/상품/주문/정산/리뷰) | ✅ 완료 | `feature/admin/admin-init/218` |
+| 상품 강제 내리기 Kafka Consumer (Product 서비스) | ✅ 완료 | `feature/product/product-admin-delete-product/231` |
+
+### Product 서비스 Consumer 추가 파일
+
+```
+service/product/.../infrastructure/kafka/admin/
+├── AdminProductMessage.java         # 메시지 역직렬화 레코드
+├── AdminProductEventHandler.java    # DB 트랜잭션 처리 (processForceDown, restoreProductStatus)
+└── AdminProductKafkaConsumer.java   # @KafkaListener + ES 삭제 + 보상 오케스트레이션
+```
+
+수정된 파일:
+- `ScheduleRepository` — `softDeleteByProductId(UUID)` 추가
+- `ScheduleJpaRepository` — bulk soft-delete JPQL 쿼리 추가
+- `ScheduleRepositoryAdapter` — 위 인터페이스 구현 위임

--- a/service/admin/src/main/java/jabaclass/admin/product/infrastructure/kafka/AdminProductEventPublisher.java
+++ b/service/admin/src/main/java/jabaclass/admin/product/infrastructure/kafka/AdminProductEventPublisher.java
@@ -26,6 +26,7 @@ public class AdminProductEventPublisher {
 			kafkaTemplate.send(TOPIC, event.productId(), objectMapper.writeValueAsString(event));
 		} catch (Exception e) {
 			log.error("[ADMIN] AdminProductEvent 발행 실패. type={}, productId={}", event.type(), event.productId(), e);
+			throw new RuntimeException("AdminProductEvent 발행 실패", e);
 		}
 	}
 }

--- a/service/product/src/main/java/jabaclass/product/domain/repository/ScheduleRepository.java
+++ b/service/product/src/main/java/jabaclass/product/domain/repository/ScheduleRepository.java
@@ -76,4 +76,7 @@ public interface ScheduleRepository {
 		@Param("status") List<ReservedStatus> status,
 		@Param("closedStatus") ReservedStatus closedStatus
 	);
+
+	// admin.product FORCE_DOWN 처리 — 해당 상품의 모든 스케줄 소프트 딜리트
+	int softDeleteByProductId(UUID productId);
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/kafka/admin/AdminProductEventHandler.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/kafka/admin/AdminProductEventHandler.java
@@ -1,0 +1,41 @@
+package jabaclass.product.infrastructure.kafka.admin;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import jabaclass.product.application.exception.BusinessException;
+import jabaclass.product.common.exception.CommonErrorCode;
+import jabaclass.product.domain.model.Product;
+import jabaclass.product.domain.model.status.ProductStatus;
+import jabaclass.product.domain.repository.ProductRepository;
+import jabaclass.product.domain.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AdminProductEventHandler {
+
+	private final ProductRepository productRepository;
+	private final ScheduleRepository scheduleRepository;
+
+	@Transactional
+	public void processForceDown(UUID productId) {
+		Product product = productRepository.findById(productId)
+			.orElseThrow(() -> new BusinessException(CommonErrorCode.PRODUCT_NOT_FOUND));
+		product.changeStatus(ProductStatus.DISABLE);
+		product.changeDelete();
+		int deletedCount = scheduleRepository.softDeleteByProductId(productId);
+		log.info("FORCE_DOWN DB 처리 완료. productId={}, 삭제된 스케줄 수={}", productId, deletedCount);
+	}
+
+	@Transactional
+	public void restoreProductStatus(UUID productId) {
+		productRepository.findById(productId)
+			.ifPresent(p -> p.changeStatus(ProductStatus.ENABLE));
+		log.info("FORCE_DOWN 보상 트랜잭션 완료 — product status ENABLE 복구. productId={}", productId);
+	}
+}

--- a/service/product/src/main/java/jabaclass/product/infrastructure/kafka/admin/AdminProductKafkaConsumer.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/kafka/admin/AdminProductKafkaConsumer.java
@@ -1,0 +1,52 @@
+package jabaclass.product.infrastructure.kafka.admin;
+
+import java.util.UUID;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jabaclass.product.domain.repository.ProductSearchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AdminProductKafkaConsumer {
+
+	private final AdminProductEventHandler handler;
+	private final ProductSearchRepository productSearchRepository;
+	private final ObjectMapper objectMapper;
+
+	@KafkaListener(topics = "admin.product", groupId = "product-admin-consumer")
+	public void consume(String message) {
+		try {
+			AdminProductMessage event = objectMapper.readValue(message, AdminProductMessage.class);
+
+			if ("FORCE_DOWN".equals(event.type())) {
+				handleForceDown(event);
+			} else {
+				log.warn("알 수 없는 admin.product type: {}", event.type());
+			}
+		} catch (Exception e) {
+			throw new RuntimeException("admin.product 이벤트 처리 실패: " + e.getMessage(), e);
+		}
+	}
+
+	private void handleForceDown(AdminProductMessage event) {
+		UUID productId = UUID.fromString(event.productId());
+
+		handler.processForceDown(productId);
+
+		try {
+			productSearchRepository.deleteById(event.productId());
+			log.info("FORCE_DOWN ES 삭제 완료. productId={}", event.productId());
+		} catch (Exception esEx) {
+			log.error("ES 삭제 실패, 보상 트랜잭션 실행. productId={}", event.productId(), esEx);
+			handler.restoreProductStatus(productId);
+			throw new RuntimeException("FORCE_DOWN ES 처리 실패. productId=" + event.productId(), esEx);
+		}
+	}
+}

--- a/service/product/src/main/java/jabaclass/product/infrastructure/kafka/admin/AdminProductMessage.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/kafka/admin/AdminProductMessage.java
@@ -1,0 +1,4 @@
+package jabaclass.product.infrastructure.kafka.admin;
+
+public record AdminProductMessage(String type, String productId) {
+}

--- a/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ScheduleJpaRepository.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ScheduleJpaRepository.java
@@ -159,4 +159,8 @@ public interface ScheduleJpaRepository extends JpaRepository<Schedule, UUID> {
 		@Param("closedStatus") ReservedStatus closedStatus
 	);
 
+	@Modifying
+	@Query("UPDATE Schedule s SET s.deleteDt = CURRENT_TIMESTAMP WHERE s.productId = :productId AND s.deleteDt IS NULL")
+	int softDeleteByProductId(@Param("productId") UUID productId);
+
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ScheduleRepositoryAdapter.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ScheduleRepositoryAdapter.java
@@ -91,4 +91,9 @@ public class ScheduleRepositoryAdapter implements ScheduleRepository {
 		return scheduleJpaRepository.bulkClose(ids, status, closedStatus);
 	}
 
+	@Override
+	public int softDeleteByProductId(UUID productId) {
+		return scheduleJpaRepository.softDeleteByProductId(productId);
+	}
+
 }

--- a/service/product/src/test/java/jabaclass/product/AdminProductEventHandlerTest.java
+++ b/service/product/src/test/java/jabaclass/product/AdminProductEventHandlerTest.java
@@ -1,0 +1,79 @@
+package jabaclass.product;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import jabaclass.product.application.exception.BusinessException;
+import jabaclass.product.domain.model.Product;
+import jabaclass.product.domain.model.status.ProductStatus;
+import jabaclass.product.domain.repository.ProductRepository;
+import jabaclass.product.domain.repository.ScheduleRepository;
+import jabaclass.product.infrastructure.kafka.admin.AdminProductEventHandler;
+
+@ExtendWith(MockitoExtension.class)
+class AdminProductEventHandlerTest {
+
+	@InjectMocks
+	private AdminProductEventHandler handler;
+
+	@Mock
+	private ProductRepository productRepository;
+
+	@Mock
+	private ScheduleRepository scheduleRepository;
+
+	@Test
+	void processForceDown_상품_DISABLE_및_소프트딜리트_성공() {
+		UUID productId = UUID.randomUUID();
+		Product product = mock(Product.class);
+		given(productRepository.findById(productId)).willReturn(Optional.of(product));
+		given(scheduleRepository.softDeleteByProductId(productId)).willReturn(3);
+
+		handler.processForceDown(productId);
+
+		then(product).should().changeStatus(ProductStatus.DISABLE);
+		then(product).should().changeDelete();
+		then(scheduleRepository).should().softDeleteByProductId(productId);
+	}
+
+	@Test
+	void processForceDown_상품이_없으면_BusinessException_발생() {
+		UUID productId = UUID.randomUUID();
+		given(productRepository.findById(productId)).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> handler.processForceDown(productId))
+			.isInstanceOf(BusinessException.class)
+			.hasMessageContaining("존재하지 않는 상품");
+	}
+
+	@Test
+	void restoreProductStatus_상품_상태를_ENABLE로_복구한다() {
+		UUID productId = UUID.randomUUID();
+		Product product = mock(Product.class);
+		given(productRepository.findById(productId)).willReturn(Optional.of(product));
+
+		handler.restoreProductStatus(productId);
+
+		then(product).should().changeStatus(ProductStatus.ENABLE);
+	}
+
+	@Test
+	void restoreProductStatus_상품이_없으면_아무_작업도_하지_않는다() {
+		UUID productId = UUID.randomUUID();
+		given(productRepository.findById(productId)).willReturn(Optional.empty());
+
+		assertThatCode(() -> handler.restoreProductStatus(productId))
+			.doesNotThrowAnyException();
+
+		then(scheduleRepository).shouldHaveNoInteractions();
+	}
+}


### PR DESCRIPTION
## 관련 이슈                                                                                          
  - Close #231                                                                                          
                                                                                                        
  ## 변경 요약                                                                                          
  - 관리자 상품 강제 삭제(`FORCE_DOWN`) 이벤트를 product 서비스에서 Kafka로 수신하여 DB 상태 변경 및 ES 
  인덱스 삭제 처리                                                                                      
  - 이벤트 발행 실패 시 예외가 묻히지 않도록 `AdminProductEventPublisher` 수정
                                                                                                        
  ## 주요 변경점  
  - `AdminProductKafkaConsumer`: `admin.product` 토픽 소비, `FORCE_DOWN` 타입 분기 처리                 
  - `AdminProductEventHandler`: 상품 DISABLE + soft delete, 해당 상품 스케줄 전체 soft delete (트랜잭션)
  - `ScheduleRepository` / `ScheduleJpaRepository`: `softDeleteByProductId` 추가 (JPQL bulk update)     
  - ES 삭제 실패 시 보상 트랜잭션으로 상품 상태 ENABLE 복구                                             
  - `AdminProductEventPublisher`: 발행 실패 시 예외를 상위로 전파하도록 수정                            
                                                                                                        
  ## 테스트       
  - [x] 단위 테스트 통과 (AdminProductEventHandlerTest)                                                 
  - [ ] 로컬 실행 확인
  - [ ] (해당 시) Postman/Swagger로 API 확인
  - [ ] FE 연동 시 E2E 흐름 확인 예정 — Kafka/ES 통합 테스트는 FE 연동 시점에 함께 검증                 
                                                                                                        
  ## 리뷰 포인트                                                                                        
  - ES 삭제 실패 시 보상 트랜잭션(ENABLE 복구)으로 처리했는데, 이 방식이 적절한지 의견 부탁드립니다     
  - `FORCE_DOWN` 외 다른 타입이 들어올 경우 warn 로그만 찍고 무시하는 전략이 괜찮을지 확인 부탁드립니다