### PR TITLE
feat: ai 서비스를 위한 메서드 추가

### DIFF
--- a/api-gateway/src/main/java/jabaclass/apigateway/filter/JwtAuthenticationFilter.java
+++ b/api-gateway/src/main/java/jabaclass/apigateway/filter/JwtAuthenticationFilter.java
@@ -70,7 +70,7 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
         return whitelistService.isWhitelisted(path, httpMethod)
             .flatMap(isWhitelisted -> {
                 if (isWhitelisted) {
-                    return chain.filter(sanitizedExchange);
+                    return enrichIfAuthenticated(sanitizedExchange, chain, path, httpMethod);
                 }
                 return authenticate(sanitizedExchange, chain, path, httpMethod);
             });
@@ -118,7 +118,7 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
                     log.warn("[GATEWAY] Optional auth enrichment failed: {} {}", httpMethod, path, e);
                     return chain.filter(exchange);
                 });
-        } catch (JwtAuthException e) {
+        } catch (Exception e) {
             log.debug("[GATEWAY] Ignore invalid token on whitelisted path: {} {}", httpMethod, path);
             return chain.filter(exchange);
         }

--- a/api-gateway/src/main/java/jabaclass/apigateway/filter/JwtAuthenticationFilter.java
+++ b/api-gateway/src/main/java/jabaclass/apigateway/filter/JwtAuthenticationFilter.java
@@ -76,6 +76,54 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
             });
     }
 
+    private Mono<Void> enrichIfAuthenticated(ServerWebExchange exchange,
+        GatewayFilterChain chain,
+        String path,
+        HttpMethod httpMethod) {
+        String token = tokenResolver.resolveToken(exchange);
+        if (token == null) {
+            return chain.filter(exchange);
+        }
+
+        try {
+            Claims claims = jwtProvider.parseClaims(token);
+
+            if (!jwtProvider.isAccessToken(claims)) {
+                log.debug("[GATEWAY] Ignore non-access token on whitelisted path: {} {}", httpMethod, path);
+                return chain.filter(exchange);
+            }
+
+            UUID userId = jwtProvider.getUserId(claims);
+            String role = jwtProvider.getRole(claims);
+
+            return redisTemplate.hasKey(BLACKLIST_PREFIX + token)
+                .flatMap(isBlacklisted -> {
+                    if (isBlacklisted) {
+                        log.debug("[GATEWAY] Ignore blacklisted token on whitelisted path: {} {}", httpMethod, path);
+                        return chain.filter(exchange);
+                    }
+
+                    ServerWebExchange mutatedExchange = exchange.mutate()
+                        .request(r -> {
+                            r.header("X-User-Id", userId.toString());
+                            if (role != null) {
+                                r.header("X-User-Role", role);
+                            }
+                        })
+                        .build();
+
+                    return chain.filter(mutatedExchange);
+                })
+                .onErrorResume(e -> {
+                    log.warn("[GATEWAY] Optional auth enrichment failed: {} {}", httpMethod, path, e);
+                    return chain.filter(exchange);
+                });
+        } catch (JwtAuthException e) {
+            log.debug("[GATEWAY] Ignore invalid token on whitelisted path: {} {}", httpMethod, path);
+            return chain.filter(exchange);
+        }
+    }
+
     private Mono<Void> authenticate(ServerWebExchange exchange,
         GatewayFilterChain chain,
         String path,

--- a/service/admin/src/main/resources/application.yml
+++ b/service/admin/src/main/resources/application.yml
@@ -18,3 +18,7 @@ management:
     web:
       exposure:
         include: health
+  endpoint:
+    health:
+      probes:
+        enabled: true


### PR DESCRIPTION
## 관련 이슈
- Close #268 

## 변경 요약
- ai 서비스를 위한 메서드 추가

## 주요 변경점
- 현재 상품 조회는 whitelist 대상 api다. 하지만 예정된 ai 서비스 도입에 맞춰 상품 조회에 있어 토큰 정보의 유무를 판단하여 있는 경우에만 ai 서비스를 적용해야 하므로 이에 맞는 메서드 추가

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인