### PR TITLE
fix: admin Order/Settlement 엔티티 BaseEntity 의존 제거 및 주문 응답 필드 추가 

### DIFF
--- a/api-gateway/src/main/resources/data.sql
+++ b/api-gateway/src/main/resources/data.sql
@@ -1,17 +1,17 @@
-INSERT INTO gateway_whitelist (method, path_pattern, description) VALUES
-    ('POST', '/api/v1/auth/login',              '로그인'),
-    ('POST', '/api/v1/auth/reissue',            '토큰 재발급'),
-    ('POST', '/api/v1/users/register',          '회원가입'),
-    ('POST', '/api/v1/users/email-check',       '이메일 중복 확인'),
-    ('POST', '/api/v1/email/**',                '이메일 인증'),
-    ('GET',  '/api/v1/products',                '상품 목록 조회'),
-    ('GET',  '/api/v1/products/*',              '상품 상세 조회'),
-    ('GET',  '/api/v1/products/*/schedules',    '상품 일정 목록 조회'),
-    ('GET',  '/api/v1/products/*/availability', '스케줄 예약 가능 여부'),
-    ('GET',  '/api/v1/products/*/reviewList',   '상품 리뷰 목록 조회'),
-    ('GET',  '/api/v1/products/*/reviews/*',    '리뷰 단건 조회'),
-    ('GET',  '/oauth2/authorization/**',        '소셜 로그인 시작'),
-    ('GET',  '/login/oauth2/code/**',           '소셜 로그인 콜백');
+INSERT INTO gateway_whitelist (method, path_pattern, description)
+VALUES ('POST', '/api/v1/auth/login', '로그인'),
+       ('POST', '/api/v1/auth/reissue', '토큰 재발급'),
+       ('POST', '/api/v1/users/register', '회원가입'),
+       ('POST', '/api/v1/users/email-check', '이메일 중복 확인'),
+       ('POST', '/api/v1/email/**', '이메일 인증'),
+       ('GET', '/api/v1/products', '상품 목록 조회'),
+       ('GET', '/api/v1/products/*', '상품 상세 조회'),
+       ('GET', '/api/v1/products/*/schedules', '상품 일정 목록 조회'),
+       ('GET', '/api/v1/products/*/availability', '스케줄 예약 가능 여부'),
+       ('GET', '/api/v1/products/*/reviewList', '상품 리뷰 목록 조회'),
+       ('GET', '/api/v1/products/*/reviews/*', '리뷰 단건 조회'),
+       ('GET', '/oauth2/authorization/**', '소셜 로그인 시작'),
+       ('GET', '/login/oauth2/code/**', '소셜 로그인 콜백');
 
 INSERT INTO gateway_route_policy (method, path_pattern, allowed_roles, description) VALUES
     ('POST',   '/api/v1/products',               'SELLER,ADMIN', '상품 등록'),

--- a/service/admin/src/main/java/jabaclass/admin/order/domain/model/Order.java
+++ b/service/admin/src/main/java/jabaclass/admin/order/domain/model/Order.java
@@ -1,6 +1,7 @@
 package jabaclass.admin.order.domain.model;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import jakarta.persistence.Column;
