### PR TITLE
fix: email중복 체크시 socailType 함께 검증

### DIFF
--- a/docs/user-auth.md
+++ b/docs/user-auth.md
@@ -16,7 +16,10 @@ User 서비스는 API Gateway 중앙집중 인증 구조에서 두 가지 역할
 ```
 POST /api/v1/auth/login
   → AuthController.login()
-  → AuthService: 이메일/비밀번호 검증
+      - ClientIpUtils.extractIp(): X-Real-IP 헤더 → 없으면 remoteAddr
+      - User-Agent 헤더 추출 (null이면 "unknown")
+  → AuthService: (email, SocialType.SYSTEM)으로 유저 조회 → 비밀번호 검증
+  → AuthService.handleLoginSecurity(): 새 기기 감지 → 보안 알림 이메일 발송 (비동기)
   → JwtProvider: Access Token + Refresh Token 생성
   → Redis: Refresh Token 저장 (key: "refresh:{userId}")
   → 응답: Access Token (body) + Refresh Token (HttpOnly Cookie)
@@ -41,6 +44,8 @@ GET /login/oauth2/code/{provider}?code=AUTH_CODE&state=...
        - 없으면 신규 가입 ((email, social_type) 복합 unique — 동일 이메일 + 다른 소셜타입은 허용)
        - CustomOAuth2User 반환
   → OAuth2SuccessHandler.onAuthenticationSuccess()
+       - ClientIpUtils.extractIp(): X-Real-IP 헤더 → 없으면 remoteAddr
+       - AuthService.handleLoginSecurity(): 새 기기 감지 → 보안 알림 이메일 발송 (비동기)
        - Access Token + Refresh Token 생성
        - Redis: Refresh Token 저장 (key: "refresh:{userId}")
        - Refresh Token → HttpOnly Cookie
@@ -67,6 +72,22 @@ POST /api/v1/auth/logout
   → Access Token → Redis 블랙리스트 등록 (만료 시간까지 유지)
   → Redis에서 Refresh Token 삭제
   → Refresh Token Cookie 만료 처리
+```
+
+### 새 기기 감지 및 토큰 탈취 신고
+
+```
+[로그인 시 - 일반/OAuth2 공통]
+  → handleLoginSecurity(userId, clientIp, userAgent)
+      - lastLoginIp 또는 lastLoginUserAgent 변경 감지 시 새 기기로 판단
+      - theft_report 토큰 생성 → Redis 저장 (key: "theft_report:{token}", TTL: 7일)
+      - 보안 알림 이메일 비동기 발송 (CompletableFuture.runAsync)
+      - lastLoginIp / lastLoginUserAgent 업데이트
+
+GET /api/v1/auth/report-theft?token={token}
+  → Redis에서 theft_report 토큰으로 userId 조회
+  → force_logout:{userId} 설정 → Redis에서 Refresh Token 삭제
+  → 이후 해당 userId의 모든 기존 Access Token 차단
 ```
 
 ---
@@ -197,10 +218,10 @@ OAuth2 state를 쿠키에 직렬화하는 방식은 Java `SerializationUtils`를
 |---|---|---|
 | `password` | BCrypt 해시값 | `null` |
 | `phone` | 필수 | `null` (선택) |
-| `social_type` | `null` | `GOOGLE` / `KAKAO` / `NAVER` |
+| `social_type` | `SYSTEM` | `GOOGLE` / `KAKAO` / `NAVER` |
 | `social_id` | `null` | provider가 발급한 고유 ID |
 | 로그인 방식 | 이메일 + 비밀번호 | OAuth2 provider 인증 |
-| 동일 이메일 중복 가입 | 불가 | 허용 (`(email, social_type)` 복합 unique — 동일 이메일 + 다른 소셜타입은 별개 계정) |
+| 동일 이메일 중복 가입 | 불가 (`(email, SYSTEM)` 기준) | 허용 (`(email, social_type)` 복합 unique — 동일 이메일 + 다른 소셜타입은 별개 계정) |
 
 ---
 
