### PR TITLE
fix: 사용자 이름 변경 시 상품 목록 페이지 sellerName 미동기화 버그 수정

### DIFF
--- a/docs/elasticsearch.md
+++ b/docs/elasticsearch.md
@@ -57,7 +57,8 @@ ProductRestController
 | `regDt` | date (`date_hour_minute_second`) | — | 등록일시 — 명시적 타입 지정으로 정렬 보장 |
 
 > **비정규화 전략:** `sellerName`을 ES에 직접 저장해 검색 시 user 서비스 REST 호출을 제거한다.
-> 판매자 이름이 변경되는 경우는 드물기 때문에 허용 가능한 trade-off로 판단.
+> 판매자 이름이 변경되면 user-service가 `user.events` 토픽에 `USER_NAME_CHANGED` 이벤트를 발행하고,
+> product-service의 `UserEventsConsumer`가 해당 sellerId의 모든 ES 문서를 일괄 업데이트한다.
 
 > **@Field 명시 이유:** Spring Data ES는 `@Field` 없는 String 필드를 `text + keyword` 멀티필드로 기본 매핑한다.
 > UUID, URL, boolean, date 등 토크나이즈가 필요 없거나 정렬/필터 전용인 필드는 반드시 명시적 타입을 지정해야 한다.
@@ -386,6 +387,13 @@ spring:
 - [x] `searchByKeyword()` — `title`에 `fuzziness: AUTO + prefixLength(1)`, `description`은 일반 match
 - [x] `KafkaConsumerConfig` — `DefaultErrorHandler` + `DeadLetterPublishingRecoverer` (DLQ: `product.es.index.dlq`)
 - [x] `KafkaTopicConfig` — `PRODUCT_ES_TOPIC` 상수 + `NewTopic` 빈 (토픽명 단일 관리, `EsEventType` / `ProductEsKafkaConsumer` 참조)
+
+### 판매자 이름 변경 시 ES 동기화
+- [x] `UserEventsPublisher` (user-service) — `updateMyInfo`에서 이름 변경 감지 시 `user.events`에 `USER_NAME_CHANGED` 발행
+- [x] `UserEventsConsumer` (product-service) — `user.events` 수신 후 `updateSellerNameForAll` 호출
+- [x] `ProductSearchRepository.updateSellerNameForAll()` — 인터페이스 추가
+- [x] `ProductSearchRepositoryAdapter.updateSellerNameForAll()` — sellerId로 ES 문서 전체 조회 후 sellerName bulkIndex
+- [x] `ProductDocument` — `@Builder(toBuilder = true)` 추가 (sellerName 교체 시 불변 복사)
 
 ### 인프라
 - [x] `docker-compose.yml`에 Elasticsearch 9.0.3 컨테이너 추가 (nori 플러그인 포함)

--- a/docs/elasticsearch.md
+++ b/docs/elasticsearch.md
@@ -392,8 +392,7 @@ spring:
 - [x] `UserEventsPublisher` (user-service) — `updateMyInfo`에서 이름 변경 감지 시 `user.events`에 `USER_NAME_CHANGED` 발행
 - [x] `UserEventsConsumer` (product-service) — `user.events` 수신 후 `updateSellerNameForAll` 호출
 - [x] `ProductSearchRepository.updateSellerNameForAll()` — 인터페이스 추가
-- [x] `ProductSearchRepositoryAdapter.updateSellerNameForAll()` — sellerId로 ES 문서 전체 조회 후 sellerName bulkIndex
-- [x] `ProductDocument` — `@Builder(toBuilder = true)` 추가 (sellerName 교체 시 불변 복사)
+- [x] `ProductSearchRepositoryAdapter.updateSellerNameForAll()` — `updateByQuery` + Painless 스크립트로 sellerId 조건의 모든 ES 문서 sellerName 일괄 업데이트
 
 ### 인프라
 - [x] `docker-compose.yml`에 Elasticsearch 9.0.3 컨테이너 추가 (nori 플러그인 포함)

