### PR TITLE
feat: 어드민 리뷰 목록 조회 API 추가 

### DIFF
--- a/service/admin/src/main/java/jabaclass/admin/common/error/GlobalExceptionHandler.java
+++ b/service/admin/src/main/java/jabaclass/admin/common/error/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import jabaclass.admin.common.dto.ApiResponseDto;
 
@@ -34,6 +35,13 @@ public class GlobalExceptionHandler {
 		return ResponseEntity
 			.status(HttpStatus.BAD_REQUEST)
 			.body(ApiResponseDto.fail(HttpStatus.BAD_REQUEST, ex.getMessage()));
+	}
+
+	@ExceptionHandler(NoResourceFoundException.class)
+	public ResponseEntity<ApiResponseDto<Void>> handleNoResourceFound(NoResourceFoundException ex) {
+		return ResponseEntity
+			.status(HttpStatus.NOT_FOUND)
+			.body(ApiResponseDto.fail(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."));
 	}
 
 	@ExceptionHandler(Exception.class)

--- a/service/admin/src/main/java/jabaclass/admin/dashboard/application/service/DashboardAdminService.java
+++ b/service/admin/src/main/java/jabaclass/admin/dashboard/application/service/DashboardAdminService.java
@@ -1,0 +1,87 @@
+package jabaclass.admin.dashboard.application.service;
+
+import java.math.BigDecimal;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jabaclass.admin.dashboard.application.usecase.DashboardAdminUseCase;
+import jabaclass.admin.dashboard.presentation.dto.response.DashboardResponseDto;
+import jabaclass.admin.order.domain.model.OrderStatus;
+import jabaclass.admin.order.domain.repository.OrderAdminRepository;
+import jabaclass.admin.product.domain.repository.ProductAdminRepository;
+import jabaclass.admin.settlement.domain.repository.SettlementAdminRepository;
+import jabaclass.admin.user.domain.repository.UserAdminRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DashboardAdminService implements DashboardAdminUseCase {
+
+	private final OrderAdminRepository orderAdminRepository;
+	private final UserAdminRepository userAdminRepository;
+	private final ProductAdminRepository productAdminRepository;
+	private final SettlementAdminRepository settlementAdminRepository;
+
+	@Override
+	public DashboardResponseDto getDashboard(int year) {
+		DashboardResponseDto.DomainOverview overview = buildOverview();
+		List<DashboardResponseDto.MonthlyOrderStat> monthlyOrderStats = buildMonthlyOrderStats(year);
+		List<DashboardResponseDto.MonthlyNewUserStat> monthlyNewUserStats = buildMonthlyNewUserStats(year);
+
+		return new DashboardResponseDto(overview, monthlyOrderStats, monthlyNewUserStats);
+	}
+
+	private DashboardResponseDto.DomainOverview buildOverview() {
+		long totalUsers = userAdminRepository.countAll();
+		long activeProducts = productAdminRepository.countActiveProducts();
+		long pendingOrders = orderAdminRepository.countByStatus(OrderStatus.PENDING);
+		String currentMonth = YearMonth.now().toString();
+		BigDecimal currentMonthSettlement = settlementAdminRepository.sumSettlementAmountByMonth(currentMonth);
+
+		return new DashboardResponseDto.DomainOverview(totalUsers, activeProducts, pendingOrders, currentMonthSettlement);
+	}
+
+	private List<DashboardResponseDto.MonthlyOrderStat> buildMonthlyOrderStats(int year) {
+		List<Object[]> rows = orderAdminRepository.findMonthlyOrderStats(year);
+		Map<Integer, Object[]> dataByMonth = new HashMap<>();
+		for (Object[] row : rows) {
+			dataByMonth.put(((Number) row[0]).intValue(), row);
+		}
+
+		List<DashboardResponseDto.MonthlyOrderStat> result = new ArrayList<>();
+		for (int month = 1; month <= 12; month++) {
+			String monthLabel = String.format("%d-%02d", year, month);
+			if (dataByMonth.containsKey(month)) {
+				Object[] row = dataByMonth.get(month);
+				long orderCount = ((Number) row[1]).longValue();
+				BigDecimal totalRevenue = row[2] != null ? (BigDecimal) row[2] : BigDecimal.ZERO;
+				result.add(new DashboardResponseDto.MonthlyOrderStat(monthLabel, orderCount, totalRevenue));
+			} else {
+				result.add(new DashboardResponseDto.MonthlyOrderStat(monthLabel, 0L, BigDecimal.ZERO));
+			}
+		}
+		return result;
+	}
+
+	private List<DashboardResponseDto.MonthlyNewUserStat> buildMonthlyNewUserStats(int year) {
+		List<Object[]> rows = userAdminRepository.findMonthlyNewUserStats(year);
+		Map<Integer, Long> dataByMonth = new HashMap<>();
+		for (Object[] row : rows) {
+			dataByMonth.put(((Number) row[0]).intValue(), ((Number) row[1]).longValue());
+		}
+
+		List<DashboardResponseDto.MonthlyNewUserStat> result = new ArrayList<>();
+		for (int month = 1; month <= 12; month++) {
+			String monthLabel = String.format("%d-%02d", year, month);
+			result.add(new DashboardResponseDto.MonthlyNewUserStat(monthLabel, dataByMonth.getOrDefault(month, 0L)));
+		}
+		return result;
+	}
+}

--- a/service/admin/src/main/java/jabaclass/admin/dashboard/application/usecase/DashboardAdminUseCase.java
+++ b/service/admin/src/main/java/jabaclass/admin/dashboard/application/usecase/DashboardAdminUseCase.java
@@ -1,0 +1,8 @@
+package jabaclass.admin.dashboard.application.usecase;
+
+import jabaclass.admin.dashboard.presentation.dto.response.DashboardResponseDto;
+
+public interface DashboardAdminUseCase {
+
+	DashboardResponseDto getDashboard(int year);
+}

--- a/service/admin/src/main/java/jabaclass/admin/dashboard/presentation/controller/DashboardAdminApi.java
+++ b/service/admin/src/main/java/jabaclass/admin/dashboard/presentation/controller/DashboardAdminApi.java
@@ -1,0 +1,18 @@
+package jabaclass.admin.dashboard.presentation.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jabaclass.admin.common.dto.ApiResponseDto;
+import jabaclass.admin.dashboard.presentation.dto.response.DashboardResponseDto;
+
+@Tag(name = "Admin - Dashboard", description = "어드민 통계 대시보드 API")
+public interface DashboardAdminApi {
+
+	@Operation(summary = "통계 대시보드 조회", description = "월별 주문 수/매출액, 도메인별 현황 수치, 신규 가입자 추이를 조회합니다.")
+	ResponseEntity<ApiResponseDto<DashboardResponseDto>> getDashboard(
+		@RequestParam(required = false) Integer year
+	);
+}

--- a/service/admin/src/main/java/jabaclass/admin/dashboard/presentation/controller/DashboardAdminController.java
+++ b/service/admin/src/main/java/jabaclass/admin/dashboard/presentation/controller/DashboardAdminController.java
@@ -1,0 +1,33 @@
+package jabaclass.admin.dashboard.presentation.controller;
+
+import java.time.Year;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jabaclass.admin.common.dto.ApiResponseDto;
+import jabaclass.admin.dashboard.application.usecase.DashboardAdminUseCase;
+import jabaclass.admin.dashboard.presentation.dto.response.DashboardResponseDto;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/admins/dashboard")
+@RequiredArgsConstructor
+public class DashboardAdminController implements DashboardAdminApi {
+
+	private final DashboardAdminUseCase dashboardAdminUseCase;
+
+	@Override
+	@GetMapping
+	public ResponseEntity<ApiResponseDto<DashboardResponseDto>> getDashboard(
+		@RequestParam(required = false) Integer year
+	) {
+		int targetYear = (year != null) ? year : Year.now().getValue();
+		DashboardResponseDto response = dashboardAdminUseCase.getDashboard(targetYear);
+		return ResponseEntity.ok(ApiResponseDto.success(HttpStatus.OK, "대시보드 조회 성공", response));
+	}
+}

--- a/service/admin/src/main/java/jabaclass/admin/dashboard/presentation/dto/response/DashboardResponseDto.java
+++ b/service/admin/src/main/java/jabaclass/admin/dashboard/presentation/dto/response/DashboardResponseDto.java
@@ -1,0 +1,29 @@
+package jabaclass.admin.dashboard.presentation.dto.response;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record DashboardResponseDto(
+	DomainOverview overview,
+	List<MonthlyOrderStat> monthlyOrderStats,
+	List<MonthlyNewUserStat> monthlyNewUserStats
+) {
+
+	public record DomainOverview(
+		long totalUsers,
+		long activeProducts,
+		long pendingOrders,
+		BigDecimal currentMonthSettlement
+	) {}
+
+	public record MonthlyOrderStat(
+		String month,
+		long orderCount,
+		BigDecimal totalRevenue
+	) {}
+
+	public record MonthlyNewUserStat(
+		String month,
+		long newUserCount
+	) {}
+}

--- a/service/admin/src/main/java/jabaclass/admin/order/domain/repository/OrderAdminRepository.java
+++ b/service/admin/src/main/java/jabaclass/admin/order/domain/repository/OrderAdminRepository.java
@@ -1,11 +1,16 @@
 package jabaclass.admin.order.domain.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import jabaclass.admin.order.domain.dto.OrderSearchCondition;
 import jabaclass.admin.order.domain.model.Order;
+import jabaclass.admin.order.domain.model.OrderStatus;
 
 public interface OrderAdminRepository {
 	Page<Order> findAll(OrderSearchCondition condition, Pageable pageable);
+	long countByStatus(OrderStatus status);
+	List<Object[]> findMonthlyOrderStats(int year);
 }

--- a/service/admin/src/main/java/jabaclass/admin/order/infrastructure/persistence/OrderAdminJpaRepository.java
+++ b/service/admin/src/main/java/jabaclass/admin/order/infrastructure/persistence/OrderAdminJpaRepository.java
@@ -15,7 +15,8 @@ public interface OrderAdminJpaRepository extends JpaRepository<Order, UUID>, Jpa
 
 	long countByStatus(OrderStatus status);
 
-	@Query("SELECT MONTH(o.createdAt), COUNT(o), " +
+	@Query("SELECT MONTH(o.createdAt), " +
+		"SUM(CASE WHEN o.status = jabaclass.admin.order.domain.model.OrderStatus.PAID THEN 1 ELSE 0 END), " +
 		"SUM(CASE WHEN o.status = jabaclass.admin.order.domain.model.OrderStatus.PAID THEN o.price ELSE 0 END) " +
 		"FROM Order o WHERE YEAR(o.createdAt) = :year " +
 		"GROUP BY MONTH(o.createdAt) ORDER BY MONTH(o.createdAt)")

--- a/service/admin/src/main/java/jabaclass/admin/order/infrastructure/persistence/OrderAdminJpaRepository.java
+++ b/service/admin/src/main/java/jabaclass/admin/order/infrastructure/persistence/OrderAdminJpaRepository.java
@@ -1,11 +1,23 @@
 package jabaclass.admin.order.infrastructure.persistence;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import jabaclass.admin.order.domain.model.Order;
+import jabaclass.admin.order.domain.model.OrderStatus;
 
 public interface OrderAdminJpaRepository extends JpaRepository<Order, UUID>, JpaSpecificationExecutor<Order> {
+
+	long countByStatus(OrderStatus status);
+
+	@Query("SELECT MONTH(o.createdAt), COUNT(o), " +
+		"SUM(CASE WHEN o.status = jabaclass.admin.order.domain.model.OrderStatus.PAID THEN o.price ELSE 0 END) " +
+		"FROM Order o WHERE YEAR(o.createdAt) = :year " +
+		"GROUP BY MONTH(o.createdAt) ORDER BY MONTH(o.createdAt)")
+	List<Object[]> findMonthlyOrderStats(@Param("year") int year);
 }

--- a/service/admin/src/main/java/jabaclass/admin/order/infrastructure/persistence/OrderAdminRepositoryAdapter.java
+++ b/service/admin/src/main/java/jabaclass/admin/order/infrastructure/persistence/OrderAdminRepositoryAdapter.java
@@ -1,11 +1,14 @@
 package jabaclass.admin.order.infrastructure.persistence;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import jabaclass.admin.order.domain.dto.OrderSearchCondition;
 import jabaclass.admin.order.domain.model.Order;
+import jabaclass.admin.order.domain.model.OrderStatus;
 import jabaclass.admin.order.domain.repository.OrderAdminRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -18,5 +21,15 @@ public class OrderAdminRepositoryAdapter implements OrderAdminRepository {
 	@Override
 	public Page<Order> findAll(OrderSearchCondition condition, Pageable pageable) {
 		return orderAdminJpaRepository.findAll(OrderAdminSpecification.withCondition(condition), pageable);
+	}
+
+	@Override
+	public long countByStatus(OrderStatus status) {
+		return orderAdminJpaRepository.countByStatus(status);
+	}
+
+	@Override
+	public List<Object[]> findMonthlyOrderStats(int year) {
+		return orderAdminJpaRepository.findMonthlyOrderStats(year);
 	}
 }

--- a/service/admin/src/main/java/jabaclass/admin/product/domain/repository/ProductAdminRepository.java
+++ b/service/admin/src/main/java/jabaclass/admin/product/domain/repository/ProductAdminRepository.java
@@ -13,4 +13,5 @@ public interface ProductAdminRepository {
 	Page<Product> findAll(Pageable pageable);
 	Page<Product> findAll(ProductSearchCondition condition, Pageable pageable);
 	Optional<Product> findById(UUID productId);
+	long countActiveProducts();
 }

--- a/service/admin/src/main/java/jabaclass/admin/product/infrastructure/persistence/ProductAdminJpaRepository.java
+++ b/service/admin/src/main/java/jabaclass/admin/product/infrastructure/persistence/ProductAdminJpaRepository.java
@@ -6,6 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import jabaclass.admin.product.domain.model.Product;
+import jabaclass.admin.product.domain.model.ProductStatus;
 
 public interface ProductAdminJpaRepository extends JpaRepository<Product, UUID>, JpaSpecificationExecutor<Product> {
+
+	long countByStatusAndDeleteDtIsNull(ProductStatus status);
 }

--- a/service/admin/src/main/java/jabaclass/admin/product/infrastructure/persistence/ProductAdminRepositoryAdapter.java
+++ b/service/admin/src/main/java/jabaclass/admin/product/infrastructure/persistence/ProductAdminRepositoryAdapter.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 
 import jabaclass.admin.product.domain.dto.ProductSearchCondition;
 import jabaclass.admin.product.domain.model.Product;
+import jabaclass.admin.product.domain.model.ProductStatus;
 import jabaclass.admin.product.domain.repository.ProductAdminRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -31,5 +32,10 @@ public class ProductAdminRepositoryAdapter implements ProductAdminRepository {
 	@Override
 	public Optional<Product> findById(UUID productId) {
 		return productAdminJpaRepository.findById(productId);
+	}
+
+	@Override
+	public long countActiveProducts() {
+		return productAdminJpaRepository.countByStatusAndDeleteDtIsNull(ProductStatus.ENABLE);
 	}
 }

--- a/service/admin/src/main/java/jabaclass/admin/review/application/service/ReviewAdminService.java
+++ b/service/admin/src/main/java/jabaclass/admin/review/application/service/ReviewAdminService.java
@@ -1,7 +1,12 @@
 package jabaclass.admin.review.application.service;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,6 +15,8 @@ import jabaclass.admin.common.error.BusinessException;
 import jabaclass.admin.review.application.usecase.ReviewAdminUseCase;
 import jabaclass.admin.review.domain.model.Review;
 import jabaclass.admin.review.domain.repository.ReviewAdminRepository;
+import jabaclass.admin.review.presentation.dto.response.ReviewAdminResponseDto;
+import jabaclass.admin.user.domain.repository.UserAdminRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -17,6 +24,23 @@ import lombok.RequiredArgsConstructor;
 public class ReviewAdminService implements ReviewAdminUseCase {
 
 	private final ReviewAdminRepository reviewAdminRepository;
+	private final UserAdminRepository userAdminRepository;
+
+	@Override
+	@Transactional(readOnly = true)
+	public Page<ReviewAdminResponseDto> getReviews(Pageable pageable) {
+		Page<Review> reviews = reviewAdminRepository.findAll(pageable);
+
+		Set<UUID> userIds = reviews.stream()
+			.map(Review::getUserId)
+			.collect(Collectors.toSet());
+
+		Map<UUID, String> emailMap = userAdminRepository.findEmailsByIds(userIds);
+
+		return reviews.map(review ->
+			ReviewAdminResponseDto.from(review, emailMap.getOrDefault(review.getUserId(), ""))
+		);
+	}
 
 	@Override
 	@Transactional

--- a/service/admin/src/main/java/jabaclass/admin/review/application/usecase/ReviewAdminUseCase.java
+++ b/service/admin/src/main/java/jabaclass/admin/review/application/usecase/ReviewAdminUseCase.java
@@ -2,7 +2,14 @@ package jabaclass.admin.review.application.usecase;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import jabaclass.admin.review.presentation.dto.response.ReviewAdminResponseDto;
+
 public interface ReviewAdminUseCase {
+
+	Page<ReviewAdminResponseDto> getReviews(Pageable pageable);
 
 	void deleteReview(UUID reviewId);
 

--- a/service/admin/src/main/java/jabaclass/admin/review/domain/model/Review.java
+++ b/service/admin/src/main/java/jabaclass/admin/review/domain/model/Review.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 import jabaclass.admin.common.model.BaseEntity;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
@@ -16,6 +18,10 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @Entity
 @Table(name = "product_reviews", schema = "public")
+@AttributeOverrides({
+	@AttributeOverride(name = "createdAt", column = @Column(name = "reg_dt", nullable = false, updatable = false)),
+	@AttributeOverride(name = "updatedAt", column = @Column(name = "modify_dt", nullable = false))
+})
 public class Review extends BaseEntity {
 
 	@Column(name = "product_id", updatable = false, nullable = false)

--- a/service/admin/src/main/java/jabaclass/admin/review/domain/repository/ReviewAdminRepository.java
+++ b/service/admin/src/main/java/jabaclass/admin/review/domain/repository/ReviewAdminRepository.java
@@ -3,9 +3,13 @@ package jabaclass.admin.review.domain.repository;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import jabaclass.admin.review.domain.model.Review;
 
 public interface ReviewAdminRepository {
+	Page<Review> findAll(Pageable pageable);
 	Optional<Review> findById(UUID reviewId);
 	void deleteById(UUID reviewId);
 }

--- a/service/admin/src/main/java/jabaclass/admin/review/infrastructure/persistence/ReviewAdminJpaRepository.java
+++ b/service/admin/src/main/java/jabaclass/admin/review/infrastructure/persistence/ReviewAdminJpaRepository.java
@@ -2,9 +2,13 @@ package jabaclass.admin.review.infrastructure.persistence;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import jabaclass.admin.review.domain.model.Review;
 
 public interface ReviewAdminJpaRepository extends JpaRepository<Review, UUID> {
+
+	Page<Review> findByDeleteDtIsNull(Pageable pageable);
 }

--- a/service/admin/src/main/java/jabaclass/admin/review/infrastructure/persistence/ReviewAdminRepositoryAdapter.java
+++ b/service/admin/src/main/java/jabaclass/admin/review/infrastructure/persistence/ReviewAdminRepositoryAdapter.java
@@ -3,6 +3,8 @@ package jabaclass.admin.review.infrastructure.persistence;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import jabaclass.admin.review.domain.model.Review;
@@ -14,6 +16,11 @@ import lombok.RequiredArgsConstructor;
 public class ReviewAdminRepositoryAdapter implements ReviewAdminRepository {
 
 	private final ReviewAdminJpaRepository reviewAdminJpaRepository;
+
+	@Override
+	public Page<Review> findAll(Pageable pageable) {
+		return reviewAdminJpaRepository.findByDeleteDtIsNull(pageable);
+	}
 
 	@Override
 	public Optional<Review> findById(UUID reviewId) {

--- a/service/admin/src/main/java/jabaclass/admin/review/presentation/controller/ReviewAdminApi.java
+++ b/service/admin/src/main/java/jabaclass/admin/review/presentation/controller/ReviewAdminApi.java
@@ -2,15 +2,21 @@ package jabaclass.admin.review.presentation.controller;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jabaclass.admin.common.dto.ApiResponseDto;
+import jabaclass.admin.review.presentation.dto.response.ReviewAdminResponseDto;
 
 @Tag(name = "Admin - Review", description = "어드민 리뷰 관리 API")
 public interface ReviewAdminApi {
+
+	@Operation(summary = "리뷰 목록 조회")
+	ResponseEntity<ApiResponseDto<Page<ReviewAdminResponseDto>>> getReviews(Pageable pageable);
 
 	@Operation(summary = "부적절한 리뷰 삭제")
 	ResponseEntity<ApiResponseDto<Void>> deleteReview(@PathVariable UUID reviewId);

--- a/service/admin/src/main/java/jabaclass/admin/review/presentation/controller/ReviewAdminController.java
+++ b/service/admin/src/main/java/jabaclass/admin/review/presentation/controller/ReviewAdminController.java
@@ -2,15 +2,19 @@ package jabaclass.admin.review.presentation.controller;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import jabaclass.admin.common.dto.ApiResponseDto;
 import jabaclass.admin.review.application.usecase.ReviewAdminUseCase;
+import jabaclass.admin.review.presentation.dto.response.ReviewAdminResponseDto;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -19,6 +23,14 @@ import lombok.RequiredArgsConstructor;
 public class ReviewAdminController implements ReviewAdminApi {
 
 	private final ReviewAdminUseCase reviewAdminUseCase;
+
+	@Override
+	@GetMapping
+	public ResponseEntity<ApiResponseDto<Page<ReviewAdminResponseDto>>> getReviews(Pageable pageable) {
+		return ResponseEntity.ok(
+			ApiResponseDto.success(HttpStatus.OK, "리뷰 목록 조회 성공", reviewAdminUseCase.getReviews(pageable))
+		);
+	}
 
 	@Override
 	@DeleteMapping("/{reviewId}")

--- a/service/admin/src/main/java/jabaclass/admin/review/presentation/dto/response/ReviewAdminResponseDto.java
+++ b/service/admin/src/main/java/jabaclass/admin/review/presentation/dto/response/ReviewAdminResponseDto.java
@@ -1,0 +1,28 @@
+package jabaclass.admin.review.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jabaclass.admin.review.domain.model.Review;
+
+public record ReviewAdminResponseDto(
+	UUID id,
+	UUID productId,
+	UUID userId,
+	String userEmail,
+	int rating,
+	String content,
+	LocalDateTime createdAt
+) {
+	public static ReviewAdminResponseDto from(Review review, String userEmail) {
+		return new ReviewAdminResponseDto(
+			review.getId(),
+			review.getProductId(),
+			review.getUserId(),
+			userEmail,
+			review.getRating(),
+			review.getContent(),
+			review.getCreatedAt()
+		);
+	}
+}

--- a/service/admin/src/main/java/jabaclass/admin/settlement/domain/repository/SettlementAdminRepository.java
+++ b/service/admin/src/main/java/jabaclass/admin/settlement/domain/repository/SettlementAdminRepository.java
@@ -1,5 +1,7 @@
 package jabaclass.admin.settlement.domain.repository;
 
+import java.math.BigDecimal;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -8,4 +10,5 @@ import jabaclass.admin.settlement.domain.model.Settlement;
 
 public interface SettlementAdminRepository {
 	Page<Settlement> findAll(SettlementSearchCondition condition, Pageable pageable);
+	BigDecimal sumSettlementAmountByMonth(String month);
 }

--- a/service/admin/src/main/java/jabaclass/admin/settlement/infrastructure/persistence/SettlementAdminJpaRepository.java
+++ b/service/admin/src/main/java/jabaclass/admin/settlement/infrastructure/persistence/SettlementAdminJpaRepository.java
@@ -1,11 +1,17 @@
 package jabaclass.admin.settlement.infrastructure.persistence;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import jabaclass.admin.settlement.domain.model.Settlement;
 
 public interface SettlementAdminJpaRepository extends JpaRepository<Settlement, UUID>, JpaSpecificationExecutor<Settlement> {
+
+	@Query("SELECT COALESCE(SUM(s.settlementAmount), 0) FROM Settlement s WHERE s.settlementMonth = :month")
+	BigDecimal sumSettlementAmountByMonth(@Param("month") String month);
 }

--- a/service/admin/src/main/java/jabaclass/admin/settlement/infrastructure/persistence/SettlementAdminRepositoryAdapter.java
+++ b/service/admin/src/main/java/jabaclass/admin/settlement/infrastructure/persistence/SettlementAdminRepositoryAdapter.java
@@ -1,5 +1,7 @@
 package jabaclass.admin.settlement.infrastructure.persistence;
 
+import java.math.BigDecimal;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -18,5 +20,10 @@ public class SettlementAdminRepositoryAdapter implements SettlementAdminReposito
 	@Override
 	public Page<Settlement> findAll(SettlementSearchCondition condition, Pageable pageable) {
 		return settlementAdminJpaRepository.findAll(SettlementAdminSpecification.withCondition(condition), pageable);
+	}
+
+	@Override
+	public BigDecimal sumSettlementAmountByMonth(String month) {
+		return settlementAdminJpaRepository.sumSettlementAmountByMonth(month);
 	}
 }

--- a/service/admin/src/main/java/jabaclass/admin/user/domain/repository/UserAdminRepository.java
+++ b/service/admin/src/main/java/jabaclass/admin/user/domain/repository/UserAdminRepository.java
@@ -1,5 +1,8 @@
 package jabaclass.admin.user.domain.repository;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,4 +15,7 @@ import jabaclass.admin.user.domain.model.User;
 public interface UserAdminRepository {
 	Page<User> findAll(UserSearchCondition condition, Pageable pageable);
 	Optional<User> findById(UUID userId);
+	Map<UUID, String> findEmailsByIds(Collection<UUID> userIds);
+	long countAll();
+	List<Object[]> findMonthlyNewUserStats(int year);
 }

--- a/service/admin/src/main/java/jabaclass/admin/user/infrastructure/persistence/UserAdminJpaRepository.java
+++ b/service/admin/src/main/java/jabaclass/admin/user/infrastructure/persistence/UserAdminJpaRepository.java
@@ -1,11 +1,18 @@
 package jabaclass.admin.user.infrastructure.persistence;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import jabaclass.admin.user.domain.model.User;
 
 public interface UserAdminJpaRepository extends JpaRepository<User, UUID>, JpaSpecificationExecutor<User> {
+
+	@Query("SELECT MONTH(u.createdAt), COUNT(u) FROM User u WHERE YEAR(u.createdAt) = :year " +
+		"GROUP BY MONTH(u.createdAt) ORDER BY MONTH(u.createdAt)")
+	List<Object[]> findMonthlyNewUserStats(@Param("year") int year);
 }

--- a/service/admin/src/main/java/jabaclass/admin/user/infrastructure/persistence/UserAdminRepositoryAdapter.java
+++ b/service/admin/src/main/java/jabaclass/admin/user/infrastructure/persistence/UserAdminRepositoryAdapter.java
@@ -1,7 +1,11 @@
 package jabaclass.admin.user.infrastructure.persistence;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,5 +30,22 @@ public class UserAdminRepositoryAdapter implements UserAdminRepository {
 	@Override
 	public Optional<User> findById(UUID userId) {
 		return userAdminJpaRepository.findById(userId);
+	}
+
+	@Override
+	public Map<UUID, String> findEmailsByIds(Collection<UUID> userIds) {
+		return userAdminJpaRepository.findAllById(userIds)
+			.stream()
+			.collect(Collectors.toMap(User::getId, User::getEmail));
+	}
+
+	@Override
+	public long countAll() {
+		return userAdminJpaRepository.count();
+	}
+
+	@Override
+	public List<Object[]> findMonthlyNewUserStats(int year) {
+		return userAdminJpaRepository.findMonthlyNewUserStats(year);
 	}
 }

--- a/service/ai/build.gradle
+++ b/service/ai/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
     // DB Driver
     runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'com.h2database:h2'
 
     // Jackson
     implementation 'com.fasterxml.jackson.core:jackson-databind'


### PR DESCRIPTION
 ## 관련 이슈
  - Close #325

  ## 변경 요약
  - 어드민 리뷰 목록 조회 API 추가 (`GET /api/v1/admins/reviews`)
  - 리뷰 응답에 `userEmail` 필드 포함

  ## 주요 변경점
  - `ReviewAdminResponseDto` 추가 — `userEmail` 포함한 응답 DTO
  - `ReviewAdminUseCase` / `ReviewAdminService` — 리뷰 페이징 조회 + userId 배치 조회로 이메일 매핑
  - `ReviewAdminJpaRepository` — `findByDeleteDtIsNull(Pageable)` derived query (소프트 삭제 필터링)
  - `Review` 엔티티 — `@AttributeOverride`로 `reg_dt` / `modify_dt` 컬럼 매핑 수정 (product 서비스 스키마 기준)
  - `UserAdminRepository.findEmailsByIds()` — userId 목록으로 이메일 배치 조회
  - `GlobalExceptionHandler` — `NoResourceFoundException` → 404 처리 추가

  ## 테스트
  - [x] 로컬 실행 확인
  - [ ] 테스트 통과
  - [x] Postman/Swagger로 API 확인

  ## 리뷰 포인트
  - `Review` 엔티티가 admin `BaseEntity`(`created_at`)가 아닌 product 서비스 스키마(`reg_dt`, `modify_dt`)를 따르도록 `@AttributeOverride` 적용 
  - 리뷰 조회 시 userId 배치 조회(쿼리 2회)로 N+1 방지