### PR TITLE
fix: DB 재시작 시 ES 인덱스 불일치 문제 수정

### DIFF
--- a/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ElasticsearchIndexInitializer.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ElasticsearchIndexInitializer.java
@@ -3,6 +3,7 @@ package jabaclass.product.infrastructure.elasticsearch;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
@@ -16,10 +17,21 @@ public class ElasticsearchIndexInitializer implements ApplicationRunner {
 
 	private final ElasticsearchOperations elasticsearchOperations;
 
+	@Value("${spring.jpa.hibernate.ddl-auto:none}")
+	private String ddlAuto;
+
 	@Override
 	public void run(ApplicationArguments args) {
 		IndexOperations indexOps = elasticsearchOperations.indexOps(ProductDocument.class);
-		if (!indexOps.exists()) {
+
+		if ("create".equals(ddlAuto) || "create-drop".equals(ddlAuto)) {
+			if (indexOps.exists()) {
+				indexOps.delete();
+				log.info("products 인덱스 삭제 (DB 초기화 감지)");
+			}
+			indexOps.createWithMapping();
+			log.info("products 인덱스 재생성 완료");
+		} else if (!indexOps.exists()) {
 			indexOps.createWithMapping();
 			log.info("products 인덱스 생성 완료");
 		}


### PR DESCRIPTION
## 관련 이슈
- Close #288 

## 변경 요약
  - ddl-auto가 create/create-drop인 환경에서 앱 시작 시 ES 인덱스를 삭제 후 재생성하여 DB와 ES 간 데이터 불일치 방지                                               
                                                                                                                                                                   
  ## 주요 변경점
  - `ElasticsearchIndexInitializer`: 앱 시작 시 `ddl-auto` 값을 읽어 `create`/`create-drop`이면 기존 ES 인덱스 삭제 후 재생성, 그 외 환경에서는 기존 동작 유지     
                                                                                                                                                                   
  ## 테스트
  - [ ] 로컬 실행 확인                                                                                                                                             
  - [ ] 테스트 통과                                                                                                                                                
  - [ ] (해당 시) Postman/Swagger로 API 확인
                                                                                                                                                                   
  ## 리뷰 포인트                                                                                                                                                 
  - prod 환경은 `ddl-auto: validate`이므로 ES 인덱스 삭제 분기가 실행되지 않아 운영 영향 없음