### PR TITLE
feat : 정산 계좌 추가 및 Seller 초기 프로모션 이벤트 발행 추가

### DIFF
--- a/api-gateway/src/main/resources/data.sql
+++ b/api-gateway/src/main/resources/data.sql
@@ -17,6 +17,7 @@ INSERT INTO gateway_route_policy (method, path_pattern, allowed_roles, descripti
 VALUES ('POST', '/api/v1/products', 'SELLER,ADMIN', '상품 등록'),
        ('PUT', '/api/v1/products/*', 'SELLER,ADMIN', '상품 수정'),
        ('DELETE', '/api/v1/products/*', 'SELLER,ADMIN', '상품 삭제'),
+       ('PUT', '/api/v1/users/me/seller-settlement-account', 'SELLER,ADMIN', '내 정산 계좌 등록 또는 수정'),
        ('POST', '/api/v1/products/*/schedules', 'SELLER,ADMIN', '일정 등록'),
        ('PUT', '/api/v1/products/*/schedules/*', 'SELLER,ADMIN', '일정 수정'),
        ('DELETE', '/api/v1/products/*/schedules/*', 'SELLER,ADMIN', '일정 삭제'),

--- a/api-gateway/src/main/resources/db/migration/V2__insert_data.sql
+++ b/api-gateway/src/main/resources/db/migration/V2__insert_data.sql
@@ -17,6 +17,7 @@ INSERT INTO gateway_route_policy (id, method, path_pattern, allowed_roles, descr
 VALUES (gen_random_uuid(), 'POST', '/api/v1/products', 'SELLER,ADMIN', '상품 등록'),
        (gen_random_uuid(), 'PUT', '/api/v1/products/*', 'SELLER,ADMIN', '상품 수정'),
        (gen_random_uuid(), 'DELETE', '/api/v1/products/*', 'SELLER,ADMIN', '상품 삭제'),
+       (gen_random_uuid(), 'PUT', '/api/v1/users/me/seller-settlement-account', 'SELLER,ADMIN', '내 정산 계좌 등록 또는 수정'),
        (gen_random_uuid(), 'POST', '/api/v1/products/*/schedules', 'SELLER,ADMIN', '일정 등록'),
        (gen_random_uuid(), 'PUT', '/api/v1/products/*/schedules/*', 'SELLER,ADMIN', '일정 수정'),
        (gen_random_uuid(), 'DELETE', '/api/v1/products/*/schedules/*', 'SELLER,ADMIN', '일정 삭제'),

--- a/docs/admin/admin.md
+++ b/docs/admin/admin.md
@@ -40,7 +40,7 @@ Admin은 보안 최상급 영역이므로 이중 검증 구조를 채택한다.
 |------|------|------|
 | 전체 유저 목록 조회 | 직접 DB (user) | 조회, 부작용 없음 |
 | 특정 유저 상세 조회 | 직접 DB (user) | 조회, 부작용 없음 |
-| 셀러 승인 | 직접 DB (user) | role 컬럼만 변경, 연쇄 로직 없음 |
+| 셀러 승인 | 직접 DB (user) + Kafka 이벤트 | role 컬럼 변경 후 신규 셀러 프로모션 등록을 settlement 서비스에 위임 |
 | 전체 상품 조회 | 직접 DB (product) | 조회, 부작용 없음 |
 | 상품 강제 내리기 | 직접 DB (product) + Kafka 이벤트 | soft delete 후 schedule 취소 + ES 삭제를 product 서비스에 위임 |
 | 전체 주문 조회 | 직접 DB (order) | 조회, 부작용 없음 |
@@ -56,6 +56,14 @@ Admin은 보안 최상급 영역이므로 이중 검증 구조를 채택한다.
 > **Outbox 패턴**을 적용해 product soft delete와 outbox 이벤트 저장을 같은 트랜잭션으로 묶어 원자적으로 커밋한다.
 > 별도 스케줄러(`OutboxEventPoller`)가 Kafka에 발행하며, Kafka 장애 시에도 이벤트 유실 없이 재발행이 보장된다.
 > 신뢰성 설계 상세는 [force-down-reliability.md](force-down-reliability.md)를 참고한다.
+
+> **셀러 승격을 이벤트 기반으로 처리하는 이유**
+>
+> 셀러 승인 자체는 user DB의 `role` 컬럼 변경이지만, 이후 정산 서비스에서는 신규 셀러 프로모션을 seller에게 할당해야 한다.
+> Admin이 settlement DB를 직접 수정하면 서비스 간 책임이 섞이고 결합이 강해진다.
+>
+> 따라서 Admin은 user DB 변경과 outbox 이벤트 저장을 같은 트랜잭션으로 묶고,
+> settlement 서비스가 `USER_SELLER_APPROVED` 이벤트를 소비해 `seller_promotions`를 직접 등록하도록 분리한다.
 
 ### 상품 강제 내리기 흐름
 
@@ -103,6 +111,45 @@ Kafka 토픽: admin.product
 | Product DB `products` | Kafka 소비 후 (비동기) | status=DISABLE, deleteDt=now() |
 | Product DB `products_schedule` | 위와 같은 트랜잭션 | delete_dt=now() (soft-delete) |
 | Elasticsearch | DB 커밋 직후 | 인덱스 삭제 |
+
+### 셀러 승인 흐름
+
+```text
+[Admin 서비스 — 동기, HTTP 응답 전]
+
+PATCH /api/v1/admins/users/{userId}/approve-seller
+  -> AdminRoleInterceptor: X-User-Role == ADMIN 검증
+  -> UserAdminService.approveSeller()  @Transactional(adminTransactionManager)
+      1. Admin DB users 조회 (없으면 404)
+      2. user.approveSeller() -> role = SELLER
+      3. AdminUserEvent.sellerApproved() 생성
+      4. OutboxEvent.create() 저장 -> admin_outbox_events: status=PENDING, topic=settlement.events
+      ↓ DB 커밋 (users + outbox 원자적)
+  -> HTTP 200 응답 반환
+
+[Admin 서비스 — 비동기, OutboxEventPoller]
+
+OutboxEventPoller  @Scheduled(fixedDelay=1000)
+  -> admin_outbox_events PENDING 조회
+  -> OutboxService.markSending() -> status=SENDING
+  -> kafkaTemplate.send(ProducerRecord).get()
+      topic   = settlement.events
+      key     = userId
+      header  = eventType: USER_SELLER_APPROVED
+      value   = {"eventId":"...","type":"SELLER_APPROVED","sellerId":"...","approvedAt":"..."}
+      성공: OutboxService.markPublished() -> status=PUBLISHED
+      실패: OutboxService.retry() -> retryCount++, status=PENDING
+
+[Settlement 서비스 — 비동기, Kafka]
+
+SettlementEventsConsumer.consume()
+  -> eventType == USER_SELLER_APPROVED
+  -> SellerPromotionEventHandler.handleSellerApproved()
+  -> NewSellerPromotionService.register()
+      1. settlement_promotions 에서 NEW_SELLER active 정책 조회
+      2. seller_promotions 에 동일 seller/promotion 활성 여부 확인
+      3. 없으면 seller_promotions 저장
+```
 
 ### DataSource 구성
 
@@ -200,6 +247,8 @@ service/admin/src/main/java/jabaclass/admin/
 │   │   └── repository/
 │   │       └── UserAdminRepository.java
 │   ├── infrastructure/
+│   │   ├── kafka/
+│   │   │   └── AdminUserEvent.java             # 셀러 승격 이벤트 payload
 │   │   └── persistence/
 │   │       ├── UserAdminJpaRepository.java
 │   │       ├── UserAdminRepositoryAdapter.java
@@ -235,7 +284,7 @@ service/admin/src/main/java/jabaclass/admin/
 │   │   ├── kafka/
 │   │   │   └── AdminProductEvent.java          # 강제 내리기 이벤트 payload (type + productId)
 │   │   └── outbox/
-│   │       ├── EventType.java                  # PRODUCT_FORCE_DOWN("admin.product")
+│   │       ├── EventType.java                  # PRODUCT_FORCE_DOWN("admin.product"), USER_SELLER_APPROVED("settlement.events")
 │   │       ├── OutboxService.java              # 상태 전환 전용 @Transactional
 │   │       └── OutboxEventPoller.java          # @Scheduled 폴러
 │   └── presentation/

--- a/docs/api-spec/06-settlement.md
+++ b/docs/api-spec/06-settlement.md
@@ -4,7 +4,7 @@
 
 > 외부 호출은 API Gateway 기준 경로(`/api/v1/...`)를 사용한다.
 
-> 정산 대상(`SettlementTarget`) 적재는 외부 REST 호출이 아니라 Kafka `settlement.events` 소비로 들어온다.
+> 정산 관련 비동기 이벤트는 Kafka `settlement.events` 소비로 처리된다. 결제/환불은 `SettlementTarget` 적재로, 판매자 승격은 신규 셀러 프로모션 등록으로 이어진다.
 
 ---
 
@@ -281,6 +281,7 @@
 - `settlement.events` 소비로 `SettlementTarget`이 저장된다.
 - 이벤트 payload의 `eventId`는 `SettlementTarget.sourceEventId`로 저장된다.
 - `sourceEventId` 유니크 제약으로 동일 이벤트 재수신을 멱등 처리한다.
+- `USER_SELLER_APPROVED` 이벤트는 정산 타겟이 아니라 신규 셀러 프로모션 등록에 사용된다.
 
 **Response** `200 OK`
 

--- a/docs/kafka-topics.md
+++ b/docs/kafka-topics.md
@@ -21,7 +21,7 @@
 | 주문 | `order.events` | order-service |
 | 상품 | `product.events` | product-service |
 | 예치금 | `deposit.events` | user-service |
-| 정산 | `settlement.events` | order-service |
+| 정산 | `settlement.events` | order-service, admin-service |
 
 ---
 
@@ -46,12 +46,13 @@
 | `SETTLEMENT_PAYMENT_COMPLETED` | 결제 정산 대상 생성 | settlement-service |
 | `SETTLEMENT_REFUND_COMPLETED` | 환불 정산 대상 생성 | settlement-service |
 
-### `settlement.events` (order-service → settlement-service)
+### `settlement.events` (order-service, admin-service → settlement-service)
 
 | eventType | 설명 | Consumer |
 |-----------|------|----------|
 | `SETTLEMENT_PAYMENT_COMPLETED` | 결제 정산 대상 적재 | settlement-service |
 | `SETTLEMENT_REFUND_COMPLETED` | 환불 정산 대상 적재 | settlement-service |
+| `USER_SELLER_APPROVED` | 신규 셀러 프로모션 등록 | settlement-service |
 
 ### `product.events` (product-service → 여러 서비스)
 
@@ -83,11 +84,13 @@ header  = eventType: PAYMENT_COMPLETED
 value   = {"eventId":"...","paymentId":"p1","orderId":"o1","productId":"prd1","totalAmount":10000,"occurredAt":"2026-04-20T12:00:00"}
 ```
 
-정산 이벤트 적재 규칙:
+정산 이벤트 처리 규칙:
 
 - `settlement-service`는 payload의 `eventId`를 `SettlementTarget.sourceEventId`로 저장한다.
 - `source_event_id` 유니크 제약으로 동일 이벤트 재수신을 멱등 처리한다.
-- Kafka `key`는 파티션 순서 보장을 위한 `orderId`이며, 멱등키는 payload의 `eventId`다.
+- `SETTLEMENT_PAYMENT_COMPLETED`, `SETTLEMENT_REFUND_COMPLETED`는 Kafka `key`로 `orderId`를 사용한다.
+- `USER_SELLER_APPROVED`는 Kafka `key`로 `sellerId`를 사용한다.
+- 정산 타겟 적재 멱등키는 payload의 `eventId`다.
 
 ---
 
@@ -104,6 +107,7 @@ value   = {"eventId":"...","paymentId":"p1","orderId":"o1","productId":"prd1","t
 | `order.deposit.refund-requested` | `order.events` | `ORDER_DEPOSIT_REFUND_REQUESTED` |
 | `settlement.payment.completed` | `settlement.events` | `SETTLEMENT_PAYMENT_COMPLETED` |
 | `settlement.refund.completed` | `settlement.events` | `SETTLEMENT_REFUND_COMPLETED` |
+| `user.seller-approved` | `settlement.events` | `USER_SELLER_APPROVED` |
 
 ---
 
@@ -115,13 +119,22 @@ Kafka는 같은 파티션 키를 가진 메시지만 순서를 보장한다. 파
 
 ### order.events 파티션 키: `orderId`
 
-모든 `order.events` 및 `settlement.events` 이벤트는 **`orderId`를 파티션 키**로 사용한다.
+모든 `order.events` 이벤트는 **`orderId`를 파티션 키**로 사용한다.
 
 **이유**: 같은 주문의 이벤트(CONFIRMED → REFUNDED 등)가 항상 같은 파티션에 들어가야 Consumer가 라이프사이클 순서를 보장받을 수 있다.
 
 **개선 배경**: 초기 구현에서 `ORDER_RESERVATION_CONFIRMED` / `ORDER_RESERVATION_RELEASED`는 `productUserId`를, `ORDER_REFUNDED` / `ORDER_DEPOSIT_REFUND_REQUESTED`는 `orderId`를 파티션 키로 사용했다. 같은 주문의 이벤트가 서로 다른 파티션에 흩어지면 일관성 추론이 어렵고, 컨슈머가 적체 상황에서 처리 순서를 보장받기 어렵다. 유지보수 명확성과 파티션 일관성을 위해 `orderId`로 통일했다.
 
-**해결**: 모든 order/settlement 관련 이벤트를 `orderId`로 통일.
+**해결**: 모든 order 관련 이벤트를 `orderId`로 통일.
+
+### settlement.events 파티션 키
+
+`settlement.events`는 eventType에 따라 파티션 키가 다르다.
+
+- `SETTLEMENT_PAYMENT_COMPLETED`, `SETTLEMENT_REFUND_COMPLETED` -> `orderId`
+- `USER_SELLER_APPROVED` -> `sellerId`
+
+즉 `settlement.events`는 토픽 하나를 유지하되, 같은 비즈니스 흐름 안에서 순서가 필요한 식별자를 key로 사용한다.
 
 ### payment.events 파티션 키: `paymentId`
 

--- a/docs/settlement/batch-flow.md
+++ b/docs/settlement/batch-flow.md
@@ -93,7 +93,8 @@ admin-service
 
 - 이벤트에는 `sellerId`, `approvedAt`이 포함된다.
 - `approvedAt`을 신규 셀러 프로모션 시작 시각으로 사용한다.
-- 이미 같은 seller에게 같은 활성 프로모션이 있으면 중복 저장하지 않는다.
+- 프로모션 종료 시각은 `approvedAt + durationDays - 1ns`로 계산해 전체 기간이 정확히 적용되도록 한다.
+- 동일 승격 이벤트 재처리에도 중복 저장되지 않도록 `sellerId + promotionId + approvedAt` 기준으로 기존 이력을 확인한다.
 - 신규 셀러 프로모션 마스터(`settlement_promotions`)가 없으면 예외로 처리한다.
 
 ## 정산 계산 Job

--- a/docs/settlement/batch-flow.md
+++ b/docs/settlement/batch-flow.md
@@ -2,6 +2,8 @@
 
 정산 배치는 크게 정산 계산 배치와 정산 송금 배치로 나뉜다.
 
+정산 서비스는 배치만 담당하는 것이 아니라, Kafka 이벤트를 통해 정산 타겟 적재와 판매자 프로모션 등록도 함께 처리한다.
+
 ## 배치 패키지 구조
 
 ```text
@@ -60,6 +62,39 @@ SettlementBatchController
 ```
 
 `SettlementBatchJobLauncher`는 배치 실행 파라미터 생성과 공통 예외 처리를 담당한다. 스케줄러와 컨트롤러는 직접 `JobParameters`를 만들지 않는다.
+
+## Kafka 이벤트 소비 흐름
+
+정산 서비스는 현재 정산 관련 이벤트를 `settlement.events` 토픽 하나에서 받고, `eventType` 헤더로 분기한다.
+
+```text
+settlement.events
+  -> SETTLEMENT_PAYMENT_COMPLETED
+  -> SETTLEMENT_REFUND_COMPLETED
+  -> USER_SELLER_APPROVED
+```
+
+이 중 결제/환불 이벤트는 `SettlementTarget` 적재로 이어지고, 판매자 승격 이벤트는 신규 셀러 프로모션 등록으로 이어진다.
+
+### 신규 셀러 프로모션 등록 흐름
+
+```text
+admin-service
+  -> USER_SELLER_APPROVED 발행
+    -> settlement.events
+      -> SettlementEventsConsumer
+        -> SellerPromotionEventHandler
+          -> NewSellerPromotionService
+            -> NEW_SELLER 프로모션 조회
+            -> seller_promotions 저장
+```
+
+주요 규칙:
+
+- 이벤트에는 `sellerId`, `approvedAt`이 포함된다.
+- `approvedAt`을 신규 셀러 프로모션 시작 시각으로 사용한다.
+- 이미 같은 seller에게 같은 활성 프로모션이 있으면 중복 저장하지 않는다.
+- 신규 셀러 프로모션 마스터(`settlement_promotions`)가 없으면 예외로 처리한다.
 
 ## 정산 계산 Job
 
@@ -133,6 +168,17 @@ SettlementTargetCalculation summary paging 조회
 이 구조는 seller별 단건 조회를 반복하지 않고, 현재 chunk에 포함된 sellerIds 기준으로 필요한 데이터를 모아 가져오기 위한 것이다.
 
 월 전체 데이터를 한 번에 메모리에 올리지 않으면서도 seller 수에 비례해 쿼리가 증가하는 N+1 문제를 줄인다.
+
+또한 `SettlementTargetCalculation` 생성 시 seller의 활성 프로모션도 함께 반영한다.
+
+```text
+SettlementTarget
+  -> SettlementPromotionResolver
+    -> seller_promotions 조회
+    -> 적용 가능한 프로모션 있으면 appliedFeeRate 사용
+```
+
+즉 신규 셀러 프로모션은 이벤트 소비 시점에 `seller_promotions`에 먼저 등록되고, 이후 정산 계산 배치가 `occurredAt` 기준으로 적용 가능 여부를 판단해 수수료율을 할인한다.
 
 ## 정산 송금 Job
 

--- a/docs/settlement/entities.md
+++ b/docs/settlement/entities.md
@@ -104,6 +104,7 @@ Kafka 이벤트를 통해 적재되는 원천 정산 대상이다.
 - 어드민에서 판매자가 SELLER로 승격되면 `USER_SELLER_APPROVED` 이벤트가 발행된다.
 - 정산 서비스는 이 이벤트를 소비해 `NEW_SELLER` 프로모션을 찾아 seller에게 할당한다.
 - `startedAt`은 승격 승인 시각(`approvedAt`)이다.
-- `endedAt`은 `startedAt + durationDays - 1일`로 계산된다.
+- `endedAt`은 `startedAt + durationDays - 1ns`로 계산된다.
+- 즉 30일 프로모션이면 `startedAt`부터 정확히 30일 전체 구간이 적용된다.
 - 정산 계산 시 `occurredAt`이 `startedAt ~ endedAt` 구간 안에 있으면 프로모션이 적용된다.
-- 이미 같은 seller에게 같은 활성 프로모션이 있으면 중복 등록하지 않는다.
+- 동일 승격 이벤트 재처리에도 중복 등록되지 않도록 `sellerId + promotionId + startedAt(=approvedAt)` 기준으로 기존 이력을 확인한다.

--- a/docs/settlement/entities.md
+++ b/docs/settlement/entities.md
@@ -87,3 +87,23 @@ Kafka 이벤트를 통해 적재되는 원천 정산 대상이다.
 `SellerGradePolicy`는 최근 3개월 판매금액 기준 등급/수수료 정책이다. 월 정산 집계 시 active 정책을 한 번 조회하고 메모리에서 판매자별 기준 금액에 맞는 정책을 찾는다.
 
 `SellerPromotion`과 `SettlementPromotion`은 건별 정산 계산 시 적용 수수료율을 판단하는 데 사용된다. 적용된 프로모션 정보는 `SettlementTargetCalculation`에 스냅샷으로 남는다.
+
+### `SettlementPromotion`
+
+정산 프로모션의 마스터 정책이다.
+
+- 현재 신규 셀러 프로모션(`NEW_SELLER`)을 사용한다.
+- `feeRate`는 할인된 수수료율이다.
+- 즉 "정산 금액에서 추가 할인액을 차감"하는 구조가 아니라, 정산 계산 시 기본 수수료율 대신 더 낮은 수수료율을 적용하는 구조다.
+- `durationDays`는 판매자에게 할당된 프로모션의 적용 기간 계산에 사용된다.
+
+### `SellerPromotion`
+
+판매자에게 실제로 할당된 프로모션 이력이다.
+
+- 어드민에서 판매자가 SELLER로 승격되면 `USER_SELLER_APPROVED` 이벤트가 발행된다.
+- 정산 서비스는 이 이벤트를 소비해 `NEW_SELLER` 프로모션을 찾아 seller에게 할당한다.
+- `startedAt`은 승격 승인 시각(`approvedAt`)이다.
+- `endedAt`은 `startedAt + durationDays - 1일`로 계산된다.
+- 정산 계산 시 `occurredAt`이 `startedAt ~ endedAt` 구간 안에 있으면 프로모션이 적용된다.
+- 이미 같은 seller에게 같은 활성 프로모션이 있으면 중복 등록하지 않는다.

--- a/docs/settlement/target-ingestion.md
+++ b/docs/settlement/target-ingestion.md
@@ -2,6 +2,8 @@
 
 정산 대상(`SettlementTarget`)은 외부 REST API로 직접 생성하지 않는다. 주문/결제/환불 흐름에서 발행된 Kafka 이벤트를 `settlement` 서비스가 소비해 적재한다.
 
+현재 `settlement.events` 토픽에는 정산 타겟 적재 이벤트 외에 `USER_SELLER_APPROVED`도 함께 들어온다. 다만 이 이벤트는 `SettlementTarget` 적재가 아니라 신규 셀러 프로모션 등록에 사용된다.
+
 ## 전체 흐름
 
 ```text
@@ -18,6 +20,7 @@ order-service
 |-------------|------|-----------|
 | `SETTLEMENT_PAYMENT_COMPLETED` | 결제 완료 후 정산 대상 생성 | `SettlementTargetType.PAYMENT` |
 | `SETTLEMENT_REFUND_COMPLETED` | 환불 완료 후 정산 대상 생성 | `SettlementTargetType.REFUND` |
+| `USER_SELLER_APPROVED` | 신규 셀러 프로모션 등록 | `SettlementTarget` 미생성 |
 
 ## 적재 데이터
 

--- a/service/admin/src/main/java/jabaclass/admin/common/config/JacksonConfig.java
+++ b/service/admin/src/main/java/jabaclass/admin/common/config/JacksonConfig.java
@@ -4,12 +4,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 @Configuration
 public class JacksonConfig {
 
 	@Bean
 	public ObjectMapper objectMapper() {
-		return new ObjectMapper();
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		return objectMapper;
 	}
 }

--- a/service/admin/src/main/java/jabaclass/admin/common/config/JacksonConfig.java
+++ b/service/admin/src/main/java/jabaclass/admin/common/config/JacksonConfig.java
@@ -4,6 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 @Configuration
@@ -11,8 +13,9 @@ public class JacksonConfig {
 
 	@Bean
 	public ObjectMapper objectMapper() {
-		ObjectMapper objectMapper = new ObjectMapper();
-		objectMapper.registerModule(new JavaTimeModule());
-		return objectMapper;
+		return JsonMapper.builder()
+			.addModule(new JavaTimeModule())
+			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.build();
 	}
 }

--- a/service/admin/src/main/java/jabaclass/admin/product/infrastructure/outbox/EventType.java
+++ b/service/admin/src/main/java/jabaclass/admin/product/infrastructure/outbox/EventType.java
@@ -1,7 +1,8 @@
 package jabaclass.admin.product.infrastructure.outbox;
 
 public enum EventType {
-	PRODUCT_FORCE_DOWN("admin.product");
+	PRODUCT_FORCE_DOWN("admin.product"),
+	USER_SELLER_APPROVED("settlement.events");
 
 	private final String topic;
 

--- a/service/admin/src/main/java/jabaclass/admin/user/application/service/UserAdminService.java
+++ b/service/admin/src/main/java/jabaclass/admin/user/application/service/UserAdminService.java
@@ -7,19 +7,32 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import jabaclass.admin.common.error.AdminErrorCode;
 import jabaclass.admin.common.error.BusinessException;
+import jabaclass.admin.product.domain.model.OutboxEvent;
+import jabaclass.admin.product.domain.repository.OutboxEventRepository;
+import jabaclass.admin.product.infrastructure.outbox.EventType;
 import jabaclass.admin.user.domain.dto.UserSearchCondition;
 import jabaclass.admin.user.application.usecase.UserAdminUseCase;
 import jabaclass.admin.user.domain.repository.UserAdminRepository;
+import jabaclass.admin.user.infrastructure.kafka.AdminUserEvent;
 import jabaclass.admin.user.presentation.dto.response.UserAdminResponseDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserAdminService implements UserAdminUseCase {
 
 	private final UserAdminRepository userAdminRepository;
+	private final OutboxEventRepository outboxEventRepository;
+	private final ObjectMapper objectMapper;
 
 	@Override
 	@Transactional(readOnly = true)
@@ -42,5 +55,20 @@ public class UserAdminService implements UserAdminUseCase {
 		userAdminRepository.findById(userId)
 			.orElseThrow(() -> new BusinessException(AdminErrorCode.USER_NOT_FOUND))
 			.approveSeller();
+
+		try {
+			String payload = objectMapper.writeValueAsString(
+				AdminUserEvent.sellerApproved(userId, LocalDateTime.now())
+			);
+			outboxEventRepository.save(OutboxEvent.create(
+				"user",
+				userId.toString(),
+				EventType.USER_SELLER_APPROVED,
+				payload
+			));
+		} catch (JsonProcessingException e) {
+			log.error("OutboxEvent 직렬화 실패. userId={}", userId, e);
+			throw new BusinessException(AdminErrorCode.OUTBOX_SERIALIZATION_FAILED);
+		}
 	}
 }

--- a/service/admin/src/main/java/jabaclass/admin/user/infrastructure/kafka/AdminUserEvent.java
+++ b/service/admin/src/main/java/jabaclass/admin/user/infrastructure/kafka/AdminUserEvent.java
@@ -1,0 +1,21 @@
+package jabaclass.admin.user.infrastructure.kafka;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record AdminUserEvent(
+	UUID eventId,
+	String type,
+	UUID sellerId,
+	LocalDateTime approvedAt
+) {
+
+	public static AdminUserEvent sellerApproved(UUID sellerId, LocalDateTime approvedAt) {
+		return new AdminUserEvent(
+			UUID.randomUUID(),
+			"SELLER_APPROVED",
+			sellerId,
+			approvedAt
+		);
+	}
+}

--- a/service/admin/src/test/java/jabaclass/admin/user/application/service/UserAdminServiceTest.java
+++ b/service/admin/src/test/java/jabaclass/admin/user/application/service/UserAdminServiceTest.java
@@ -26,7 +26,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import jabaclass.admin.common.error.BusinessException;
+import jabaclass.admin.product.domain.model.OutboxEvent;
+import jabaclass.admin.product.domain.repository.OutboxEventRepository;
 import jabaclass.admin.user.domain.dto.UserSearchCondition;
 import jabaclass.admin.user.domain.model.User;
 import jabaclass.admin.user.domain.model.UserRole;
@@ -40,6 +44,12 @@ class UserAdminServiceTest {
 
 	@Mock
 	private UserAdminRepository userAdminRepository;
+
+	@Mock
+	private OutboxEventRepository outboxEventRepository;
+
+	@Mock
+	private ObjectMapper objectMapper;
 
 	@InjectMocks
 	private UserAdminService userAdminService;
@@ -165,9 +175,10 @@ class UserAdminServiceTest {
 	}
 
 	@Test
-	void 셀러를_승인한다() {
+	void 셀러를_승인하면_아웃박스_이벤트를_저장한다() throws Exception {
 		// given
 		given(userAdminRepository.findById(userId)).willReturn(Optional.of(user));
+		given(objectMapper.writeValueAsString(any())).willReturn("{\"type\":\"SELLER_APPROVED\"}");
 
 		// when
 		userAdminService.approveSeller(userId);
@@ -175,6 +186,7 @@ class UserAdminServiceTest {
 		// then
 		assertThat(user.getRole()).isEqualTo(UserRole.SELLER);
 		then(userAdminRepository).should(times(1)).findById(userId);
+		then(outboxEventRepository).should(times(1)).save(any(OutboxEvent.class));
 	}
 
 	@Test
@@ -187,5 +199,6 @@ class UserAdminServiceTest {
 			.isInstanceOf(BusinessException.class)
 			.hasMessage("유저를 찾을 수 없습니다.");
 		then(userAdminRepository).should(times(1)).findById(userId);
+		then(outboxEventRepository).shouldHaveNoInteractions();
 	}
 }

--- a/service/settlement/src/main/java/jabaclass/settlement/application/exception/SettlementErrorCode.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/application/exception/SettlementErrorCode.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum SettlementErrorCode implements ErrorCode {
 
 	SETTLEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "정산 정보를 찾을 수 없습니다."),
+	SETTLEMENT_PROMOTION_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "정산 프로모션 정보를 찾을 수 없습니다."),
 	SELLER_GRADE_POLICY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "판매자 등급 정책을 찾을 수 없습니다."),
 	INVALID_SETTLEMENT_STATUS(HttpStatus.BAD_REQUEST, "정산 상태가 올바르지 않습니다."),
 	INVALID_SETTLEMENT_AMOUNT(HttpStatus.BAD_REQUEST, "정산 금액이 올바르지 않습니다."),

--- a/service/settlement/src/main/java/jabaclass/settlement/application/service/promotion/NewSellerPromotionService.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/application/service/promotion/NewSellerPromotionService.java
@@ -27,7 +27,11 @@ public class NewSellerPromotionService {
 		SettlementPromotion promotion = settlementPromotionRepository.findActiveByPromotionType(PromotionType.NEW_SELLER)
 			.orElseThrow(() -> new BusinessException(SettlementErrorCode.SETTLEMENT_PROMOTION_NOT_FOUND));
 
-		if (sellerPromotionRepository.existsActiveBySellerIdAndPromotionId(sellerId, promotion.getId())) {
+		if (sellerPromotionRepository.existsBySellerIdAndPromotionIdAndStartedAt(
+			sellerId,
+			promotion.getId(),
+			approvedAt
+		)) {
 			return;
 		}
 

--- a/service/settlement/src/main/java/jabaclass/settlement/application/service/promotion/NewSellerPromotionService.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/application/service/promotion/NewSellerPromotionService.java
@@ -1,0 +1,38 @@
+package jabaclass.settlement.application.service.promotion;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jabaclass.settlement.application.exception.BusinessException;
+import jabaclass.settlement.application.exception.SettlementErrorCode;
+import jabaclass.settlement.domain.model.promotion.PromotionType;
+import jabaclass.settlement.domain.model.promotion.SellerPromotion;
+import jabaclass.settlement.domain.model.promotion.SettlementPromotion;
+import jabaclass.settlement.domain.repository.SellerPromotionRepository;
+import jabaclass.settlement.domain.repository.SettlementPromotionRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NewSellerPromotionService {
+
+	private final SettlementPromotionRepository settlementPromotionRepository;
+	private final SellerPromotionRepository sellerPromotionRepository;
+
+	@Transactional
+	public void register(UUID sellerId, LocalDateTime approvedAt) {
+		SettlementPromotion promotion = settlementPromotionRepository.findActiveByPromotionType(PromotionType.NEW_SELLER)
+			.orElseThrow(() -> new BusinessException(SettlementErrorCode.SETTLEMENT_PROMOTION_NOT_FOUND));
+
+		if (sellerPromotionRepository.existsActiveBySellerIdAndPromotionId(sellerId, promotion.getId())) {
+			return;
+		}
+
+		sellerPromotionRepository.save(
+			SellerPromotion.assign(sellerId, promotion, approvedAt)
+		);
+	}
+}

--- a/service/settlement/src/main/java/jabaclass/settlement/domain/model/promotion/SellerPromotion.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/domain/model/promotion/SellerPromotion.java
@@ -63,7 +63,7 @@ public class SellerPromotion extends BaseEntity {
 			sellerId,
 			promotion.getId(),
 			startedAt,
-			startedAt.plusDays((long) promotion.getDurationDays() - 1),
+			startedAt.plusDays(promotion.getDurationDays()).minusNanos(1),
 			true
 		);
 	}

--- a/service/settlement/src/main/java/jabaclass/settlement/domain/repository/SellerPromotionRepository.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/domain/repository/SellerPromotionRepository.java
@@ -10,7 +10,7 @@ public interface SellerPromotionRepository {
 
 	Optional<SellerPromotion> findActiveApplicablePromotion(UUID sellerId, LocalDateTime occurredAt);
 
-	boolean existsActiveBySellerIdAndPromotionId(UUID sellerId, UUID promotionId);
+	boolean existsBySellerIdAndPromotionIdAndStartedAt(UUID sellerId, UUID promotionId, LocalDateTime startedAt);
 
 	SellerPromotion save(SellerPromotion sellerPromotion);
 }

--- a/service/settlement/src/main/java/jabaclass/settlement/domain/repository/SellerPromotionRepository.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/domain/repository/SellerPromotionRepository.java
@@ -9,4 +9,8 @@ import jabaclass.settlement.domain.model.promotion.SellerPromotion;
 public interface SellerPromotionRepository {
 
 	Optional<SellerPromotion> findActiveApplicablePromotion(UUID sellerId, LocalDateTime occurredAt);
+
+	boolean existsActiveBySellerIdAndPromotionId(UUID sellerId, UUID promotionId);
+
+	SellerPromotion save(SellerPromotion sellerPromotion);
 }

--- a/service/settlement/src/main/java/jabaclass/settlement/domain/repository/SettlementPromotionRepository.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/domain/repository/SettlementPromotionRepository.java
@@ -3,9 +3,12 @@ package jabaclass.settlement.domain.repository;
 import java.util.Optional;
 import java.util.UUID;
 
+import jabaclass.settlement.domain.model.promotion.PromotionType;
 import jabaclass.settlement.domain.model.promotion.SettlementPromotion;
 
 public interface SettlementPromotionRepository {
 
 	Optional<SettlementPromotion> findById(UUID promotionId);
+
+	Optional<SettlementPromotion> findActiveByPromotionType(PromotionType promotionType);
 }

--- a/service/settlement/src/main/java/jabaclass/settlement/infrastructure/config/DevSettlementPromotionInitializer.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/infrastructure/config/DevSettlementPromotionInitializer.java
@@ -1,0 +1,48 @@
+package jabaclass.settlement.infrastructure.config;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import jabaclass.settlement.domain.model.promotion.PromotionType;
+import jabaclass.settlement.domain.model.promotion.SettlementPromotion;
+import jabaclass.settlement.infrastructure.persistence.SettlementPromotionJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@Profile({"dev", "prod"})
+@RequiredArgsConstructor
+public class DevSettlementPromotionInitializer implements ApplicationRunner {
+
+	private final SettlementPromotionJpaRepository settlementPromotionJpaRepository;
+
+	@Override
+	@Transactional
+	public void run(ApplicationArguments args) {
+		if (settlementPromotionJpaRepository.count() > 0) {
+			log.info("SettlementPromotion 시드 생략: 기존 프로모션이 이미 존재합니다. count={}",
+				settlementPromotionJpaRepository.count());
+			return;
+		}
+
+		List<SettlementPromotion> promotions = List.of(
+			new SettlementPromotion(
+				"신규 가입 셀러 30일 우대 수수료",
+				PromotionType.NEW_SELLER,
+				new BigDecimal("0.0300"),
+				30,
+				true
+			)
+		);
+
+		settlementPromotionJpaRepository.saveAll(promotions);
+		log.info("SettlementPromotion 시드 완료. count={}", promotions.size());
+	}
+}

--- a/service/settlement/src/main/java/jabaclass/settlement/infrastructure/config/JacksonConfig.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/infrastructure/config/JacksonConfig.java
@@ -4,6 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 @Configuration
@@ -11,6 +13,9 @@ public class JacksonConfig {
 
 	@Bean
 	public ObjectMapper objectMapper() {
-		return new ObjectMapper().registerModule(new JavaTimeModule());
+		return JsonMapper.builder()
+			.addModule(new JavaTimeModule())
+			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.build();
 	}
 }

--- a/service/settlement/src/main/java/jabaclass/settlement/infrastructure/config/SellerGradePolicyInitializer.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/infrastructure/config/SellerGradePolicyInitializer.java
@@ -18,9 +18,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-@Profile("dev")
+@Profile({"dev", "prod"})
 @RequiredArgsConstructor
-public class DevSellerGradePolicyInitializer implements ApplicationRunner {
+public class SellerGradePolicyInitializer implements ApplicationRunner {
 
 	private final SellerGradePolicyJpaRepository sellerGradePolicyJpaRepository;
 

--- a/service/settlement/src/main/java/jabaclass/settlement/infrastructure/kafka/SellerPromotionEventHandler.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/infrastructure/kafka/SellerPromotionEventHandler.java
@@ -1,0 +1,18 @@
+package jabaclass.settlement.infrastructure.kafka;
+
+import org.springframework.stereotype.Component;
+
+import jabaclass.settlement.application.service.promotion.NewSellerPromotionService;
+import jabaclass.settlement.infrastructure.kafka.dto.SellerApprovedEvent;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SellerPromotionEventHandler {
+
+	private final NewSellerPromotionService newSellerPromotionService;
+
+	public void handleSellerApproved(SellerApprovedEvent event) {
+		newSellerPromotionService.register(event.sellerId(), event.approvedAt());
+	}
+}

--- a/service/settlement/src/main/java/jabaclass/settlement/infrastructure/kafka/SettlementEventsConsumer.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/infrastructure/kafka/SettlementEventsConsumer.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import jabaclass.settlement.infrastructure.kafka.dto.SellerApprovedEvent;
 import jabaclass.settlement.infrastructure.kafka.dto.SettlementPaymentCompletedEvent;
 import jabaclass.settlement.infrastructure.kafka.dto.SettlementRefundCompletedEvent;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 public class SettlementEventsConsumer {
 
 	private final SettlementTargetEventHandler settlementTargetEventHandler;
+	private final SellerPromotionEventHandler sellerPromotionEventHandler;
 	private final ObjectMapper objectMapper;
 
 	@KafkaListener(topics = "settlement.events", groupId = "settlement-service")
@@ -47,6 +49,13 @@ public class SettlementEventsConsumer {
 						SettlementRefundCompletedEvent.class
 					);
 					settlementTargetEventHandler.handleRefundCompleted(event);
+				}
+				case "USER_SELLER_APPROVED" -> {
+					SellerApprovedEvent event = objectMapper.readValue(
+						message,
+						SellerApprovedEvent.class
+					);
+					sellerPromotionEventHandler.handleSellerApproved(event);
 				}
 				default -> log.warn("알 수 없는 settlement eventType: {}", eventType);
 			}

--- a/service/settlement/src/main/java/jabaclass/settlement/infrastructure/kafka/dto/SellerApprovedEvent.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/infrastructure/kafka/dto/SellerApprovedEvent.java
@@ -1,0 +1,12 @@
+package jabaclass.settlement.infrastructure.kafka.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record SellerApprovedEvent(
+	UUID eventId,
+	String type,
+	UUID sellerId,
+	LocalDateTime approvedAt
+) {
+}

--- a/service/settlement/src/main/java/jabaclass/settlement/infrastructure/persistence/SellerPromotionJpaRepository.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/infrastructure/persistence/SellerPromotionJpaRepository.java
@@ -12,6 +12,8 @@ import jabaclass.settlement.domain.model.promotion.SellerPromotion;
 
 public interface SellerPromotionJpaRepository extends JpaRepository<SellerPromotion, UUID> {
 
+	boolean existsBySellerIdAndPromotionIdAndActiveTrue(UUID sellerId, UUID promotionId);
+
 	@Query("""
 		select sp
 		from SellerPromotion sp

--- a/service/settlement/src/main/java/jabaclass/settlement/infrastructure/persistence/SellerPromotionJpaRepository.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/infrastructure/persistence/SellerPromotionJpaRepository.java
@@ -12,7 +12,7 @@ import jabaclass.settlement.domain.model.promotion.SellerPromotion;
 
 public interface SellerPromotionJpaRepository extends JpaRepository<SellerPromotion, UUID> {
 
-	boolean existsBySellerIdAndPromotionIdAndActiveTrue(UUID sellerId, UUID promotionId);
+	boolean existsBySellerIdAndPromotionIdAndStartedAt(UUID sellerId, UUID promotionId, LocalDateTime startedAt);
 
 	@Query("""
 		select sp

--- a/service/settlement/src/main/java/jabaclass/settlement/infrastructure/persistence/SettlementPromotionJpaRepository.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/infrastructure/persistence/SettlementPromotionJpaRepository.java
@@ -4,7 +4,10 @@ import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import jabaclass.settlement.domain.model.promotion.PromotionType;
 import jabaclass.settlement.domain.model.promotion.SettlementPromotion;
 
 public interface SettlementPromotionJpaRepository extends JpaRepository<SettlementPromotion, UUID> {
+
+	java.util.Optional<SettlementPromotion> findFirstByPromotionTypeAndActiveTrue(PromotionType promotionType);
 }

--- a/service/settlement/src/main/java/jabaclass/settlement/infrastructure/persistence/adapter/SellerPromotionRepositoryAdapter.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/infrastructure/persistence/adapter/SellerPromotionRepositoryAdapter.java
@@ -29,8 +29,16 @@ public class SellerPromotionRepositoryAdapter implements SellerPromotionReposito
 	}
 
 	@Override
-	public boolean existsActiveBySellerIdAndPromotionId(UUID sellerId, UUID promotionId) {
-		return sellerPromotionJpaRepository.existsBySellerIdAndPromotionIdAndActiveTrue(sellerId, promotionId);
+	public boolean existsBySellerIdAndPromotionIdAndStartedAt(
+		UUID sellerId,
+		UUID promotionId,
+		LocalDateTime startedAt
+	) {
+		return sellerPromotionJpaRepository.existsBySellerIdAndPromotionIdAndStartedAt(
+			sellerId,
+			promotionId,
+			startedAt
+		);
 	}
 
 	@Override

--- a/service/settlement/src/main/java/jabaclass/settlement/infrastructure/persistence/adapter/SellerPromotionRepositoryAdapter.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/infrastructure/persistence/adapter/SellerPromotionRepositoryAdapter.java
@@ -27,4 +27,14 @@ public class SellerPromotionRepositoryAdapter implements SellerPromotionReposito
 			.stream()
 			.findFirst();
 	}
+
+	@Override
+	public boolean existsActiveBySellerIdAndPromotionId(UUID sellerId, UUID promotionId) {
+		return sellerPromotionJpaRepository.existsBySellerIdAndPromotionIdAndActiveTrue(sellerId, promotionId);
+	}
+
+	@Override
+	public SellerPromotion save(SellerPromotion sellerPromotion) {
+		return sellerPromotionJpaRepository.save(sellerPromotion);
+	}
 }

--- a/service/settlement/src/main/java/jabaclass/settlement/infrastructure/persistence/adapter/SettlementPromotionRepositoryAdapter.java
+++ b/service/settlement/src/main/java/jabaclass/settlement/infrastructure/persistence/adapter/SettlementPromotionRepositoryAdapter.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import org.springframework.stereotype.Repository;
 
+import jabaclass.settlement.domain.model.promotion.PromotionType;
 import jabaclass.settlement.domain.model.promotion.SettlementPromotion;
 import jabaclass.settlement.domain.repository.SettlementPromotionRepository;
 import jabaclass.settlement.infrastructure.persistence.SettlementPromotionJpaRepository;
@@ -19,5 +20,10 @@ public class SettlementPromotionRepositoryAdapter implements SettlementPromotion
 	@Override
 	public Optional<SettlementPromotion> findById(UUID promotionId) {
 		return settlementPromotionJpaRepository.findById(promotionId);
+	}
+
+	@Override
+	public Optional<SettlementPromotion> findActiveByPromotionType(PromotionType promotionType) {
+		return settlementPromotionJpaRepository.findFirstByPromotionTypeAndActiveTrue(promotionType);
 	}
 }

--- a/service/settlement/src/test/java/jabaclass/settlement/application/service/promotion/NewSellerPromotionServiceTest.java
+++ b/service/settlement/src/test/java/jabaclass/settlement/application/service/promotion/NewSellerPromotionServiceTest.java
@@ -1,0 +1,105 @@
+package jabaclass.settlement.application.service.promotion;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import jabaclass.settlement.application.exception.BusinessException;
+import jabaclass.settlement.domain.model.promotion.PromotionType;
+import jabaclass.settlement.domain.model.promotion.SellerPromotion;
+import jabaclass.settlement.domain.model.promotion.SettlementPromotion;
+import jabaclass.settlement.domain.repository.SellerPromotionRepository;
+import jabaclass.settlement.domain.repository.SettlementPromotionRepository;
+
+@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class NewSellerPromotionServiceTest {
+
+	@Mock
+	private SettlementPromotionRepository settlementPromotionRepository;
+
+	@Mock
+	private SellerPromotionRepository sellerPromotionRepository;
+
+	@InjectMocks
+	private NewSellerPromotionService newSellerPromotionService;
+
+	@Test
+	void 같은_seller와_approvedAt이면_비활성_상태여도_중복_등록하지_않는다() {
+		UUID sellerId = UUID.randomUUID();
+		UUID promotionId = UUID.randomUUID();
+		LocalDateTime approvedAt = LocalDateTime.of(2026, 4, 24, 10, 0);
+		SettlementPromotion promotion = new SettlementPromotion(
+			"신규 가입 셀러 30일 우대 수수료",
+			PromotionType.NEW_SELLER,
+			new BigDecimal("0.0300"),
+			30,
+			true
+		);
+		ReflectionTestUtils.setField(promotion, "id", promotionId);
+
+		given(settlementPromotionRepository.findActiveByPromotionType(PromotionType.NEW_SELLER))
+			.willReturn(Optional.of(promotion));
+		given(sellerPromotionRepository.existsBySellerIdAndPromotionIdAndStartedAt(sellerId, promotionId, approvedAt))
+			.willReturn(true);
+
+		newSellerPromotionService.register(sellerId, approvedAt);
+
+		then(sellerPromotionRepository).should(never()).save(any(SellerPromotion.class));
+	}
+
+	@Test
+	void 활성_NEW_SELLER_프로모션이_없으면_예외가_발생한다() {
+		UUID sellerId = UUID.randomUUID();
+		LocalDateTime approvedAt = LocalDateTime.of(2026, 4, 24, 10, 0);
+
+		given(settlementPromotionRepository.findActiveByPromotionType(PromotionType.NEW_SELLER))
+			.willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> newSellerPromotionService.register(sellerId, approvedAt))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("정산 프로모션 정보를 찾을 수 없습니다.");
+	}
+
+	@Test
+	void 같은_seller와_approvedAt_기록이_없으면_프로모션을_등록한다() {
+		UUID sellerId = UUID.randomUUID();
+		UUID promotionId = UUID.randomUUID();
+		LocalDateTime approvedAt = LocalDateTime.of(2026, 4, 24, 10, 0);
+		SettlementPromotion promotion = new SettlementPromotion(
+			"신규 가입 셀러 30일 우대 수수료",
+			PromotionType.NEW_SELLER,
+			new BigDecimal("0.0300"),
+			30,
+			true
+		);
+		ReflectionTestUtils.setField(promotion, "id", promotionId);
+
+		given(settlementPromotionRepository.findActiveByPromotionType(PromotionType.NEW_SELLER))
+			.willReturn(Optional.of(promotion));
+		given(sellerPromotionRepository.existsBySellerIdAndPromotionIdAndStartedAt(sellerId, promotionId, approvedAt))
+			.willReturn(false);
+
+		newSellerPromotionService.register(sellerId, approvedAt);
+
+		then(sellerPromotionRepository).should().save(any(SellerPromotion.class));
+	}
+}

--- a/service/settlement/src/test/java/jabaclass/settlement/domain/model/promotion/SellerPromotionTest.java
+++ b/service/settlement/src/test/java/jabaclass/settlement/domain/model/promotion/SellerPromotionTest.java
@@ -1,0 +1,35 @@
+package jabaclass.settlement.domain.model.promotion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class SellerPromotionTest {
+
+	@Test
+	void 신규셀러_30일_프로모션은_마지막날_끝시각까지_적용된다() {
+		LocalDateTime startedAt = LocalDateTime.of(2026, 4, 24, 10, 0);
+		SettlementPromotion promotion = new SettlementPromotion(
+			"신규 가입 셀러 30일 우대 수수료",
+			PromotionType.NEW_SELLER,
+			new BigDecimal("0.0300"),
+			30,
+			true
+		);
+		ReflectionTestUtils.setField(promotion, "id", UUID.randomUUID());
+
+		SellerPromotion sellerPromotion = SellerPromotion.assign(UUID.randomUUID(), promotion, startedAt);
+
+		assertThat(sellerPromotion.getStartedAt()).isEqualTo(startedAt);
+		assertThat(sellerPromotion.getEndedAt()).isEqualTo(startedAt.plusDays(30).minusNanos(1));
+	}
+}

--- a/service/settlement/src/test/java/jabaclass/settlement/kafka/SettlementEventsConsumerTest.java
+++ b/service/settlement/src/test/java/jabaclass/settlement/kafka/SettlementEventsConsumerTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -22,7 +23,11 @@ import org.springframework.test.context.ActiveProfiles;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import jabaclass.settlement.domain.model.promotion.PromotionType;
+import jabaclass.settlement.domain.model.promotion.SettlementPromotion;
 import jabaclass.settlement.domain.model.settlement.SettlementTargetType;
+import jabaclass.settlement.infrastructure.persistence.SellerPromotionJpaRepository;
+import jabaclass.settlement.infrastructure.persistence.SettlementPromotionJpaRepository;
 import jabaclass.settlement.infrastructure.persistence.SettlementTargetJpaRepository;
 
 @SpringBootTest
@@ -41,6 +46,27 @@ class SettlementEventsConsumerTest {
 
 	@Autowired
 	private SettlementTargetJpaRepository settlementTargetJpaRepository;
+
+	@Autowired
+	private SellerPromotionJpaRepository sellerPromotionJpaRepository;
+
+	@Autowired
+	private SettlementPromotionJpaRepository settlementPromotionJpaRepository;
+
+	@BeforeEach
+	void setUp() {
+		if (settlementPromotionJpaRepository.count() > 0) {
+			return;
+		}
+
+		settlementPromotionJpaRepository.save(new SettlementPromotion(
+			"신규 가입 셀러 30일 우대 수수료",
+			PromotionType.NEW_SELLER,
+			new BigDecimal("0.0300"),
+			30,
+			true
+		));
+	}
 
 	@Test
 	void SETTLEMENT_PAYMENT_COMPLETED_수신시_settlementTarget에_저장된다() throws Exception {
@@ -114,6 +140,54 @@ class SettlementEventsConsumerTest {
 		});
 	}
 
+	@Test
+	void USER_SELLER_APPROVED_수신시_신규셀러_프로모션이_등록된다() throws Exception {
+		UUID sellerId = UUID.randomUUID();
+		send("USER_SELLER_APPROVED", objectMapper.writeValueAsString(new SellerApprovedPayload(
+			UUID.randomUUID(),
+			"SELLER_APPROVED",
+			sellerId,
+			LocalDateTime.of(2026, 4, 24, 10, 0)
+		)));
+
+		await().atMost(5, SECONDS).untilAsserted(() -> {
+			assertThat(
+				sellerPromotionJpaRepository.findAll().stream()
+					.filter(promotion -> sellerId.equals(promotion.getSellerId()))
+					.count()
+			).isEqualTo(1L);
+		});
+	}
+
+	@Test
+	void 동일_신규셀러_이벤트를_중복_수신해도_프로모션은_한_번만_등록된다() throws Exception {
+		UUID sellerId = UUID.randomUUID();
+		String payload = objectMapper.writeValueAsString(new SellerApprovedPayload(
+			UUID.randomUUID(),
+			"SELLER_APPROVED",
+			sellerId,
+			LocalDateTime.of(2026, 4, 24, 10, 0)
+		));
+
+		send("USER_SELLER_APPROVED", payload);
+		await().atMost(5, SECONDS).untilAsserted(() -> {
+			assertThat(
+				sellerPromotionJpaRepository.findAll().stream()
+					.filter(promotion -> sellerId.equals(promotion.getSellerId()))
+					.count()
+			).isEqualTo(1L);
+		});
+
+		send("USER_SELLER_APPROVED", payload);
+		await().atMost(5, SECONDS).untilAsserted(() -> {
+			assertThat(
+				sellerPromotionJpaRepository.findAll().stream()
+					.filter(promotion -> sellerId.equals(promotion.getSellerId()))
+					.count()
+			).isEqualTo(1L);
+		});
+	}
+
 	private void send(String eventType, String payload) {
 		ProducerRecord<String, String> record = new ProducerRecord<>("settlement.events", payload);
 		record.headers().add("eventType", eventType.getBytes(StandardCharsets.UTF_8));
@@ -139,5 +213,12 @@ class SettlementEventsConsumerTest {
 		UUID productId,
 		BigDecimal settlementBaseAmount,
 		LocalDateTime occurredAt
+	) {}
+
+	record SellerApprovedPayload(
+		UUID eventId,
+		String type,
+		UUID sellerId,
+		LocalDateTime approvedAt
 	) {}
 }

--- a/service/user/src/main/java/jabaclass/user/user/application/exception/UserErrorCode.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/exception/UserErrorCode.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum UserErrorCode implements ErrorCode {
 
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-	EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 이메일입니다.");
+	EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
+	SELLER_SETTLEMENT_ACCOUNT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "판매자 또는 관리자만 정산 계좌를 등록할 수 있습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
@@ -25,6 +25,7 @@ import jabaclass.user.user.domain.repository.SellerSettlementAccountRepository;
 import jabaclass.user.user.domain.repository.UserRepository;
 import jabaclass.user.user.presentation.dto.request.ChangeMyEmailRequestDto;
 import jabaclass.user.user.presentation.dto.request.RegisterUserRequestDto;
+import jabaclass.user.user.presentation.dto.request.UpsertSellerSettlementAccountRequestDto;
 import jabaclass.user.user.presentation.dto.request.UpdateUserRequestDto;
 import jabaclass.user.user.presentation.dto.response.SellerSettlementAccountResponseDto;
 import jabaclass.user.user.presentation.dto.response.SellerSettlementDetailResponseDto;
@@ -104,6 +105,37 @@ public class UserService implements UserUseCase {
 	}
 
 	@Override
+	@Transactional
+	public SellerSettlementAccountResponseDto upsertSellerSettlementAccount(
+		UUID userId,
+		String currentUserRole,
+		UpsertSellerSettlementAccountRequestDto request
+	) {
+		User user = getUser(userId);
+		validateSellerSettlementAccountAccess(currentUserRole, user);
+
+		SellerSettlementAccount account = sellerSettlementAccountRepository.findByUserId(userId)
+			.map(existing -> {
+				existing.updateAccount(
+					request.bankCode(),
+					request.accountNumber(),
+					request.accountHolder(),
+					request.active()
+				);
+				return existing;
+			})
+			.orElseGet(() -> SellerSettlementAccount.register(
+				userId,
+				request.bankCode(),
+				request.accountNumber(),
+				request.accountHolder(),
+				request.active()
+			));
+
+		return SellerSettlementAccountResponseDto.from(sellerSettlementAccountRepository.save(account));
+	}
+
+	@Override
 	public List<UserResponseDto> getUsersByIds(List<UUID> userIds) {
 		if (userIds == null || userIds.isEmpty()) {
 			return List.of();
@@ -180,6 +212,25 @@ public class UserService implements UserUseCase {
 		log.info("UserService.getUser lookup userId={}", userId);
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+	}
+
+	private void validateSellerSettlementAccountAccess(String currentUserRole, User user) {
+		UserRole role = resolveRole(currentUserRole);
+		if (!isSellerSettlementAccountAllowed(role) || !isSellerSettlementAccountAllowed(user.getRole())) {
+			throw new BusinessException(UserErrorCode.SELLER_SETTLEMENT_ACCOUNT_ACCESS_DENIED);
+		}
+	}
+
+	private UserRole resolveRole(String currentUserRole) {
+		try {
+			return UserRole.valueOf(currentUserRole);
+		} catch (IllegalArgumentException e) {
+			throw new BusinessException(UserErrorCode.SELLER_SETTLEMENT_ACCOUNT_ACCESS_DENIED);
+		}
+	}
+
+	private boolean isSellerSettlementAccountAllowed(UserRole role) {
+		return role == UserRole.SELLER || role == UserRole.ADMIN;
 	}
 
 	private void saveUser(User user) {

--- a/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
@@ -222,6 +222,9 @@ public class UserService implements UserUseCase {
 	}
 
 	private UserRole resolveRole(String currentUserRole) {
+		if (currentUserRole == null) {
+			throw new BusinessException(UserErrorCode.SELLER_SETTLEMENT_ACCOUNT_ACCESS_DENIED);
+		}
 		try {
 			return UserRole.valueOf(currentUserRole);
 		} catch (IllegalArgumentException e) {

--- a/service/user/src/main/java/jabaclass/user/user/application/usercase/UserUseCase.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/usercase/UserUseCase.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import jabaclass.user.user.presentation.dto.request.ChangeMyEmailRequestDto;
 import jabaclass.user.user.presentation.dto.request.RegisterUserRequestDto;
+import jabaclass.user.user.presentation.dto.request.UpsertSellerSettlementAccountRequestDto;
 import jabaclass.user.user.presentation.dto.request.UpdateUserRequestDto;
 import jabaclass.user.user.presentation.dto.response.SellerSettlementAccountResponseDto;
 import jabaclass.user.user.presentation.dto.response.SellerSettlementDetailResponseDto;
@@ -23,6 +24,12 @@ public interface UserUseCase {
 	void changeEmail(UUID userId, ChangeMyEmailRequestDto request);
 
 	void withdraw(UUID userId);
+
+	SellerSettlementAccountResponseDto upsertSellerSettlementAccount(
+		UUID userId,
+		String currentUserRole,
+		UpsertSellerSettlementAccountRequestDto request
+	);
 
 	List<UserResponseDto> getUsersByIds(List<UUID> userIds);
 

--- a/service/user/src/main/java/jabaclass/user/user/domain/model/SellerSettlementAccount.java
+++ b/service/user/src/main/java/jabaclass/user/user/domain/model/SellerSettlementAccount.java
@@ -34,4 +34,53 @@ public class SellerSettlementAccount extends BaseEntity {
 
 	@Column(name = "active", nullable = false)
 	private boolean active;
+
+	public static SellerSettlementAccount register(
+		UUID userId,
+		String bankCode,
+		String accountNumber,
+		String accountHolder,
+		boolean active
+	) {
+		validateUserId(userId);
+		validateRequiredText(bankCode, "은행 코드");
+		validateRequiredText(accountNumber, "계좌번호");
+		validateRequiredText(accountHolder, "예금주");
+
+		return SellerSettlementAccount.builder()
+			.userId(userId)
+			.bankCode(bankCode)
+			.accountNumber(accountNumber)
+			.accountHolder(accountHolder)
+			.active(active)
+			.build();
+	}
+
+	public void updateAccount(
+		String bankCode,
+		String accountNumber,
+		String accountHolder,
+		boolean active
+	) {
+		validateRequiredText(bankCode, "은행 코드");
+		validateRequiredText(accountNumber, "계좌번호");
+		validateRequiredText(accountHolder, "예금주");
+
+		this.bankCode = bankCode;
+		this.accountNumber = accountNumber;
+		this.accountHolder = accountHolder;
+		this.active = active;
+	}
+
+	private static void validateUserId(UUID userId) {
+		if (userId == null) {
+			throw new IllegalArgumentException("사용자 ID는 null일 수 없습니다.");
+		}
+	}
+
+	private static void validateRequiredText(String value, String fieldName) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(fieldName + "는 비어 있을 수 없습니다.");
+		}
+	}
 }

--- a/service/user/src/main/java/jabaclass/user/user/domain/repository/SellerSettlementAccountRepository.java
+++ b/service/user/src/main/java/jabaclass/user/user/domain/repository/SellerSettlementAccountRepository.java
@@ -11,4 +11,6 @@ public interface SellerSettlementAccountRepository {
 	Optional<SellerSettlementAccount> findByUserId(UUID userId);
 
 	List<SellerSettlementAccount> findAllByUserIds(List<UUID> userIds);
+
+	SellerSettlementAccount save(SellerSettlementAccount sellerSettlementAccount);
 }

--- a/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/SellerSettlementAccountRepositoryAdapter.java
+++ b/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/SellerSettlementAccountRepositoryAdapter.java
@@ -25,4 +25,9 @@ public class SellerSettlementAccountRepositoryAdapter implements SellerSettlemen
 	public List<SellerSettlementAccount> findAllByUserIds(List<UUID> userIds) {
 		return sellerSettlementAccountJpaRepository.findAllByUserIdIn(userIds);
 	}
+
+	@Override
+	public SellerSettlementAccount save(SellerSettlementAccount sellerSettlementAccount) {
+		return sellerSettlementAccountJpaRepository.save(sellerSettlementAccount);
+	}
 }

--- a/service/user/src/main/java/jabaclass/user/user/presentation/controller/UserApi.java
+++ b/service/user/src/main/java/jabaclass/user/user/presentation/controller/UserApi.java
@@ -11,13 +11,16 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jabaclass.user.common.apidocs.ApiErrorSpec;
 import jabaclass.user.common.apidocs.ApiErrorSpecs;
 import jabaclass.user.common.auth.CurrentUser;
+import jabaclass.user.common.auth.CurrentUserRole;
 import jabaclass.user.mail.application.exception.MailErrorCode;
 import jabaclass.user.user.application.exception.UserErrorCode;
 import jabaclass.user.user.presentation.dto.request.ChangeMyEmailRequestDto;
 import jabaclass.user.user.presentation.dto.request.EmailCheckRequestDto;
 import jabaclass.user.user.presentation.dto.request.RegisterUserRequestDto;
+import jabaclass.user.user.presentation.dto.request.UpsertSellerSettlementAccountRequestDto;
 import jabaclass.user.user.presentation.dto.request.UpdateUserRequestDto;
 import jabaclass.user.user.presentation.dto.response.EmailCheckResponseDto;
+import jabaclass.user.user.presentation.dto.response.SellerSettlementAccountResponseDto;
 import jabaclass.user.user.presentation.dto.response.UserResponseDto;
 import jakarta.validation.Valid;
 
@@ -173,6 +176,34 @@ public interface UserApi {
 	})
 	ResponseEntity<Void> withdraw(
 		@CurrentUser UUID userId
+	);
+
+	@Operation(
+		summary = "내 정산 계좌 등록 또는 수정",
+		description = """
+			현재 로그인한 판매자 또는 관리자의 정산 계좌를 등록하거나 수정합니다.
+			- 기존 정산 계좌가 없으면 새로 등록합니다.
+			- 기존 정산 계좌가 있으면 입력값으로 수정합니다.
+			- SELLER, ADMIN 권한만 요청할 수 있습니다.
+			"""
+	)
+	@SecurityRequirement(name = "bearerAuth")
+	@ApiErrorSpecs({
+		@ApiErrorSpec(
+			value = UserErrorCode.class,
+			constant = "USER_NOT_FOUND",
+			summary = "사용자를 찾을 수 없습니다"
+		),
+		@ApiErrorSpec(
+			value = UserErrorCode.class,
+			constant = "SELLER_SETTLEMENT_ACCOUNT_ACCESS_DENIED",
+			summary = "판매자 또는 관리자만 정산 계좌를 등록할 수 있습니다"
+		)
+	})
+	ResponseEntity<SellerSettlementAccountResponseDto> upsertSellerSettlementAccount(
+		@CurrentUser UUID userId,
+		@CurrentUserRole String currentUserRole,
+		@Valid @RequestBody UpsertSellerSettlementAccountRequestDto request
 	);
 
 	@Operation(

--- a/service/user/src/main/java/jabaclass/user/user/presentation/controller/UserController.java
+++ b/service/user/src/main/java/jabaclass/user/user/presentation/controller/UserController.java
@@ -13,12 +13,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import jabaclass.user.common.auth.CurrentUser;
+import jabaclass.user.common.auth.CurrentUserRole;
 import jabaclass.user.user.application.usercase.UserUseCase;
 import jabaclass.user.user.presentation.dto.request.ChangeMyEmailRequestDto;
 import jabaclass.user.user.presentation.dto.request.EmailCheckRequestDto;
 import jabaclass.user.user.presentation.dto.request.RegisterUserRequestDto;
+import jabaclass.user.user.presentation.dto.request.UpsertSellerSettlementAccountRequestDto;
 import jabaclass.user.user.presentation.dto.request.UpdateUserRequestDto;
 import jabaclass.user.user.presentation.dto.response.EmailCheckResponseDto;
+import jabaclass.user.user.presentation.dto.response.SellerSettlementAccountResponseDto;
 import jabaclass.user.user.presentation.dto.response.UserResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -79,6 +82,15 @@ public class UserController implements UserApi {
 	) {
 		userUseCase.withdraw(userId);
 		return ResponseEntity.noContent().build();
+	}
+
+	@PutMapping("/me/seller-settlement-account")
+	public ResponseEntity<SellerSettlementAccountResponseDto> upsertSellerSettlementAccount(
+		@CurrentUser UUID userId,
+		@CurrentUserRole String currentUserRole,
+		@Valid @RequestBody UpsertSellerSettlementAccountRequestDto request
+	) {
+		return ResponseEntity.ok(userUseCase.upsertSellerSettlementAccount(userId, currentUserRole, request));
 	}
 
 	@Override

--- a/service/user/src/main/java/jabaclass/user/user/presentation/dto/request/UpsertSellerSettlementAccountRequestDto.java
+++ b/service/user/src/main/java/jabaclass/user/user/presentation/dto/request/UpsertSellerSettlementAccountRequestDto.java
@@ -1,0 +1,19 @@
+package jabaclass.user.user.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpsertSellerSettlementAccountRequestDto(
+	@NotBlank(message = "은행 코드는 필수입니다.")
+	String bankCode,
+
+	@NotBlank(message = "계좌번호는 필수입니다.")
+	String accountNumber,
+
+	@NotBlank(message = "예금주는 필수입니다.")
+	String accountHolder,
+
+	@NotNull(message = "정산 계좌 활성 여부는 필수입니다.")
+	Boolean active
+) {
+}

--- a/service/user/src/test/java/jabaclass/user/user/application/service/UserServiceTest.java
+++ b/service/user/src/test/java/jabaclass/user/user/application/service/UserServiceTest.java
@@ -515,4 +515,26 @@ class UserServiceTest {
 			.hasMessage(UserErrorCode.SELLER_SETTLEMENT_ACCOUNT_ACCESS_DENIED.getMessage());
 	}
 
+	@Test
+	void 현재_사용자_권한이_null이면_정산_계좌를_등록할_수_없다() {
+		// given
+		UpsertSellerSettlementAccountRequestDto request = new UpsertSellerSettlementAccountRequestDto(
+			"088",
+			"123-456-789",
+			"권한없음",
+			true
+		);
+
+		given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+		// when & then
+		assertThatThrownBy(() -> userService.upsertSellerSettlementAccount(
+			userId,
+			null,
+			request
+		))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage(UserErrorCode.SELLER_SETTLEMENT_ACCOUNT_ACCESS_DENIED.getMessage());
+	}
+
 }

--- a/service/user/src/test/java/jabaclass/user/user/application/service/UserServiceTest.java
+++ b/service/user/src/test/java/jabaclass/user/user/application/service/UserServiceTest.java
@@ -29,10 +29,14 @@ import jabaclass.user.mail.application.usecase.EmailVerificationUseCase;
 import jabaclass.user.user.application.exception.UserErrorCode;
 import jabaclass.user.user.domain.model.User;
 import jabaclass.user.user.domain.model.UserRole;
+import jabaclass.user.user.domain.model.SellerSettlementAccount;
+import jabaclass.user.user.domain.repository.SellerSettlementAccountRepository;
 import jabaclass.user.user.domain.repository.UserRepository;
 import jabaclass.user.user.presentation.dto.request.ChangeMyEmailRequestDto;
 import jabaclass.user.user.presentation.dto.request.RegisterUserRequestDto;
+import jabaclass.user.user.presentation.dto.request.UpsertSellerSettlementAccountRequestDto;
 import jabaclass.user.user.presentation.dto.request.UpdateUserRequestDto;
+import jabaclass.user.user.presentation.dto.response.SellerSettlementAccountResponseDto;
 import jabaclass.user.user.presentation.dto.response.UserResponseDto;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,6 +50,9 @@ class UserServiceTest {
 
 	@Mock
 	private EmailVerificationUseCase emailVerificationUseCase;
+
+	@Mock
+	private SellerSettlementAccountRepository sellerSettlementAccountRepository;
 
 	private UUID userId;
 	private User user;
@@ -398,6 +405,114 @@ class UserServiceTest {
 		assertThat(result.get(1).name()).isEqualTo("철수");
 
 		then(userRepository).should(times(1)).findAllByIds(List.of(userId, secondUserId));
+	}
+
+	@Test
+	void 판매자는_정산_계좌를_등록할_수_있다() {
+		// given
+		user = User.builder()
+			.name("판매자")
+			.email("seller@example.com")
+			.password("encoded-password")
+			.phone("010-1111-2222")
+			.role(UserRole.SELLER)
+			.deposit(BigDecimal.ZERO)
+			.build();
+		ReflectionTestUtils.setField(user, "id", userId);
+
+		UpsertSellerSettlementAccountRequestDto request = new UpsertSellerSettlementAccountRequestDto(
+			"088",
+			"123-456-789",
+			"판매자",
+			true
+		);
+
+		given(userRepository.findById(userId)).willReturn(Optional.of(user));
+		given(sellerSettlementAccountRepository.findByUserId(userId)).willReturn(Optional.empty());
+		given(sellerSettlementAccountRepository.save(any(SellerSettlementAccount.class)))
+			.willAnswer(invocation -> invocation.getArgument(0));
+
+		// when
+		SellerSettlementAccountResponseDto result = userService.upsertSellerSettlementAccount(
+			userId,
+			UserRole.SELLER.name(),
+			request
+		);
+
+		// then
+		assertThat(result.sellerId()).isEqualTo(userId);
+		assertThat(result.bankCode()).isEqualTo("088");
+		assertThat(result.accountNumber()).isEqualTo("123-456-789");
+		assertThat(result.accountHolder()).isEqualTo("판매자");
+		assertThat(result.active()).isTrue();
+	}
+
+	@Test
+	void 기존_정산_계좌가_있으면_수정한다() {
+		// given
+		user = User.builder()
+			.name("관리자")
+			.email("admin@example.com")
+			.password("encoded-password")
+			.phone("010-1111-2222")
+			.role(UserRole.ADMIN)
+			.deposit(BigDecimal.ZERO)
+			.build();
+		ReflectionTestUtils.setField(user, "id", userId);
+
+		SellerSettlementAccount existing = SellerSettlementAccount.register(
+			userId,
+			"088",
+			"111-111-111",
+			"이전예금주",
+			true
+		);
+
+		UpsertSellerSettlementAccountRequestDto request = new UpsertSellerSettlementAccountRequestDto(
+			"090",
+			"999-888-777",
+			"새예금주",
+			false
+		);
+
+		given(userRepository.findById(userId)).willReturn(Optional.of(user));
+		given(sellerSettlementAccountRepository.findByUserId(userId)).willReturn(Optional.of(existing));
+		given(sellerSettlementAccountRepository.save(existing)).willReturn(existing);
+
+		// when
+		SellerSettlementAccountResponseDto result = userService.upsertSellerSettlementAccount(
+			userId,
+			UserRole.ADMIN.name(),
+			request
+		);
+
+		// then
+		assertThat(result.bankCode()).isEqualTo("090");
+		assertThat(result.accountNumber()).isEqualTo("999-888-777");
+		assertThat(result.accountHolder()).isEqualTo("새예금주");
+		assertThat(result.active()).isFalse();
+	}
+
+	@Test
+	void 일반_사용자는_정산_계좌를_등록할_수_없다() {
+		// given
+		UpsertSellerSettlementAccountRequestDto request = new UpsertSellerSettlementAccountRequestDto(
+			"088",
+			"123-456-789",
+			"일반사용자",
+			true
+		);
+
+		given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+		// when & then
+		assertThatThrownBy(() -> userService.upsertSellerSettlementAccount(
+			userId,
+			UserRole.USER.name(),
+			request
+		))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage(UserErrorCode.SELLER_SETTLEMENT_ACCOUNT_ACCESS_DENIED.getMessage());
 	}
 
 }


### PR DESCRIPTION
## 관련 이슈
- Close #306 

</br></br>

## 정산 안정성 개선 및 신규 셀러 프로모션 연동

이번 PR에서는 정산 배치 안정성 개선과 함께, **Admin의 seller 승격 액션이 settlement 서비스의 신규 셀러 프로모션 등록으로 이어지는 흐름**을 추가했습니다.



- Admin에서 seller 승격 시 정산으로 `USER_SELLER_APPROVED` 이벤트를 발행
- Settlement는 해당 이벤트를 소비해 `seller_promotions`에 신규 셀러 프로모션 등록
- 신규 셀러 프로모션은 **30일 전체 기간** 동안 적용되도록 기간 계산 보정
- 동일 승격 이벤트 재처리에도 프로모션이 중복 등록되지 않도록 멱등 처리 보강
- 정산 계산/송금 배치 구조 개선, 월 단위 락, 송금 복구(reconcile) 흐름 보강
- 판매자 정산 계좌 등록 API 추가 및 Gateway 권한 정책 반영


---

</br></br>

## 1. 신규 셀러 프로모션 연동

### 추가 기능

Admin 서비스에는 유저를 seller로 승격하는 기능이 이미 존재합니다.

```text
PATCH /api/v1/admins/users/{userId}/approve-seller
```

기존에는 이 액션이 user DB의 `role = SELLER` 변경으로만 끝났습니다.

하지만 정산 정책상 seller로 승격된 판매자는 **신규 셀러 프로모션**을 받아야 하므로,  
승격 이후 settlement 서비스가 `seller_promotions`에 해당 프로모션을 직접 등록할 수 있어야 했습니다.

</br>

### 적용 방식

Admin이 settlement DB를 직접 수정하지 않고, **이벤트 기반으로 책임을 분리**했습니다.

- Admin: seller 승격 이벤트 발행
- Settlement: 이벤트 소비 후 신규 셀러 프로모션 등록

즉, Admin은 “승격 사실”만 알리고,  
정산 정책 적용은 Settlement가 자신의 DB 안에서 수행합니다.

---

</br></br>

## 2. Admin 이벤트 발행 액션

이벤트 발행 트리거는 아래 액션입니다.

```text
PATCH /api/v1/admins/users/{userId}/approve-seller
```

동작 순서는 다음과 같습니다.

1. Admin이 특정 유저를 seller로 승인
2. user DB의 `role`을 `SELLER`로 변경
3. 같은 트랜잭션 안에서 outbox 이벤트 저장
4. Outbox poller가 Kafka `settlement.events` 토픽으로 발행
5. Settlement가 이를 소비해 신규 셀러 프로모션 등록

</br>

### 발행 이벤트

토픽:

```text
settlement.events
```

헤더:

```text
eventType = USER_SELLER_APPROVED
```

payload:

```json
{
  "eventId": "uuid",
  "type": "SELLER_APPROVED",
  "sellerId": "uuid",
  "approvedAt": "2026-04-24T10:00:00"
}
```

여기서 중요한 필드는:

- `sellerId`: 어떤 seller에게 프로모션을 붙일지
- `approvedAt`: 프로모션 시작 시각

---

</br></br>

## 3. Settlement에서 프로모션 이벤트 처리 흐름

Settlement는 `settlement.events` 토픽 하나를 사용하고, `eventType` 헤더로 분기합니다.

현재 `settlement.events`에서 처리하는 이벤트는 아래와 같습니다.

- `SETTLEMENT_PAYMENT_COMPLETED`
- `SETTLEMENT_REFUND_COMPLETED`
- `USER_SELLER_APPROVED`

즉 신규 셀러 승격 이벤트도 별도 토픽이 아니라 **기존 정산 토픽 안에서 함께 처리**합니다.

</br>

### Settlement 내부 처리 흐름

```mermaid
flowchart TD
    A["settlement.events 수신"] --> B["SettlementEventsConsumer"]
    B --> C{"eventType"}

    C -- "SETTLEMENT_PAYMENT_COMPLETED" --> D["SettlementTarget 적재"]
    C -- "SETTLEMENT_REFUND_COMPLETED" --> E["SettlementTarget 적재"]
    C -- "USER_SELLER_APPROVED" --> F["신규 셀러 프로모션 등록"]

    F --> G["SellerPromotionEventHandler"]
    G --> H["NewSellerPromotionService.register"]

    H --> I["settlement_promotions 에서 NEW_SELLER 조회"]
    I --> J["동일 seller/promotion/approvedAt 존재 여부 확인"]
    J --> K{"이미 있음?"}

    K -- "예" --> L["중복 저장 없이 종료"]
    K -- "아니오" --> M["seller_promotions 저장"]
```

</br>

### 실제 저장되는 테이블

신규 셀러 정책 마스터:

```text
settlement_promotions
```

판매자에게 실제 할당된 프로모션:

```text
seller_promotions
```

즉 이벤트를 받으면 `settlement_promotions`의 `NEW_SELLER` 정책을 조회하고,  
해당 seller에게 `seller_promotions` row를 생성합니다.

---

</br></br>

## 4. 신규 셀러 30일 정책 동작

이번 브랜치에서는 신규 셀러 프로모션 마스터도 함께 추가했습니다.

예시 정책:

- `promotionType = NEW_SELLER`
- `feeRate = 0.0300`
- `durationDays = 30`
- `active = true`

이 정책은 “정산금에서 추가 할인액 차감”이 아니라,  
**기본 수수료율 대신 더 낮은 수수료율을 적용하는 방식**입니다.

즉:

```text
기본 수수료율 6%
-> 신규 셀러 기간에는 3%
```

처럼 동작합니다.

</br>

### 기간 계산

초기 구현에서는 `startedAt.plusDays(durationDays - 1)`로 저장되어  
마지막 날의 대부분 시간이 빠질 수 있는 문제가 있었습니다.

이번 PR에서 아래처럼 수정했습니다.

```text
endedAt = startedAt + durationDays - 1ns
```

즉 30일 정책이면 **정확히 30일 전체 구간**이 적용됩니다.

예:

```text
startedAt = 2026-04-24 10:00:00
endedAt   = 2026-05-24 09:59:59.999999999
```

---

</br></br>

## 5. 배치에서 프로모션 적용 흐름

신규 셀러 프로모션은 이벤트 소비 시점에 `seller_promotions`에 먼저 등록되고,  
실제 정산 계산은 **배치가 `occurredAt` 기준으로 조회해서 적용**합니다.

### 결제 계산 시

`SettlementCalculateService.calculateTarget(...)`에서:

```text
sellerId + occurredAt 기준으로 seller_promotions 조회
-> 적용 가능한 프로모션 있으면 appliedFeeRate 사용
-> 없으면 기본 등급 수수료율 사용
```

즉 프로모션은 `SettlementTargetCalculation`에 스냅샷으로 남습니다.

```text
appliedPromotionId
appliedPromotionType
appliedFeeRate
```

### 월 정산 집계 시

월 정산 집계는 `SettlementTargetCalculation`에 저장된 `appliedFeeRate`를 우선 사용합니다.

즉 신규 셀러 프로모션은:

```text
이벤트 등록
-> seller_promotions 저장
-> 결제 계산 배치에서 appliedFeeRate 반영
-> 월 정산 집계 시 해당 수수료율로 feeAmount 계산
```

으로 이어집니다.

</br>

### 배치 반영 흐름

```mermaid
flowchart TD
    A["USER_SELLER_APPROVED 수신"] --> B["seller_promotions 등록"]

    B --> C["결제 SettlementTarget(PENDING)"]
    C --> D["settlementPaymentTargetCalculationStep"]

    D --> E["SettlementPromotionResolver"]
    E --> F["sellerId + occurredAt 기준 seller_promotions 조회"]

    F --> G{"프로모션 적용 대상?"}
    G -- "예" --> H["appliedFeeRate = 프로모션 수수료율"]
    G -- "아니오" --> I["appliedFeeRate = null"]

    H --> J["SettlementTargetCalculation 저장"]
    I --> J

    J --> K["settlementAggregationStep"]
    K --> L["SettlementFeeCalculator"]
    L --> M["appliedFeeRate 우선 사용해 feeAmount 계산"]
```

---

</br></br>

## 6. 멱등성 지원

### 신규 셀러 프로모션 등록 멱등성

초기 구현은 `sellerId + promotionId + active` 기준이라  
이벤트 재처리 시 비활성 row가 있으면 다시 등록될 수 있는 여지가 있었습니다.

이번 PR에서는 아래 기준으로 보강했습니다.

```text
sellerId + promotionId + startedAt(=approvedAt)
```

즉 같은 seller, 같은 프로모션, 같은 승인 시각이라면  
동일 승격 이벤트의 재처리로 보고 다시 저장하지 않습니다.

정리하면:

- 정산 타겟: `eventId` 기준 멱등
- 신규 셀러 프로모션: `sellerId + promotionId + approvedAt` 기준 멱등

</br>

### 멱등 흐름

```mermaid
flowchart TD
    A["USER_SELLER_APPROVED 이벤트 수신"] --> B["NEW_SELLER 프로모션 조회"]
    B --> C["sellerId + promotionId + approvedAt 존재 여부 확인"]

    C --> D{"이미 존재?"}
    D -- "예" --> E["중복 등록 없이 종료"]
    D -- "아니오" --> F["seller_promotions 저장"]
```

---

</br></br>

## 7. Gateway 반영 사항

이번 브랜치에서는 seller 정산 계좌 등록 API도 함께 추가되었고,  
Gateway 권한 정책도 반영했습니다.

추가된 경로:

```text
PUT /api/v1/users/me/seller-settlement-account
```

허용 권한:

```text
SELLER, ADMIN
```

Gateway `gateway_route_policy`에 반영된 내용:

```sql
INSERT INTO gateway_route_policy (method, path_pattern, allowed_roles, description)
VALUES ('PUT', '/api/v1/users/me/seller-settlement-account', 'SELLER,ADMIN', '내 정산 계좌 등록 또는 수정');
```


---

</br></br>

## 첨언

- 신규 셀러 프로모션은 현재 `NEW_SELLER` 활성 정책 1개를 기준으로 할당합니다.
- seller 승격 이벤트는 `settlement.events` 토픽 하나로 통합하여 관리합니다.
- 정산 계산 시 프로모션은 `seller_promotions`를 `occurredAt` 기준으로 조회하여 적용합니다.
- 프로모션은 “추가 할인액 차감”이 아니라 “할인된 수수료율 적용” 방식입니다.
- seller 계좌 등록 기능은 추가되었지만, 운영상 계좌 등록 전까지는 송금 배치에서 `HOLD` 상태로 남을 수 있습니다.

</br></br>
