### PR TITLE
fix: OAuth2 경로 dev와 prod 분리

### DIFF
--- a/service/user/src/main/resources/application-prod.yml
+++ b/service/user/src/main/resources/application-prod.yml
@@ -75,3 +75,6 @@ spring:
 cookie:
   secure: true
 
+oauth2:
+  redirect-uri: ${FRONTEND_SERVICE_URL:http://3.37.179.13:30080}/oauth2/callback
+

--- a/service/user/src/main/resources/application-prod.yml
+++ b/service/user/src/main/resources/application-prod.yml
@@ -74,7 +74,3 @@ spring:
 
 cookie:
   secure: true
-
-oauth2:
-  redirect-uri: ${FRONTEND_SERVICE_URL:http://3.37.179.13:30080}/oauth2/callback
-

--- a/service/user/src/main/resources/application.yml
+++ b/service/user/src/main/resources/application.yml
@@ -41,3 +41,6 @@ management:
     health:
       probes:
         enabled: true
+
+oauth2:
+  redirect-uri: ${OAUTH2_REDIRECT_URI:http://localhost:3000/oauth2/callback}

--- a/service/user/src/main/resources/application.yml
+++ b/service/user/src/main/resources/application.yml
@@ -16,9 +16,6 @@ spring:
     listener:
       ack-mode: record
 
-oauth2:
-  redirect-uri: ${FRONTEND_SERVICE_URL:http://localhost:3000}/oauth2/callback
-
 jwt:
   secret: ${JWT_SECRET}
   access-token-validity: 1800000


### PR DESCRIPTION
## 변경 요약
- 기존 local로 되어있던 주소를 배포 도메인에 맞게 수정

## 주요 변경점
- user 모듈 application.yml, application-prod.yml 수정

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인