--- a/docs/kafka-topics.md
+++ b/docs/kafka-topics.md
@@ -2,7 +2,7 @@
 
 ## 설계 원칙
 
-- 토픽은 **Producer 서비스 기준**으로 1개씩 운영 (총 4개)
+- 토픽은 **Producer 서비스 기준**으로 1개씩 운영 (총 5개)
 - 하나의 토픽 안에서 Kafka **header `eventType`** 으로 이벤트 종류 구분
 - **토픽 생성은 Producer 서비스의 `KafkaTopicConfig`에서만** 담당
 - Consumer는 토픽을 생성하지 않음
@@ -22,6 +22,7 @@
 | 상품 | `product.events` | product-service |
 | 예치금 | `deposit.events` | user-service |
 | 정산 | `settlement.events` | order-service, admin-service |
+| 사용자 | `user.events` | user-service |
 
 ---
 
@@ -66,6 +67,12 @@
 | eventType | 설명 | Consumer |
 |-----------|------|----------|
 | (추후 정의) | | |
+
+### `user.events` (user-service → 여러 서비스)
+
+| eventType | 설명 | Consumer |
+|-----------|------|----------|
+| `USER_NAME_CHANGED` | 사용자 이름 변경 — ES `sellerName` 동기화 | product-service |
 
 ---
 
@@ -140,6 +147,10 @@ Kafka는 같은 파티션 키를 가진 메시지만 순서를 보장한다. 파
 
 모든 `payment.events` 이벤트는 `paymentId`를 파티션 키로 사용한다. 같은 결제의 이벤트(COMPLETED, FAILED, EXPIRED 등)가 항상 같은 파티션에서 처리된다.
 
+### user.events 파티션 키: `userId`
+
+`USER_NAME_CHANGED`는 `userId`를 파티션 키로 사용한다. 동일 사용자의 이름 변경 이벤트가 항상 같은 파티션에서 순서대로 처리된다.
+
 ### Eventual Consistency — 결제 완료 후 즉시 환불 시도 문제
 
 Payment 서비스가 결제를 완료하고 `PAYMENT_COMPLETED`를 Kafka에 발행한 뒤, Order 서비스 컨슈머가 이를 처리해 Order 상태를 `PAID`로 바꾸기까지 짧은 지연이 존재한다.
@@ -160,3 +171,4 @@ Payment 서비스가 결제를 완료하고 `PAYMENT_COMPLETED`를 Kafka에 발�
 | 토픽명 | 용도 | 비고 |
 |--------|------|------|
 | `product.es.index` | product-service 내부 ES 색인 | 외부 서비스 미소비, 독립 운영 |
+| `product.es.index.dlq` | product.es.index DLQ | 3회 재시도 초과 메시지 라우팅 |

