### PR TITLE
fix: admin Product 엔티티 BaseEntity 의존 제거 및 로컬 개발 환경 설정 개선

### DIFF
--- a/api-gateway/src/main/resources/data.sql
+++ b/api-gateway/src/main/resources/data.sql
@@ -1,17 +1,17 @@
-INSERT INTO gateway_whitelist (method, path_pattern, description) VALUES
-    ('POST', '/api/v1/auth/login',              '로그인'),
-    ('POST', '/api/v1/auth/reissue',            '토큰 재발급'),
-    ('POST', '/api/v1/users/register',          '회원가입'),
-    ('POST', '/api/v1/users/email-check',       '이메일 중복 확인'),
-    ('POST', '/api/v1/email/**',                '이메일 인증'),
-    ('GET',  '/api/v1/products',                '상품 목록 조회'),
-    ('GET',  '/api/v1/products/*',              '상품 상세 조회'),
-    ('GET',  '/api/v1/products/*/schedules',    '상품 일정 목록 조회'),
-    ('GET',  '/api/v1/products/*/availability', '스케줄 예약 가능 여부'),
-    ('GET',  '/api/v1/products/*/reviewList',   '상품 리뷰 목록 조회'),
-    ('GET',  '/api/v1/products/*/reviews/*',    '리뷰 단건 조회'),
-    ('GET',  '/oauth2/authorization/**',        '소셜 로그인 시작'),
-    ('GET',  '/login/oauth2/code/**',           '소셜 로그인 콜백');
+INSERT INTO gateway_whitelist (method, path_pattern, description)
+VALUES ('POST', '/api/v1/auth/login', '로그인'),
+       ('POST', '/api/v1/auth/reissue', '토큰 재발급'),
+       ('POST', '/api/v1/users/register', '회원가입'),
+       ('POST', '/api/v1/users/email-check', '이메일 중복 확인'),
+       ('POST', '/api/v1/email/**', '이메일 인증'),
+       ('GET', '/api/v1/products', '상품 목록 조회'),
+       ('GET', '/api/v1/products/*', '상품 상세 조회'),
+       ('GET', '/api/v1/products/*/schedules', '상품 일정 목록 조회'),
+       ('GET', '/api/v1/products/*/availability', '스케줄 예약 가능 여부'),
+       ('GET', '/api/v1/products/*/reviewList', '상품 리뷰 목록 조회'),
+       ('GET', '/api/v1/products/*/reviews/*', '리뷰 단건 조회'),
+       ('GET', '/oauth2/authorization/**', '소셜 로그인 시작'),
+       ('GET', '/login/oauth2/code/**', '소셜 로그인 콜백');
 
 INSERT INTO gateway_route_policy (method, path_pattern, allowed_roles, description) VALUES
     ('POST',   '/api/v1/products',               'SELLER,ADMIN', '상품 등록'),

--- a/service/admin/src/main/java/jabaclass/admin/product/domain/model/Product.java
+++ b/service/admin/src/main/java/jabaclass/admin/product/domain/model/Product.java
@@ -4,22 +4,27 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-import jabaclass.admin.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
 @Getter
-@SuperBuilder
 @NoArgsConstructor
 @Entity
 @Table(name = "products")
-public class Product extends BaseEntity {
+public class Product {
+
+	@Id
+	@Column(name = "id", updatable = false, nullable = false)
+	private UUID id;
+
+	@Column(name = "reg_dt", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
 
 	@Column(name = "seller_id", nullable = false)
 	private UUID sellerId;

--- a/service/admin/src/main/resources/application.yml
+++ b/service/admin/src/main/resources/application.yml
@@ -18,3 +18,7 @@ management:
     web:
       exposure:
         include: health
+  endpoint:
+    health:
+      probes:
+        enabled: true

--- a/service/admin/src/test/java/jabaclass/admin/product/application/service/ProductAdminServiceTest.java
+++ b/service/admin/src/test/java/jabaclass/admin/product/application/service/ProductAdminServiceTest.java
@@ -60,14 +60,13 @@ class ProductAdminServiceTest {
 	@BeforeEach
 	void setUp() {
 		productId = UUID.randomUUID();
-		product = Product.builder()
-			.sellerId(UUID.randomUUID())
-			.title("테스트상품")
-			.maxCapacity(10)
-			.price(new BigDecimal("50000"))
-			.status(ProductStatus.ENABLE)
-			.build();
+		product = new Product();
 		ReflectionTestUtils.setField(product, "id", productId);
+		ReflectionTestUtils.setField(product, "sellerId", UUID.randomUUID());
+		ReflectionTestUtils.setField(product, "title", "테스트상품");
+		ReflectionTestUtils.setField(product, "maxCapacity", 10);
+		ReflectionTestUtils.setField(product, "price", new BigDecimal("50000"));
+		ReflectionTestUtils.setField(product, "status", ProductStatus.ENABLE);
 	}
 
 	@Test

--- a/service/order/src/main/resources/application.yml
+++ b/service/order/src/main/resources/application.yml
@@ -12,7 +12,9 @@ spring:
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
 jwt:
-  secret: ${JWT_SECRET}
+  secret: ${JWT_SECRET:abcdefghijklmnopqrstuvwxyz123456}
+  access-token-validity: 3600000
+  refresh-token-validity: 604800000
 
 management:
   endpoints:

--- a/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ProductDocument.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ProductDocument.java
@@ -1,10 +1,8 @@
 package jabaclass.product.infrastructure.elasticsearch;
 
-import jabaclass.product.domain.model.Product;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
@@ -12,8 +10,11 @@ import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.Setting;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import jabaclass.product.domain.model.Product;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder

--- a/service/product/src/main/resources/application-prod.yml
+++ b/service/product/src/main/resources/application-prod.yml
@@ -5,7 +5,7 @@ internal:
   file:
     url: ${FILE_SERVICE_HOST}
   api:
-    key: ${INTERNAL-KEY:test-internal-key}
+    key: ${INTERNAL-KEY}
 
 spring:
   elasticsearch:

--- a/service/product/src/main/resources/application-prod.yml
+++ b/service/product/src/main/resources/application-prod.yml
@@ -1,6 +1,12 @@
 api:
   user-host: ${USER_SERVICE_HOST}
 
+internal:
+  file:
+    url: ${FILE_SERVICE_HOST}
+  api:
+    key: ${INTERNAL-KEY:test-internal-key}
+
 spring:
   elasticsearch:
     uris: ${ES_HOST:http://localhost:9200}


### PR DESCRIPTION
## 관련 이슈
- Close #267

## 변경 요약
- Admin Product 엔티티 스키마 호환성 수정
- 로컬 개발 환경 설정 보완

## 주요 변경점
- admin/Product.java: BaseEntity 상속 제거 → @Id, reg_dt 컬럼 직접 매핑 (product 서비스 스키마와 일치하도록 수정)
- order/application.yml: JWT 기본값 및 토큰 유효기간 설정 추가 (로컬 환경변수 없이 실행 가능)
- admin/application.yml: Kubernetes liveness/readiness health probe 활성화
- product/application-prod.yml: internal file/api 서비스 설정 추가
- api-gateway/data.sql: SQL 포맷 정리

## 테스트
- [x] 로컬 실행 확인
- [x] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트
- admin/Product가 BaseEntity를 상속하지 않고 컬럼을 직접 선언한 이유: admin 서비스는 product DB를 읽기 전용으로 조회하므로 JPA Auditing(@CreatedDate 등)이 불필요하며, BaseEntity 의존 제거로 불필요한 AuditingEntityListener 등록을 방지