### PR TITLE
fix: 개인화 추천 노출 조건 및 유사도 필터 보정

### DIFF
--- a/service/ai/src/main/java/jabaclass/ai/domain/model/UserVector.java
+++ b/service/ai/src/main/java/jabaclass/ai/domain/model/UserVector.java
@@ -4,6 +4,16 @@ public record UserVector(
 	float[] vector
 ) {
 	public boolean isEmpty() {
-		return vector == null || vector.length == 0;
+		if (vector == null || vector.length == 0) {
+			return true;
+		}
+
+		for (float value : vector) {
+			if (value != 0.0f) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/service/ai/src/main/java/jabaclass/ai/infrastructure/persistence/CandidateSearchRepositoryImpl.java
+++ b/service/ai/src/main/java/jabaclass/ai/infrastructure/persistence/CandidateSearchRepositoryImpl.java
@@ -16,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CandidateSearchRepositoryImpl implements CandidateSearchRepository {
 
+	private static final double MAX_COSINE_DISTANCE = 0.35;
+
 	private final JdbcTemplate jdbcTemplate;
 
 	@Override
@@ -24,6 +26,8 @@ public class CandidateSearchRepositoryImpl implements CandidateSearchRepository 
 		if (userVector == null || userVector.isEmpty()) {
 			return List.of();
 		}
+
+		String vector = toPgVector(userVector.vector());
 
 		String sql = """
             SELECT 
@@ -34,6 +38,7 @@ public class CandidateSearchRepositoryImpl implements CandidateSearchRepository 
                 road_address
             FROM product_embeddings
             WHERE status = 'ENABLE'
+              AND embedding <=> (?::vector) <= ?
             ORDER BY embedding <=> (?::vector)  -- cosine distance (pgvector)
             LIMIT ?
         """;
@@ -41,8 +46,10 @@ public class CandidateSearchRepositoryImpl implements CandidateSearchRepository 
 		return jdbcTemplate.query(
 			sql,
 			ps -> {
-				ps.setString(1, toPgVector(userVector.vector()));
-				ps.setInt(2, k);
+				ps.setString(1, vector);
+				ps.setDouble(2, MAX_COSINE_DISTANCE);
+				ps.setString(3, vector);
+				ps.setInt(4, k);
 			},
 			(rs, rowNum) -> new CandidateClassDto(
 				rs.getObject("id", java.util.UUID.class),

--- a/service/ai/src/test/java/jabaclass/ai/application/service/UserVectorServiceTest.java
+++ b/service/ai/src/test/java/jabaclass/ai/application/service/UserVectorServiceTest.java
@@ -167,6 +167,18 @@ class UserVectorServiceTest {
 		assertThat(result.vector()[0]).isGreaterThan(result.vector()[1]);
 	}
 
+	@Test
+	void 활동이_없으면_0벡터를_반환하고_빈_벡터로_취급한다() {
+		given(userActivityRepository.findByUserId(USER_ID)).willReturn(List.of());
+		given(productEmbeddingRepository.findAllByProductIds(anyCollection())).willReturn(Map.of());
+
+		UserVector result = userVectorService.generate(USER_ID);
+
+		assertThat(result.isEmpty()).isTrue();
+		assertThat(result.vector()).hasSize(768);
+		assertThat(result.vector()).containsOnly(0.0f);
+	}
+
 	private static org.assertj.core.data.Offset<Float> within(float value) {
 		return org.assertj.core.data.Offset.offset(value);
 	}


### PR DESCRIPTION
## 관련 이슈

## 변경 요약
- 활동 이력이 없는 사용자는 개인화 추천 대상에서 제외되도록 수정
- 유사도가 낮은 상품은 추천 결과에서 제외되도록 cosine distance 임계값 추가
- 0 벡터 반환/빈 벡터 처리 관련 테스트 보강

## 변경 이유
- 활동 이력이 없는 사용자에게도 개인화 추천이 노출되는 문제가 있었음
- 사용자 벡터와 충분히 유사하지 않은 상품까지 추천되는 문제가 있었음
- 추천 제외 조건이 테스트로 보장되지 않아 회귀 가능성이 있었음

## 테스트
- [x] 로컬 실행 확인
- [x] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인