@@ -22,11 +23,17 @@ public class Order {
 	@Column(name = "id", nullable = false, updatable = false)
 	private UUID id;
 
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
 	@Column(name = "product_schedule_id", nullable = false)
 	private UUID productScheduleId;
 
 	@Column(name = "user_id", nullable = false)
 	private UUID userId;
+
+	@Column(name = "seller_id", nullable = false)
+	private UUID sellerId;
 
 	@Column(name = "quantity", nullable = false)
 	private Integer quantity;

--- a/service/admin/src/main/java/jabaclass/admin/order/presentation/dto/response/OrderAdminResponseDto.java
+++ b/service/admin/src/main/java/jabaclass/admin/order/presentation/dto/response/OrderAdminResponseDto.java
@@ -1,6 +1,7 @@
 package jabaclass.admin.order.presentation.dto.response;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import jabaclass.admin.order.domain.model.Order;
@@ -10,18 +11,22 @@ public record OrderAdminResponseDto(
 	UUID id,
 	UUID productScheduleId,
 	UUID userId,
+	UUID sellerId,
 	Integer quantity,
 	BigDecimal price,
-	OrderStatus status
+	OrderStatus status,
+	LocalDateTime createdAt
 ) {
 	public static OrderAdminResponseDto from(Order order) {
 		return new OrderAdminResponseDto(
 			order.getId(),
 			order.getProductScheduleId(),
 			order.getUserId(),
+			order.getSellerId(),
 			order.getQuantity(),
 			order.getPrice(),
-			order.getStatus()
+			order.getStatus(),
+			order.getCreatedAt()
 		);
 	}
 }

--- a/service/admin/src/main/java/jabaclass/admin/product/domain/model/Product.java
+++ b/service/admin/src/main/java/jabaclass/admin/product/domain/model/Product.java
@@ -4,22 +4,27 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-import jabaclass.admin.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
 @Getter
-@SuperBuilder
 @NoArgsConstructor
 @Entity
 @Table(name = "products")
-public class Product extends BaseEntity {
+public class Product {
+
+	@Id
+	@Column(name = "id", updatable = false, nullable = false)
+	private UUID id;
+
+	@Column(name = "reg_dt", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
 
 	@Column(name = "seller_id", nullable = false)
 	private UUID sellerId;

--- a/service/admin/src/main/java/jabaclass/admin/settlement/domain/model/Settlement.java
+++ b/service/admin/src/main/java/jabaclass/admin/settlement/domain/model/Settlement.java
@@ -4,22 +4,24 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-import jabaclass.admin.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
 @Getter
-@SuperBuilder
 @NoArgsConstructor
 @Entity
 @Table(name = "settlements")
-public class Settlement extends BaseEntity {
+public class Settlement {
+
+	@Id
+	@Column(name = "id", nullable = false, updatable = false)
+	private UUID id;
 
 	@Column(name = "seller_id", nullable = false)
 	private UUID sellerId;

--- a/service/admin/src/main/resources/application.yml
+++ b/service/admin/src/main/resources/application.yml
@@ -18,3 +18,7 @@ management:
     web:
       exposure:
         include: health
+  endpoint:
+    health:
+      probes:
+        enabled: true

--- a/service/admin/src/test/java/jabaclass/admin/order/application/service/OrderAdminServiceTest.java
+++ b/service/admin/src/test/java/jabaclass/admin/order/application/service/OrderAdminServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -47,8 +48,10 @@ class OrderAdminServiceTest {
 		orderId = UUID.randomUUID();
 		order = new Order();
 		ReflectionTestUtils.setField(order, "id", orderId);
+		ReflectionTestUtils.setField(order, "createdAt", LocalDateTime.of(2025, 4, 1, 12, 0));
 		ReflectionTestUtils.setField(order, "productScheduleId", UUID.randomUUID());
 		ReflectionTestUtils.setField(order, "userId", UUID.randomUUID());
+		ReflectionTestUtils.setField(order, "sellerId", UUID.randomUUID());
 		ReflectionTestUtils.setField(order, "quantity", 2);
 		ReflectionTestUtils.setField(order, "price", new BigDecimal("100000"));
 		ReflectionTestUtils.setField(order, "status", OrderStatus.PAID);
@@ -68,6 +71,8 @@ class OrderAdminServiceTest {
 		assertThat(result.getContent()).hasSize(1);
 		assertThat(result.getContent().get(0).id()).isEqualTo(orderId);
 		assertThat(result.getContent().get(0).status()).isEqualTo(OrderStatus.PAID);
+		assertThat(result.getContent().get(0).sellerId()).isNotNull();
+		assertThat(result.getContent().get(0).createdAt()).isEqualTo(LocalDateTime.of(2025, 4, 1, 12, 0));
 		then(orderAdminRepository).should(times(1)).findAll(pageable);
 	}
 }

--- a/service/admin/src/test/java/jabaclass/admin/product/application/service/ProductAdminServiceTest.java
+++ b/service/admin/src/test/java/jabaclass/admin/product/application/service/ProductAdminServiceTest.java
@@ -60,14 +60,13 @@ class ProductAdminServiceTest {
 	@BeforeEach
 	void setUp() {
 		productId = UUID.randomUUID();
-		product = Product.builder()
-			.sellerId(UUID.randomUUID())
-			.title("테스트상품")
-			.maxCapacity(10)
-			.price(new BigDecimal("50000"))
-			.status(ProductStatus.ENABLE)
-			.build();
+		product = new Product();
 		ReflectionTestUtils.setField(product, "id", productId);
+		ReflectionTestUtils.setField(product, "sellerId", UUID.randomUUID());
+		ReflectionTestUtils.setField(product, "title", "테스트상품");
+		ReflectionTestUtils.setField(product, "maxCapacity", 10);
+		ReflectionTestUtils.setField(product, "price", new BigDecimal("50000"));
+		ReflectionTestUtils.setField(product, "status", ProductStatus.ENABLE);
 	}
 
 	@Test

--- a/service/admin/src/test/java/jabaclass/admin/settlement/application/service/SettlementAdminServiceTest.java
+++ b/service/admin/src/test/java/jabaclass/admin/settlement/application/service/SettlementAdminServiceTest.java
@@ -45,16 +45,15 @@ class SettlementAdminServiceTest {
 	@BeforeEach
 	void setUp() {
 		settlementId = UUID.randomUUID();
-		settlement = Settlement.builder()
-			.sellerId(UUID.randomUUID())
-			.settlementMonth("2025-04")
-			.originalAmount(new BigDecimal("1000000"))
-			.feeAmount(new BigDecimal("30000"))
-			.feeRate(new BigDecimal("0.0300"))
-			.settlementAmount(new BigDecimal("970000"))
-			.status(SettlementStatus.SENT)
-			.build();
+		settlement = new Settlement();
 		ReflectionTestUtils.setField(settlement, "id", settlementId);
+		ReflectionTestUtils.setField(settlement, "sellerId", UUID.randomUUID());
+		ReflectionTestUtils.setField(settlement, "settlementMonth", "2025-04");
+		ReflectionTestUtils.setField(settlement, "originalAmount", new BigDecimal("1000000"));
+		ReflectionTestUtils.setField(settlement, "feeAmount", new BigDecimal("30000"));
+		ReflectionTestUtils.setField(settlement, "feeRate", new BigDecimal("0.0300"));
+		ReflectionTestUtils.setField(settlement, "settlementAmount", new BigDecimal("970000"));
+		ReflectionTestUtils.setField(settlement, "status", SettlementStatus.SENT);
 	}
 
 	@Test

--- a/service/order/src/main/resources/application.yml
+++ b/service/order/src/main/resources/application.yml
@@ -12,7 +12,9 @@ spring:
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
 jwt:
-  secret: ${JWT_SECRET}
+  secret: ${JWT_SECRET:abcdefghijklmnopqrstuvwxyz123456}
+  access-token-validity: 3600000
+  refresh-token-validity: 604800000
 
 management:
   endpoints:

--- a/service/order/src/main/resources/application.yml
+++ b/service/order/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
 jwt:
-  secret: ${JWT_SECRET:abcdefghijklmnopqrstuvwxyz123456}
+  secret: ${JWT_SECRET}
   access-token-validity: 3600000
   refresh-token-validity: 604800000
 

--- a/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ProductDocument.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ProductDocument.java
@@ -1,10 +1,8 @@
 package jabaclass.product.infrastructure.elasticsearch;
 
-import jabaclass.product.domain.model.Product;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
@@ -12,8 +10,11 @@ import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.Setting;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import jabaclass.product.domain.model.Product;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder

--- a/service/product/src/main/resources/application-prod.yml
+++ b/service/product/src/main/resources/application-prod.yml
@@ -5,7 +5,7 @@ internal:
   file:
     url: ${FILE_SERVICE_HOST}
   api:
-    key: ${INTERNAL-KEY:test-internal-key}
+    key: ${INTERNAL-KEY}
 
 spring:
   elasticsearch:

--- a/service/product/src/main/resources/application-prod.yml
+++ b/service/product/src/main/resources/application-prod.yml
@@ -1,6 +1,12 @@
 api:
   user-host: ${USER_SERVICE_HOST}
 
+internal:
+  file:
+    url: ${FILE_SERVICE_HOST}
+  api:
+    key: ${INTERNAL-KEY:test-internal-key}
+
 spring:
   elasticsearch:
     uris: ${ES_HOST:http://localhost:9200}


### PR DESCRIPTION
## 관련 이슈
- Close #267 

## 변경 요약        
  - admin 서비스의 Order/Settlement 엔티티 BaseEntity 의존 제거
  - 주문 목록 API 응답에 sellerId, createdAt 필드 추가                                                                                                           
                                                                                                                                                                 
  ## 주요 변경점                                                                                                                                                 
  - `Order.java`: BaseEntity 상속 제거 후 @Id, seller_id, created_at 직접 매핑 (Product 엔티티와 동일한 패턴 적용)                                               
  - `OrderAdminResponseDto.java`: sellerId, createdAt 필드 추가 — FE 어드민 Orders 탭에서 판매자 정보 및 주문일 표시를 위해 필요                                 
  - `Settlement.java`: BaseEntity 상속 제거 후 @Id 직접 매핑                                                                                                     
                                                                                                                                                                 
  ## 테스트                                                                                                                                                      
  - [x] 로컬 실행 확인                                                                                                                                           
  - [x] 테스트 통과
  - [x] (해당 시) Postman/Swagger로 API 확인
                                                                                                                                                                 
  ## 리뷰 포인트
  - admin 서비스는 타 서비스 DB를 읽기 전용으로 참조하는 구조라 BaseEntity의 @GeneratedValue, @EntityListeners가 문제를 일으킬 수 있어 직접 매핑 방식으로 통일함 
  (기존 Product 엔티티 수정과 동일한 이유)