### PR TITLE
feat: Prometheus + Grafana 모니터링 설정 추가

### DIFF
--- a/.github/k3s/admin-service.yml
+++ b/.github/k3s/admin-service.yml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: admin-service
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/actuator/prometheus"
+        prometheus.io/port: "9007"
     spec:
       initContainers:
         - name: wait-for-postgres

--- a/.github/k3s/monitoring/prometheus-scrape-config.yaml
+++ b/.github/k3s/monitoring/prometheus-scrape-config.yaml
@@ -1,0 +1,23 @@
+- job_name: 'spring-services'
+  metrics_path: '/actuator/prometheus'
+  kubernetes_sd_configs:
+    - role: pod
+      namespaces:
+        names:
+          - default
+  relabel_configs:
+    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+      action: keep
+      regex: "true"
+    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+      action: replace
+      target_label: __metrics_path__
+    - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      action: replace
+      regex: (.+):(?:\d+);(\d+)
+      replacement: $1:$2
+      target_label: __address__
+    - source_labels: [__meta_kubernetes_pod_label_app]
+      target_label: app
+    - source_labels: [__meta_kubernetes_namespace]
+      target_label: namespace

--- a/.github/k3s/order-service.yml
+++ b/.github/k3s/order-service.yml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: order-service
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/actuator/prometheus"
+        prometheus.io/port: "9005"
     spec:
       initContainers:
         - name: wait-for-postgres

--- a/.github/k3s/payment-service.yml
+++ b/.github/k3s/payment-service.yml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: payment-service
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/actuator/prometheus"
+        prometheus.io/port: "9001"
     spec:
       initContainers:
         - name: wait-for-postgres

--- a/.github/k3s/product-service.yml
+++ b/.github/k3s/product-service.yml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: product-service
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/actuator/prometheus"
+        prometheus.io/port: "9004"
     spec:
       initContainers:
         - name: wait-for-postgres

--- a/.github/k3s/settlement-service.yml
+++ b/.github/k3s/settlement-service.yml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: settlement-service
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/actuator/prometheus"
+        prometheus.io/port: "9002"
     spec:
       initContainers:
         - name: wait-for-postgres

--- a/.github/k3s/user-service.yml
+++ b/.github/k3s/user-service.yml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: user-service
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/actuator/prometheus"
+        prometheus.io/port: "9003"
     spec:
       initContainers:
         - name: wait-for-postgres

--- a/service/admin/build.gradle
+++ b/service/admin/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/service/admin/src/main/resources/application-prod.yml
+++ b/service/admin/src/main/resources/application-prod.yml
@@ -8,3 +8,18 @@ datasource:
   connection-timeout: 30000
   idle-timeout: 600000
   max-lifetime: 1800000
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true
+    prometheus:
+      enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/service/order/build.gradle
+++ b/service/order/build.gradle
@@ -39,6 +39,7 @@ implementation 'org.springframework.kafka:spring-kafka'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/service/order/src/main/resources/application-prod.yml
+++ b/service/order/src/main/resources/application-prod.yml
@@ -30,3 +30,18 @@ external:
 logging:
   level:
     org.hibernate.SQL: WARN
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true
+    prometheus:
+      enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/service/payment/build.gradle
+++ b/service/payment/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/service/payment/src/main/resources/application-prod.yml
+++ b/service/payment/src/main/resources/application-prod.yml
@@ -22,3 +22,18 @@ spring:
 logging:
   level:
     org.hibernate.SQL: WARN
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true
+    prometheus:
+      enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/service/product/build.gradle
+++ b/service/product/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'org.postgresql:postgresql:42.6.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 
     implementation platform('software.amazon.awssdk:bom:2.25.0')

--- a/service/product/src/main/resources/application-prod.yml
+++ b/service/product/src/main/resources/application-prod.yml
@@ -36,3 +36,18 @@ spring:
 logging:
   level:
     org.hibernate.SQL: WARN
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true
+    prometheus:
+      enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/service/settlement/build.gradle
+++ b/service/settlement/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/service/settlement/src/main/resources/application-prod.yml
+++ b/service/settlement/src/main/resources/application-prod.yml
@@ -32,3 +32,18 @@ settlement:
       cron: "${SETTLEMENT_BATCH_CALCULATE_CRON:0 */5 * * * *}"
     transfer:
       cron: "${SETTLEMENT_BATCH_TRANSFER_CRON:30 */5 * * * *}"
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true
+    prometheus:
+      enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/service/user/build.gradle
+++ b/service/user/build.gradle
@@ -74,6 +74,7 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     // OAuth2
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/service/user/src/main/resources/application-prod.yml
+++ b/service/user/src/main/resources/application-prod.yml
@@ -85,3 +85,18 @@ cookie:
 
 oauth2:
   redirect-uri: ${FRONTEND_SERVICE_URL:http://3.37.179.13:30080}/oauth2/callback
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true
+    prometheus:
+      enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}


### PR DESCRIPTION
- 전 서비스 build.gradle에 micrometer-registry-prometheus 의존성 추가
- 전 서비스 application-prod.yml에 /actuator/prometheus 엔드포인트 노출 설정
- 전 서비스 k3s Deployment에 prometheus scrape 어노테이션 추가
- prometheus-scrape-config.yaml 생성 (pod 자동 감지 설정)

## 관련 이슈
- Close #

## 주요 변경점
- 

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트

- 