--- a/service/product/src/main/java/jabaclass/product/domain/repository/ProductSearchRepository.java
+++ b/service/product/src/main/java/jabaclass/product/domain/repository/ProductSearchRepository.java
@@ -27,4 +27,7 @@ public interface ProductSearchRepository {
 
 	// 판매자 본인 상품 키워드 검색
 	Page<ProductDocument> searchByKeywordAndSellerId(String keyword, String sellerId, Pageable pageable);
+
+	// 판매자명 변경 시 해당 판매자의 모든 ES 문서 sellerName 일괄 업데이트
+	void updateSellerNameForAll(String sellerId, String newName);
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ProductDocument.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ProductDocument.java
@@ -17,7 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Document(indexName = "products")

--- a/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ProductSearchRepositoryAdapter.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ProductSearchRepositoryAdapter.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.UpdateQuery;
-import org.springframework.data.elasticsearch.core.reindex.ByQueryResponse;
+import org.springframework.data.elasticsearch.core.query.ByQueryResponse;
 
 @Repository
 @RequiredArgsConstructor

--- a/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ProductSearchRepositoryAdapter.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ProductSearchRepositoryAdapter.java
@@ -101,6 +101,29 @@ public class ProductSearchRepositoryAdapter implements ProductSearchRepository {
 	}
 
 	@Override
+	public void updateSellerNameForAll(String sellerId, String newName) {
+		Criteria criteria = new Criteria("sellerId").is(sellerId);
+		CriteriaQuery query = new CriteriaQuery(criteria);
+		query.setMaxResults(10000);
+		SearchHits<ProductDocument> hits = elasticsearchOperations.search(query, ProductDocument.class);
+
+		List<ProductDocument> updated = hits.stream()
+			.map(SearchHit::getContent)
+			.map(doc -> doc.toBuilder().sellerName(newName).build())
+			.toList();
+
+		if (updated.isEmpty()) {
+			return;
+		}
+
+		List<IndexQuery> queries = updated.stream()
+			.map(doc -> new IndexQueryBuilder().withId(doc.getId()).withObject(doc).build())
+			.toList();
+		elasticsearchOperations.bulkIndex(queries, ProductDocument.class);
+		log.info("ES sellerName 업데이트 완료: sellerId={}, 건수={}", sellerId, updated.size());
+	}
+
+	@Override
 	public Page<ProductDocument> searchByKeywordAndSellerId(String keyword, String sellerId, Pageable pageable) {
 		Query query = Query.of(q -> q
 			.bool(b -> b

--- a/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ProductSearchRepositoryAdapter.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ProductSearchRepositoryAdapter.java
@@ -20,6 +20,11 @@ import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
+import org.springframework.data.elasticsearch.core.reindex.ByQueryResponse;
 
 @Repository
 @RequiredArgsConstructor
@@ -102,25 +107,16 @@ public class ProductSearchRepositoryAdapter implements ProductSearchRepository {
 
 	@Override
 	public void updateSellerNameForAll(String sellerId, String newName) {
-		Criteria criteria = new Criteria("sellerId").is(sellerId);
-		CriteriaQuery query = new CriteriaQuery(criteria);
-		query.setMaxResults(10000);
-		SearchHits<ProductDocument> hits = elasticsearchOperations.search(query, ProductDocument.class);
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("sellerId").is(sellerId));
 
-		List<ProductDocument> updated = hits.stream()
-			.map(SearchHit::getContent)
-			.map(doc -> doc.toBuilder().sellerName(newName).build())
-			.toList();
+		UpdateQuery updateQuery = UpdateQuery.builder(criteriaQuery)
+			.withScript("ctx._source.sellerName = params.newName")
+			.withParams(Map.of("newName", newName))
+			.build();
 
-		if (updated.isEmpty()) {
-			return;
-		}
-
-		List<IndexQuery> queries = updated.stream()
-			.map(doc -> new IndexQueryBuilder().withId(doc.getId()).withObject(doc).build())
-			.toList();
-		elasticsearchOperations.bulkIndex(queries, ProductDocument.class);
-		log.info("ES sellerName 업데이트 완료: sellerId={}, 건수={}", sellerId, updated.size());
+		ByQueryResponse response = elasticsearchOperations.updateByQuery(
+			updateQuery, IndexCoordinates.of("products"));
+		log.info("ES sellerName 업데이트 완료: sellerId={}, 업데이트 건수={}", sellerId, response.getUpdated());
 	}
 
 	@Override

--- a/service/product/src/main/java/jabaclass/product/infrastructure/kafka/UserEventsConsumer.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/kafka/UserEventsConsumer.java
@@ -47,5 +47,6 @@ public class UserEventsConsumer {
 		productSearchRepository.updateSellerNameForAll(event.userId().toString(), event.newName());
 	}
 
-	record UserNameChangedEvent(UUID userId, String newName) {}
+	record UserNameChangedEvent(UUID userId, String newName) {
+	}
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/kafka/UserEventsConsumer.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/kafka/UserEventsConsumer.java
@@ -23,7 +23,12 @@ public class UserEventsConsumer {
 
 	@KafkaListener(topics = "user.events", groupId = "product-user-sync")
 	public void consume(ConsumerRecord<String, String> record) {
-		String eventType = new String(record.headers().lastHeader("eventType").value(), StandardCharsets.UTF_8);
+		var eventTypeHeader = record.headers().lastHeader("eventType");
+		if (eventTypeHeader == null) {
+			log.warn("user.events 메시지에 eventType 헤더 없음. 무시합니다. offset={}", record.offset());
+			return;
+		}
+		String eventType = new String(eventTypeHeader.value(), StandardCharsets.UTF_8);
 
 		try {
 			switch (eventType) {

--- a/service/product/src/main/java/jabaclass/product/infrastructure/kafka/UserEventsConsumer.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/kafka/UserEventsConsumer.java
@@ -1,0 +1,46 @@
+package jabaclass.product.infrastructure.kafka;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jabaclass.product.domain.repository.ProductSearchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserEventsConsumer {
+
+	private final ProductSearchRepository productSearchRepository;
+	private final ObjectMapper objectMapper;
+
+	@KafkaListener(topics = "user.events", groupId = "product-user-sync")
+	public void consume(ConsumerRecord<String, String> record) {
+		String eventType = new String(record.headers().lastHeader("eventType").value(), StandardCharsets.UTF_8);
+
+		try {
+			switch (eventType) {
+				case "USER_NAME_CHANGED" -> handleUserNameChanged(record.value());
+				default -> log.warn("알 수 없는 user.events eventType: {}", eventType);
+			}
+		} catch (Exception e) {
+			log.error("user.events 처리 실패. eventType={}", eventType, e);
+			throw new RuntimeException("user.events 이벤트 처리 실패: " + eventType, e);
+		}
+	}
+
+	private void handleUserNameChanged(String message) throws Exception {
+		UserNameChangedEvent event = objectMapper.readValue(message, UserNameChangedEvent.class);
+		log.info("USER_NAME_CHANGED 수신 - userId={}, newName={}", event.userId(), event.newName());
+		productSearchRepository.updateSellerNameForAll(event.userId().toString(), event.newName());
+	}
+
+	record UserNameChangedEvent(UUID userId, String newName) {}
+}

--- a/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
@@ -12,6 +12,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import jabaclass.user.common.error.BusinessException;
 import jabaclass.user.mail.application.usecase.EmailVerificationUseCase;
@@ -89,7 +91,13 @@ public class UserService implements UserUseCase {
 		boolean nameChanged = !Objects.equals(user.getName(), request.name());
 		user.updateProfile(request.name(), request.phone());
 		if (nameChanged) {
-			userEventsPublisher.publishNameChanged(userId, request.name());
+			String newName = request.name();
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+				@Override
+				public void afterCommit() {
+					userEventsPublisher.publishNameChanged(userId, newName);
+				}
+			});
 		}
 	}
 

--- a/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
@@ -86,7 +86,7 @@ public class UserService implements UserUseCase {
 	@Transactional
 	public void updateMyInfo(UUID userId, UpdateUserRequestDto request) {
 		User user = getUser(userId);
-		boolean nameChanged = !user.getName().equals(request.name());
+		boolean nameChanged = !Objects.equals(user.getName(), request.name());
 		user.updateProfile(request.name(), request.phone());
 		if (nameChanged) {
 			userEventsPublisher.publishNameChanged(userId, request.name());

--- a/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
@@ -92,12 +92,16 @@ public class UserService implements UserUseCase {
 		user.updateProfile(request.name(), request.phone());
 		if (nameChanged) {
 			String newName = request.name();
-			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-				@Override
-				public void afterCommit() {
-					userEventsPublisher.publishNameChanged(userId, newName);
-				}
-			});
+			if (TransactionSynchronizationManager.isSynchronizationActive()) {
+				TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+					@Override
+					public void afterCommit() {
+						userEventsPublisher.publishNameChanged(userId, newName);
+					}
+				});
+			} else {
+				userEventsPublisher.publishNameChanged(userId, newName);
+			}
 		}
 	}
 

--- a/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
@@ -23,6 +23,7 @@ import jabaclass.user.user.domain.model.User;
 import jabaclass.user.user.domain.model.UserRole;
 import jabaclass.user.user.domain.repository.SellerSettlementAccountRepository;
 import jabaclass.user.user.domain.repository.UserRepository;
+import jabaclass.user.user.infrastructure.kafka.UserEventsPublisher;
 import jabaclass.user.user.presentation.dto.request.ChangeMyEmailRequestDto;
 import jabaclass.user.user.presentation.dto.request.RegisterUserRequestDto;
 import jabaclass.user.user.presentation.dto.request.UpsertSellerSettlementAccountRequestDto;
@@ -43,6 +44,7 @@ public class UserService implements UserUseCase {
 	private final UserRepository userRepository;
 	private final SellerSettlementAccountRepository sellerSettlementAccountRepository;
 	private final EmailVerificationUseCase emailVerificationUseCase;
+	private final UserEventsPublisher userEventsPublisher;
 
 
 	@Override
@@ -84,7 +86,11 @@ public class UserService implements UserUseCase {
 	@Transactional
 	public void updateMyInfo(UUID userId, UpdateUserRequestDto request) {
 		User user = getUser(userId);
+		boolean nameChanged = !user.getName().equals(request.name());
 		user.updateProfile(request.name(), request.phone());
+		if (nameChanged) {
+			userEventsPublisher.publishNameChanged(userId, request.name());
+		}
 	}
 
 	@Override

--- a/service/user/src/main/java/jabaclass/user/user/infrastructure/kafka/UserEventsPublisher.java
+++ b/service/user/src/main/java/jabaclass/user/user/infrastructure/kafka/UserEventsPublisher.java
@@ -1,0 +1,40 @@
+package jabaclass.user.user.infrastructure.kafka;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserEventsPublisher {
+
+	public static final String USER_EVENTS_TOPIC = "user.events";
+
+	private final KafkaTemplate<String, String> kafkaTemplate;
+	private final ObjectMapper objectMapper;
+
+	public void publishNameChanged(UUID userId, String newName) {
+		try {
+			String payload = objectMapper.writeValueAsString(new UserNameChangedEvent(userId, newName));
+			ProducerRecord<String, String> record = new ProducerRecord<>(USER_EVENTS_TOPIC, userId.toString(), payload);
+			record.headers().add(new RecordHeader("eventType", "USER_NAME_CHANGED".getBytes(StandardCharsets.UTF_8)));
+			kafkaTemplate.send(record);
+			log.info("USER_NAME_CHANGED 이벤트 발행: userId={}", userId);
+		} catch (JsonProcessingException e) {
+			log.error("USER_NAME_CHANGED 이벤트 직렬화 실패: userId={}", userId, e);
+		}
+	}
+
+	public record UserNameChangedEvent(UUID userId, String newName) {}
+}

--- a/service/user/src/main/java/jabaclass/user/user/infrastructure/kafka/UserEventsPublisher.java
+++ b/service/user/src/main/java/jabaclass/user/user/infrastructure/kafka/UserEventsPublisher.java
@@ -29,8 +29,13 @@ public class UserEventsPublisher {
 			String payload = objectMapper.writeValueAsString(new UserNameChangedEvent(userId, newName));
 			ProducerRecord<String, String> record = new ProducerRecord<>(USER_EVENTS_TOPIC, userId.toString(), payload);
 			record.headers().add(new RecordHeader("eventType", "USER_NAME_CHANGED".getBytes(StandardCharsets.UTF_8)));
-			kafkaTemplate.send(record);
-			log.info("USER_NAME_CHANGED 이벤트 발행: userId={}", userId);
+			kafkaTemplate.send(record).whenComplete((result, ex) -> {
+				if (ex != null) {
+					log.error("USER_NAME_CHANGED 이벤트 발행 실패: userId={}", userId, ex);
+				} else {
+					log.info("USER_NAME_CHANGED 이벤트 발행: userId={}", userId);
+				}
+			});
 		} catch (JsonProcessingException e) {
 			log.error("USER_NAME_CHANGED 이벤트 직렬화 실패: userId={}", userId, e);
 		}

--- a/service/user/src/test/java/jabaclass/user/user/application/service/UserServiceTest.java
+++ b/service/user/src/test/java/jabaclass/user/user/application/service/UserServiceTest.java
@@ -32,6 +32,7 @@ import jabaclass.user.user.domain.model.UserRole;
 import jabaclass.user.user.domain.model.SellerSettlementAccount;
 import jabaclass.user.user.domain.repository.SellerSettlementAccountRepository;
 import jabaclass.user.user.domain.repository.UserRepository;
+import jabaclass.user.user.infrastructure.kafka.UserEventsPublisher;
 import jabaclass.user.user.presentation.dto.request.ChangeMyEmailRequestDto;
 import jabaclass.user.user.presentation.dto.request.RegisterUserRequestDto;
 import jabaclass.user.user.presentation.dto.request.UpsertSellerSettlementAccountRequestDto;
@@ -53,6 +54,9 @@ class UserServiceTest {
 
 	@Mock
 	private SellerSettlementAccountRepository sellerSettlementAccountRepository;
+
+	@Mock
+	private UserEventsPublisher userEventsPublisher;
 
 	private UUID userId;
 	private User user;


### PR DESCRIPTION
## 관련 이슈
- Close #340 

## 변경 요약
  - 사용자 이름 변경 시 /product 목록에서 변경된 이름이 반영되지 않던 버그 수정
  - user-service → product-service Kafka 이벤트 기반 ES sellerName 동기화 구현                                                                                     
                                                                                                                                                                   
  ## 주요 변경점                                                                                                                                                   
  - `UserEventsPublisher` (user-service 신규): 이름 변경 감지 시 `user.events` 토픽에 `USER_NAME_CHANGED` 이벤트 발행. 이름이 실제로 달라진 경우에만 발행 (phone만 
  변경 시 불필요한 이벤트 방지)                                                                                                                                    
  - `UserService.updateMyInfo` (수정): 기존 이름과 비교 후 변경된 경우에만 `publishNameChanged` 호출
  - `UserEventsConsumer` (product-service 신규): `user.events` 토픽 구독, `USER_NAME_CHANGED` 수신 시 해당 sellerId의 모든 ES 문서 sellerName 일괄 업데이트        
  - `ProductSearchRepository` (수정): `updateSellerNameForAll(sellerId, newName)` 인터페이스 추가                                                                  
  - `ProductSearchRepositoryAdapter` (수정): sellerId로 ES 문서 전체 조회 후 `toBuilder()`로 sellerName 교체, bulkIndex                                            
  - `ProductDocument` (수정): `@Builder(toBuilder = true)` 추가                                                                                                    
  - `docs/elasticsearch.md`, `docs/kafka-topics.md` 업데이트                                                                                                       
                                                                                                                                                                   
  ## 원인 분석                                                                                                                                                     
  - `/product` 목록은 ES `ProductDocument.sellerName`(비정규화)을 직접 읽음                                                                                      
  - 상품 상세는 user-service REST 직접 호출로 항상 최신 이름을 가져오므로 정상                                                                                     
  - 이름 변경 시 ES 동기화 로직이 없어 목록과 상세 간 불일치 발생                                                                                                  
                                                                                                                                                                   
  ## 테스트                                                                                                                                                        
  - [ ] 로컬 실행 확인                                                                                                                                             
  - [ ] 테스트 통과                                                                                                                                                
  - [ ] Postman으로 이름 변경 후 `/product` 목록 sellerName 반영 확인
  - [ ] `docker exec -it kafka kafka-console-consumer --bootstrap-server localhost:9092 --topic user.events --from-beginning` 으로 메시지 수신 확인                
                                                                                                                                                                   
  ## 리뷰 포인트                                                                                                                                                   
  - `UserService`(application layer)가 `UserEventsPublisher`(infrastructure layer)를 직접 주입 — `ProductService`의 `OutboxRepository` 직접 주입과 동일 패턴으로 허용 범위로 판단                                                                                                                                                 
  - 아웃박스 패턴 미적용 — Kafka 장애 시 ES sellerName이 stale 상태로 남을 수 있으나, `POST /api/v1/products/es-migrate`로 복구 가능하고 이름 변경 빈도가 낮아 허용범위로 판단                  