@@ -245,8 +266,9 @@ public ResponseEntity<UserResponseDto> getMyInfo(
 | `common/auth/CurrentUserRoleArgumentResolver.java` | X-User-Role 헤더 → String 변환 |
 | `common/config/WebMvcConfig.java` | ArgumentResolver 등록 |
 | `common/config/SecurityConfig.java` | Spring Security 설정 (OAuth2 로그인 포함) |
-| `auth/application/AuthService.java` | 일반 로그인/로그아웃/재발급 비즈니스 로직 |
+| `auth/application/AuthService.java` | 일반 로그인/로그아웃/재발급/토큰탈취신고/새기기감지 비즈니스 로직 |
 | `auth/presentation/AuthController.java` | 인증 API 엔드포인트 |
+| `common/util/ClientIpUtils.java` | IP 추출 유틸 (X-Real-IP → remoteAddr fallback) |
 | `auth/infrastructure/oauth2/OAuthAttributes.java` | provider별 응답 정규화 값 객체 |
 | `auth/infrastructure/oauth2/CustomOAuth2User.java` | OAuth2User ↔ User 엔티티 브리지 |
 | `auth/infrastructure/oauth2/CustomOAuth2UserService.java` | OAuth2 유저 조회/신규 가입 처리 |

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletableFuture;
 
 import io.jsonwebtoken.Claims;
 
+import jabaclass.user.user.domain.model.SocialType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -61,8 +62,8 @@ public class AuthService implements LoginUseCase, LogoutUseCase, ReissueUseCase,
     @Transactional
     public TokenResult login(LoginRequestDto request, String clientIp, String userAgent) {
 
-        User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+        User user = userRepository.findByEmailAndSocialType(request.getEmail(), SocialType.SYSTEM)
+            .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new AuthException(AuthErrorCode.USER_NOT_FOUND);

--- a/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
@@ -47,7 +47,7 @@ public class UserService implements UserUseCase {
 
 	@Override
 	public void checkEmailDuplicate(String email) {
-		if (userRepository.existsByEmail(email)) {
+		if (userRepository.existsByEmailAndSocialType(email, SocialType.SYSTEM)) {
 			throw new BusinessException(UserErrorCode.EMAIL_ALREADY_EXISTS);
 		}
 	}
@@ -252,7 +252,7 @@ public class UserService implements UserUseCase {
 		Throwable cause = e;
 		while (cause != null) {
 			String message = cause.getMessage();
-			if (message != null && message.contains("uk_users_email")) {
+			if (message != null && message.contains("uk_users_email_social_type")) {
 				return true;
 			}
 			cause = cause.getCause();

--- a/service/user/src/main/java/jabaclass/user/user/domain/model/User.java
+++ b/service/user/src/main/java/jabaclass/user/user/domain/model/User.java
@@ -25,7 +25,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
 @Table(name = "users", uniqueConstraints = {
-	@UniqueConstraint(name = "uk_users_email_social_type", columnNames = {"email", "socialType"})
+	@UniqueConstraint(name = "uk_users_email_social_type", columnNames = {"email", "social_type"})
 })
 public class User extends BaseEntity {
 

--- a/service/user/src/main/java/jabaclass/user/user/domain/model/User.java
+++ b/service/user/src/main/java/jabaclass/user/user/domain/model/User.java
@@ -24,7 +24,9 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
-@Table(name = "users", uniqueConstraints = {@UniqueConstraint(columnNames = {"email", "socialType"})})
+@Table(name = "users", uniqueConstraints = {
+	@UniqueConstraint(name = "uk_users_email_social_type", columnNames = {"email", "socialType"})
+})
 public class User extends BaseEntity {
 
 	@Column(name = "name", nullable = false, length = 50)

--- a/service/user/src/main/java/jabaclass/user/user/domain/repository/UserRepository.java
+++ b/service/user/src/main/java/jabaclass/user/user/domain/repository/UserRepository.java
@@ -26,4 +26,6 @@ public interface UserRepository {
 	Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
 
 	boolean existsByEmailAndSocialType(String email, SocialType socialType);
+
+	Optional<User> findByEmailAndSocialType(String email, SocialType socialType);
 }

--- a/service/user/src/main/java/jabaclass/user/user/domain/repository/UserRepository.java
+++ b/service/user/src/main/java/jabaclass/user/user/domain/repository/UserRepository.java
@@ -11,8 +11,6 @@ public interface UserRepository {
 
 	Optional<User> findById(UUID userId);
 
-	boolean existsByEmail(String email);
-
 	User save(User user);
 
 	User saveAndFlush(User user);
@@ -26,4 +24,6 @@ public interface UserRepository {
 	Optional<User> findByEmail(String email);
 
 	Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+
+	boolean existsByEmailAndSocialType(String email, SocialType socialType);
 }

--- a/service/user/src/main/java/jabaclass/user/user/domain/repository/UserRepository.java
+++ b/service/user/src/main/java/jabaclass/user/user/domain/repository/UserRepository.java
@@ -21,8 +21,6 @@ public interface UserRepository {
 
 	List<User> findAllByIds(List<UUID> userIds);
 
-	Optional<User> findByEmail(String email);
-
 	Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
 
 	boolean existsByEmailAndSocialType(String email, SocialType socialType);

--- a/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserJpaRepository.java
+++ b/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserJpaRepository.java
@@ -13,8 +13,6 @@ import jakarta.persistence.LockModeType;
 
 public interface UserJpaRepository extends JpaRepository<User, UUID> {
 
-	boolean existsByEmail(String email);
-
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("SELECT u FROM User u WHERE u.id = :id")
 	Optional<User> findByIdWithLock(UUID id);
@@ -22,4 +20,6 @@ public interface UserJpaRepository extends JpaRepository<User, UUID> {
 	Optional<User> findByEmail(String email);
 
 	Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+
+	boolean existsByEmailAndSocialType(String email, SocialType socialType);
 }

--- a/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserJpaRepository.java
+++ b/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserJpaRepository.java
@@ -22,4 +22,6 @@ public interface UserJpaRepository extends JpaRepository<User, UUID> {
 	Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
 
 	boolean existsByEmailAndSocialType(String email, SocialType socialType);
+
+	Optional<User> findByEmailAndSocialType(String email, SocialType socialType);
 }

--- a/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserJpaRepository.java
+++ b/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserJpaRepository.java
@@ -17,8 +17,6 @@ public interface UserJpaRepository extends JpaRepository<User, UUID> {
 	@Query("SELECT u FROM User u WHERE u.id = :id")
 	Optional<User> findByIdWithLock(UUID id);
 
-	Optional<User> findByEmail(String email);
-
 	Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
 
 	boolean existsByEmailAndSocialType(String email, SocialType socialType);

--- a/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -24,11 +24,6 @@ public class UserRepositoryAdapter implements UserRepository {
 	}
 
 	@Override
-	public boolean existsByEmail(String email) {
-		return userJpaRepository.existsByEmail(email);
-	}
-
-	@Override
 	public User save(User user) {
 		return userJpaRepository.save(user);
 	}
@@ -61,5 +56,10 @@ public class UserRepositoryAdapter implements UserRepository {
 	@Override
 	public Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId) {
 		return userJpaRepository.findBySocialTypeAndSocialId(socialType, socialId);
+	}
+
+	@Override
+	public boolean existsByEmailAndSocialType(String email, SocialType socialType) {
+		return userJpaRepository.existsByEmailAndSocialType(email, socialType);
 	}
 }

--- a/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -49,11 +49,6 @@ public class UserRepositoryAdapter implements UserRepository {
 	}
 
 	@Override
-	public Optional<User> findByEmail(String email) {
-		return userJpaRepository.findByEmail(email);
-	}
-
-	@Override
 	public Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId) {
 		return userJpaRepository.findBySocialTypeAndSocialId(socialType, socialId);
 	}

--- a/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/service/user/src/main/java/jabaclass/user/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -62,4 +62,9 @@ public class UserRepositoryAdapter implements UserRepository {
 	public boolean existsByEmailAndSocialType(String email, SocialType socialType) {
 		return userJpaRepository.existsByEmailAndSocialType(email, socialType);
 	}
+
+	@Override
+	public Optional<User> findByEmailAndSocialType(String email, SocialType socialType) {
+		return userJpaRepository.findByEmailAndSocialType(email, socialType);
+	}
 }

--- a/service/user/src/test/java/jabaclass/user/user/application/service/UserServiceTest.java
+++ b/service/user/src/test/java/jabaclass/user/user/application/service/UserServiceTest.java
@@ -21,19 +21,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import jabaclass.user.common.error.BusinessException;
 import jabaclass.user.mail.application.usecase.EmailVerificationUseCase;
 import jabaclass.user.user.application.exception.UserErrorCode;
+import jabaclass.user.user.domain.model.SocialType;
 import jabaclass.user.user.domain.model.User;
 import jabaclass.user.user.domain.model.UserRole;
 import jabaclass.user.user.domain.model.SellerSettlementAccount;
 import jabaclass.user.user.domain.repository.SellerSettlementAccountRepository;
 import jabaclass.user.user.domain.repository.UserRepository;
 import jabaclass.user.user.presentation.dto.request.ChangeMyEmailRequestDto;
-import jabaclass.user.user.presentation.dto.request.RegisterUserRequestDto;
 import jabaclass.user.user.presentation.dto.request.UpsertSellerSettlementAccountRequestDto;
 import jabaclass.user.user.presentation.dto.request.UpdateUserRequestDto;
 import jabaclass.user.user.presentation.dto.response.SellerSettlementAccountResponseDto;
@@ -147,15 +146,14 @@ class UserServiceTest {
 		// given
 		String email = "duplicate@example.com";
 
-		given(userRepository.existsByEmail(email))
-			.willReturn(true);
+		given(userRepository.existsByEmailAndSocialType(email, SocialType.SYSTEM)).willReturn(true);
 
 		// when & then
 		assertThatThrownBy(() -> userService.checkEmailDuplicate(email))
 			.isInstanceOf(BusinessException.class)
 			.hasMessage(UserErrorCode.EMAIL_ALREADY_EXISTS.getMessage());
 
-		then(userRepository).should(times(1)).existsByEmail(email);
+		then(userRepository).should(times(1)).existsByEmailAndSocialType(email, SocialType.SYSTEM);
 	}
 
 	@Test
@@ -234,8 +232,7 @@ class UserServiceTest {
 			"verified-token"
 		);
 
-		given(userRepository.existsByEmail(request.newEmail()))
-			.willReturn(false);
+		given(userRepository.existsByEmailAndSocialType(request.newEmail(), SocialType.SYSTEM)).willReturn(false);
 		given(userRepository.findById(userId))
 			.willReturn(Optional.of(user));
 
@@ -245,7 +242,7 @@ class UserServiceTest {
 		// then
 		assertThat(user.getEmail()).isEqualTo("new@example.com");
 
-		then(userRepository).should(times(1)).existsByEmail(request.newEmail());
+		then(userRepository).should(times(1)).existsByEmailAndSocialType(request.newEmail(), SocialType.SYSTEM);
 		then(emailVerificationUseCase).should(times(1))
 			.validateVerifiedToken(request.newEmail(), request.verifiedToken());
 		then(userRepository).should(times(1)).findById(userId);
@@ -259,15 +256,14 @@ class UserServiceTest {
 			"verified-token"
 		);
 
-		given(userRepository.existsByEmail(request.newEmail()))
-			.willReturn(true);
+		given(userRepository.existsByEmailAndSocialType(request.newEmail(), SocialType.SYSTEM)).willReturn(true);
 
 		// when & then
 		assertThatThrownBy(() -> userService.changeEmail(userId, request))
 			.isInstanceOf(BusinessException.class)
 			.hasMessage(UserErrorCode.EMAIL_ALREADY_EXISTS.getMessage());
 
-		then(userRepository).should(times(1)).existsByEmail(request.newEmail());
+		then(userRepository).should(times(1)).existsByEmailAndSocialType(request.newEmail(), SocialType.SYSTEM);
 		then(emailVerificationUseCase).should(never()).validateVerifiedToken(anyString(), anyString());
 		then(userRepository).should(never()).findById(any());
 	}
@@ -280,8 +276,7 @@ class UserServiceTest {
 			"verified-token"
 		);
 
-		given(userRepository.existsByEmail(request.newEmail()))
-			.willReturn(false);
+		given(userRepository.existsByEmailAndSocialType(request.newEmail(), SocialType.SYSTEM)).willReturn(false);
 		given(userRepository.findById(userId))
 			.willReturn(Optional.empty());
 
@@ -290,7 +285,7 @@ class UserServiceTest {
 			.isInstanceOf(BusinessException.class)
 			.hasMessage(UserErrorCode.USER_NOT_FOUND.getMessage());
 
-		then(userRepository).should(times(1)).existsByEmail(request.newEmail());
+		then(userRepository).should(times(1)).existsByEmailAndSocialType(request.newEmail(), SocialType.SYSTEM);
 		then(emailVerificationUseCase).should(times(1))
 			.validateVerifiedToken(request.newEmail(), request.verifiedToken());
 		then(userRepository).should(times(1)).findById(userId);


### PR DESCRIPTION
## 관련 이슈
- Close #350 

## 변경 요약
- 기존 로직으로는 email 중복 체크를 social 로그인 끼리는 했지만 일반 로그인(SocialType = SYSTEM)과는 하지 않았습니다.
- 이를 SocialType과 함께 하도록 수정하였습니다.

## 주요 변경점
- `existsByEmail` -> existsBySocialTypeAndSocialId`로 변경
- AuthService에서 login 내부 로직 `findByEmail` -> `findByEmailAndSocialType` 으로 변경
- testCode에서 `existsByEmail` 사용하고 있는 로직 전부 수정
- User 엔티티에 맞게 배포용 Postgres 제약 조건 수정

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트
- 카카오 로그인(OAuht2) 이후에 카카오 계정과 동일한 이메일로 일반 로그인 시도해 보시면 됩니다.