### PR TITLE
refactor: 추천이 최신 사용자 행동을 반영하고 이미 본 상품을 제외하도록 개선

### DIFF
--- a/docs/ai/ai-recommendation-flow.md
+++ b/docs/ai/ai-recommendation-flow.md
@@ -4,35 +4,27 @@
 
 - `RecommendationController`
   - 추천 API 진입점
-  - 현재 사용자 ID를 받아 추천 유스케이스 호출
-  - 같은 API를 polling해서 상태를 확인하는 진입점
+  - 같은 API polling의 진입점
 
 - `RecommendationService`
-  - 추천 기능의 메인 오케스트레이터
-  - 캐시 조회, 사용자 벡터 조회, 후보 검색, `PENDING` 응답 생성 담당
+  - recommendation snapshot 조회
+  - snapshot miss 시 userVector 상태 조회, 후보 검색, `PENDING` 응답 생성
 
 - `RecommendationReasonAsyncService`
-  - 추천 이유 생성 비동기 워커
-  - OpenAI 호출 후 캐시를 `COMPLETED` 또는 `FAILED`로 갱신
-
-- `ProductAiEventsConsumer`
-  - `product.events` Kafka 토픽 소비
-  - 상품 임베딩 갱신, 삭제, 사용자 조회 이력 적재 처리
-
-- `ProductEmbeddingSyncService`
-  - 상품 정보를 임베딩으로 변환
-  - 임베딩 저장/수정/삭제 담당
+  - OpenAI 추천 이유 비동기 생성
+  - snapshot을 `COMPLETED` 또는 `FAILED`로 갱신
 
 - `UserActivityService`
-  - 상품 조회 이벤트를 사용자 활동 데이터로 저장
+  - 행동 로그 저장
+  - recommendation snapshot 삭제
+  - userVector 증분 업데이트 호출
 
 - `UserVectorService`
-  - 사용자 활동 기반 벡터 조회/생성 담당
-  - 반복 VIEW 상한과 최근성 감쇠를 적용해 사용자 벡터 구성
+  - Redis user profile / exclude 조회
+  - 캐시 miss 시 full rebuild
+  - 행동 이벤트 기반 증분 업데이트
 
 ## 추천 요청 흐름
-
-### 2-Phase 구조
 
 ```mermaid
 sequenceDiagram
@@ -40,26 +32,27 @@ sequenceDiagram
     participant Client
     participant API as RecommendationController
     participant Service as RecommendationService
-    participant Redis as RecommendationRedisRepository
+    participant Snapshot as RecommendationRedisRepository
+    participant Vector as UserVectorService
     participant Async as RecommendationReasonAsyncService
     participant OpenAI as OpenAiClient
 
     Client->>API: GET /api/v1/recommendations
     API->>Service: recommend(userId)
-    Service->>Redis: get(userId)
+    Service->>Snapshot: get(userId)
 
-    alt 캐시 있음
-        Redis-->>Service: cached response
+    alt snapshot 있음
+        Snapshot-->>Service: cached response
         Service-->>API: cached response
         API-->>Client: 200 OK
-    else 캐시 없음
-        Service->>Service: 사용자 벡터 조회/생성
+    else snapshot 없음
+        Service->>Vector: getOrCreateState(userId)
         Service->>Service: 후보 5개 검색
         alt 후보 없음
             Service-->>API: fallback response (COMPLETED)
             API-->>Client: 200 OK
         else 후보 있음
-            Service->>Redis: save(PENDING + 기본 추천 이유)
+            Service->>Snapshot: save(PENDING + 기본 추천 이유)
             Service->>Async: generateAndCache(...)
             Service-->>API: PENDING response
             API-->>Client: 200 OK
@@ -67,45 +60,42 @@ sequenceDiagram
             Async->>OpenAI: generateRecommendationReasons(...)
             alt 성공
                 OpenAI-->>Async: GPT 추천 이유
-                Async->>Redis: save(COMPLETED + GPT 추천 이유)
+                Async->>Snapshot: save(COMPLETED + GPT 추천 이유)
             else 실패
-                Async->>Redis: save(FAILED + 기본 추천 이유)
+                Async->>Snapshot: save(FAILED + 기본 추천 이유)
             end
         end
     end
 ```
 
-### 단계별 설명
+단계별 설명:
 
-1. `RecommendationController`가 추천 요청을 받습니다.
-2. `RecommendationService`가 추천 캐시를 먼저 확인합니다.
-3. 캐시가 있으면 `PENDING`, `COMPLETED`, `FAILED` 상태 중 현재 값을 그대로 반환합니다.
-4. 캐시가 없으면 `UserVectorService`로 사용자 벡터를 조회 또는 생성합니다.
-5. `CandidateSearchRepository`로 벡터 기반 후보 상품을 검색합니다.
-6. 후보가 있으면 기본 추천 이유로 `PENDING` 응답을 만들고 먼저 캐시에 저장합니다.
-7. `RecommendationReasonAsyncService`가 별도 스레드에서 OpenAI 추천 이유 생성을 수행합니다.
-8. 성공하면 캐시를 `COMPLETED`로, 실패하면 `FAILED`로 갱신합니다.
-9. 클라이언트는 같은 API를 polling 하면서 최종 상태를 확인합니다.
-10. 후보가 없으면 인기 상품 기반 fallback을 `COMPLETED` 상태로 반환합니다.
+1. `RecommendationService`는 recommendation snapshot을 먼저 확인합니다.
+2. snapshot이 있으면 `PENDING`, `COMPLETED`, `FAILED` 현재 값을 그대로 반환합니다.
+3. snapshot이 없으면 `UserVectorService`에서 `userVector + excludedProductIds`를 가져옵니다.
+4. 후보가 있으면 기본 추천 이유로 `PENDING` snapshot을 저장하고 즉시 반환합니다.
+5. `RecommendationReasonAsyncService`가 별도 스레드에서 OpenAI 추천 이유 생성을 수행합니다.
+6. 성공하면 snapshot을 `COMPLETED`로, 실패하면 `FAILED`로 갱신합니다.
+7. 후보가 없으면 인기 상품 fallback을 `COMPLETED` 상태로 반환합니다.
 
 프론트 연동 포인트:
 
-- 첫 응답은 `PENDING`일 수 있으므로 기본 추천 이유를 바로 보여줄 수 있어야 합니다.
-- 이후 동일 API를 다시 호출해 `COMPLETED` 또는 `FAILED`로 상태가 바뀌는지 확인합니다.
-- 현재 프론트는 `1.5초` 간격으로 최대 `5회` polling 합니다.
+- 첫 응답은 `PENDING`일 수 있으므로 기본 추천 이유를 먼저 보여줍니다.
+- 이후 동일 API를 polling 하면서 `COMPLETED` 또는 `FAILED`로 바뀌는지 확인합니다.
+- 현재 프론트 정책은 `1.5초` 간격, 최대 `5회` polling 입니다.
 
 ## 데이터 적재 흐름
 
-1. product 서비스가 `product.events` 발행
-2. `ProductAiEventsConsumer`가 이벤트 수신
-3. `PRODUCT_AI_SYNCED`
-   - `ProductEmbeddingSyncService`가 상품 임베딩 저장/갱신
-4. `PRODUCT_DELETED`
-   - 상품 임베딩 삭제
-5. `PRODUCT_VIEWED`
-   - `UserActivityService`가 사용자 조회 이력 저장
-   - 캐시는 즉시 무효화하지 않고 TTL에 맡김
+1. product / order 서비스가 행동 이벤트 발행
+2. `UserActivityService`가 `user_activities`에 로그 저장
+3. 해당 유저 recommendation snapshot 삭제
+4. `UserVectorService.updateOnActivity()`가 Redis profile / exclude를 갱신
+5. profile이 없거나 버전이 다르면 `user_activities` 기준 full rebuild
+
+제외 정책:
+
+- `VIEW`, `WISHLIST`, `ORDER` 모두 추천 후보에서 제외합니다.
 
 ## 한 줄 요약
 
-이 추천 기능은 추천 후보를 먼저 빠르게 반환하고, 추천 이유 생성은 비동기로 처리한 뒤 같은 캐시 값을 `PENDING -> COMPLETED/FAILED`로 갱신하는 구조다.
+이 추천 기능은 `userVector`를 Redis 상태로 유지하면서, 추천 결과는 polling 동안만 snapshot으로 고정하고, 추천 이유는 `PENDING -> COMPLETED/FAILED` 2-phase로 비동기 생성하는 구조입니다.

--- a/docs/ai/ai-recommendation-flow.md
+++ b/docs/ai/ai-recommendation-flow.md
@@ -94,7 +94,8 @@ sequenceDiagram
 
 제외 정책:
 
-- `VIEW`, `WISHLIST`, `ORDER` 모두 추천 후보에서 제외합니다.
+- `VIEW`는 userVector에는 반영하지만 추천 후보에서는 제외하지 않습니다.
+- `WISHLIST`, `ORDER`만 추천 후보에서 제외합니다.
 
 ## 한 줄 요약
 

--- a/docs/ai/ai.md
+++ b/docs/ai/ai.md
@@ -21,7 +21,8 @@
 - 추천 API는 `@CurrentUser`로 전달된 `X-User-Id` 헤더를 기준으로 동작합니다.
 - 사용자 벡터는 상품 임베딩 768차원 벡터의 가중합으로 계산합니다.
 - 행동 가중치는 `VIEW=1.0`, `WISHLIST=3.0`, `ORDER=5.0`입니다.
-- 조회/찜/주문한 상품은 모두 추천 후보에서 제외합니다.
+- 조회한 상품은 추천 후보에서 제외하지 않습니다.
+- 찜/주문한 상품만 추천 후보에서 제외합니다.
 - recommendation snapshot은 Redis에 20분, user profile / exclude는 Redis에 6시간 저장합니다.
 - 추천 응답 상태는 `PENDING`, `COMPLETED`, `FAILED`입니다.
 - 추천 후보가 없으면 인기 상품 fallback 추천으로 내려갑니다.
@@ -200,7 +201,8 @@ LIMIT 5
 
 ### 3. 제외 정책
 
-- `VIEW`, `WISHLIST`, `ORDER` 모두 추천 후보에서 제외합니다.
+- `VIEW`는 추천 후보에서 제외하지 않습니다.
+- `WISHLIST`, `ORDER`만 추천 후보에서 제외합니다.
 - 제외 상품은 Redis `user:exclude:v2:{userId}`에 저장합니다.
 
 ### 4. 추천 이유 생성

--- a/docs/ai/ai.md
+++ b/docs/ai/ai.md
@@ -4,77 +4,46 @@
 
 `ai` 서비스는 사용자 행동 이력과 상품 임베딩을 기반으로 개인화 추천을 생성하는 서비스입니다.
 
-현재 프로젝트에서 `ai` 서비스는 아래 역할을 가집니다.
+현재 `ai` 서비스의 역할:
 
 | 항목 | 역할 |
 |------|------|
 | 추천 API | 사용자별 추천 목록 조회 |
-| 사용자 행동 수집 | 상품 조회 이벤트를 받아 사용자 활동 이력 저장 |
+| 사용자 행동 수집 | 조회/찜/주문 이벤트를 사용자 활동 이력으로 저장 |
 | 사용자 벡터 생성 | 행동 이력과 상품 임베딩을 합성해 사용자 취향 벡터 생성 |
 | 상품 임베딩 관리 | 상품 이벤트를 받아 OpenAI 임베딩 생성 및 갱신 |
 | 후보 탐색 | pgvector 코사인 유사도 기반 Top-K 후보 검색 |
 | 추천 이유 생성 | OpenAI Chat Completions로 추천 이유를 비동기 생성 |
-| 캐시 | 사용자 벡터 및 추천 결과를 Redis에 저장 |
-
----
+| 캐시 | userVector 상태와 recommendation snapshot을 Redis에 저장 |
 
 ## 현재 구현 상태
 
-**주요 외부 API**
-
-| 영역 | 엔드포인트 | 설명 |
-|------|------------|------|
-| 추천 | `GET /api/v1/recommendations` | 현재 사용자 맞춤 추천 조회 |
-
-**현재 서비스 흐름의 축**
-
-```
-Controller
-  -> UseCase
-    -> Application Service
-      -> Redis Cache
-      -> UserActivity JPA
-      -> ProductEmbedding JDBC/pgvector
-      -> OpenAI API
-      -> Kafka Consumer
-```
-
-**현재 도메인 특징**
-
 - 추천 API는 `@CurrentUser`로 전달된 `X-User-Id` 헤더를 기준으로 동작합니다.
 - 사용자 벡터는 상품 임베딩 768차원 벡터의 가중합으로 계산합니다.
-- 행동 가중치는 `VIEW=1.0`, `WISHLIST=2.0`, `ORDER=3.0`입니다.
-- 추천 후보가 없으면 인기 상품 fallback 추천으로 내려갑니다.
-- 추천 결과는 Redis에 20분, 사용자 벡터는 Redis에 1시간 캐시됩니다.
+- 행동 가중치는 `VIEW=1.0`, `WISHLIST=3.0`, `ORDER=5.0`입니다.
+- 조회/찜/주문한 상품은 모두 추천 후보에서 제외합니다.
+- recommendation snapshot은 Redis에 20분, user profile / exclude는 Redis에 6시간 저장합니다.
 - 추천 응답 상태는 `PENDING`, `COMPLETED`, `FAILED`입니다.
-- 상품 임베딩은 PostgreSQL `pgvector` 확장을 전제로 `product_embeddings` 테이블에 저장됩니다.
-- OpenAI는 임베딩 생성과 추천 이유 생성 두 용도로 사용됩니다.
-
----
+- 추천 후보가 없으면 인기 상품 fallback 추천으로 내려갑니다.
 
 ## 주요 도메인 구조
-
-### 엔티티별 역할
 
 | 엔티티 | 설명 | 핵심 필드 |
 |--------|------|-----------|
 | `UserActivity` | 사용자의 상품 행동 이력 | `userId`, `productId`, `actionType`, `createdAt` |
-| `ProductEmbedding` | 추천 대상 상품과 임베딩 | `id`, `title`, `description`, `price`, `roadAddress`, `status`, `popularity`, `embedding` |
 | `UserVector` | 사용자 취향 벡터 값 객체 | `vector` |
+| `UserVectorProfile` | Redis에 저장하는 사용자 벡터 상태 | `userVector`, `lastUpdatedAt`, `version` |
+| `UserPreferenceState` | 추천 계산용 사용자 상태 | `userVector`, `excludedProductIds` |
 
-### 상태/분류 값
+행동 타입:
 
 | 타입 | 값 |
 |------|----|
 | `ActionType` | `VIEW`, `WISHLIST`, `ORDER` |
 
-> 현재 실제 적재 로직은 `PRODUCT_VIEWED`, `PRODUCT_WISHLISTED`, `ORDER_COMPLETED` 이벤트를 통해 `VIEW`, `WISHLIST`, `ORDER` 행동을 저장합니다.
+## 패키지 구조
 
----
-
-## 패키지 구조 및 계층 역할
-
-```
+```text
 presentation/controller/
   RecommendationController.java
 
@@ -85,13 +54,11 @@ application/service/
   UserActivityService.java
   ProductEmbeddingSyncService.java
 
-application/port/external/
-  AiGatewayPort.java
-
 domain/model/
   UserActivity.java
-  ProductEmbedding.java
   UserVector.java
+  UserVectorProfile.java
+  UserPreferenceState.java
   ActionType.java
 
 domain/repository/
@@ -108,84 +75,60 @@ infrastructure/persistence/
   CandidateSearchRepositoryImpl.java
   UserVectorRedisRepository.java
   RecommendationRedisRepository.java
-
-infrastructure/external/openai/
-  EmbeddingService.java
-  OpenAiClient.java
-
-infrastructure/kafka/
-  ProductAiEventsConsumer.java
-  ProductAiSyncedEvent.java
-  ProductDeletedEvent.java
-  ProductViewedEvent.java
 ```
-
----
 
 ## 서비스별 책임
 
 ### RecommendationService
 
-| 기능 | 설명 |
-|------|------|
-| 추천 조회 | Redis 추천 캐시 확인 |
-| 사용자 벡터 확보 | 캐시 조회 후 없으면 새로 생성 |
-| 후보 검색 | pgvector 유사도 기반 Top-K 추천 후보 조회 |
-| 1차 응답 생성 | 기본 추천 이유로 `PENDING` 응답 생성 |
-| 비동기 작업 시작 | 추천 이유 생성 워커 호출 |
-| fallback 추천 | 후보가 없으면 인기 상품 기반 추천 생성 |
-| 추천 캐시 저장 | `PENDING`, `COMPLETED`, `FAILED` 상태를 Redis에 저장 |
+- recommendation snapshot 조회
+- snapshot miss 시 userVector 상태 확보
+- pgvector 후보 검색
+- `PENDING` snapshot 생성
+- 비동기 추천 이유 생성 워커 호출
+- 후보 없을 때 fallback 응답 생성
 
 ### RecommendationReasonAsyncService
 
-| 기능 | 설명 |
-|------|------|
-| 비동기 추천 이유 생성 | OpenAI Chat Completions 호출 |
-| 성공 처리 | GPT 추천 이유로 캐시를 `COMPLETED` 갱신 |
-| 실패 처리 | 기본 추천 이유로 캐시를 `FAILED` 갱신 |
+- OpenAI Chat Completions 비동기 호출
+- 성공 시 snapshot을 `COMPLETED`로 갱신
+- 실패 시 snapshot을 `FAILED`로 갱신
 
 ### UserVectorService
 
-| 기능 | 설명 |
-|------|------|
-| 사용자 벡터 조회 | Redis에서 사용자 벡터 캐시 조회 |
-| 사용자 벡터 생성 | 활동 이력 기준 상품 ID를 모아 임베딩을 벌크 조회한 뒤 벡터 생성 |
-| 가중치 적용 | 행동 유형별 가중치 반영 |
-| 정규화 | 코사인 유사도 안정화를 위해 L2 정규화 |
-
-> 상품 임베딩은 개별 조회하지 않고 벌크 조회하여 추천 벡터 생성 구간의 N+1 쿼리를 방지합니다.
+- Redis user profile / exclude 조회
+- cache miss 또는 version mismatch 시 full rebuild
+- 행동 이벤트 기반 증분 업데이트
+- 행동 가중치/최근성 반영
+- exclude 상품 집합 구성
 
 ### UserActivityService
 
-| 기능 | 설명 |
-|------|------|
-| 상품 조회 기록 저장 | `PRODUCT_VIEWED` 이벤트를 `UserActivity`로 저장 |
+- 조회/찜/주문 행동 로그 저장
+- 해당 유저 recommendation snapshot 삭제
+- userVector 증분 업데이트 호출
 
 ### ProductEmbeddingSyncService
 
-| 기능 | 설명 |
-|------|------|
-| 상품 임베딩 생성/갱신 | 상품 텍스트를 OpenAI 임베딩으로 변환 후 upsert |
-| 상품 임베딩 삭제 | 상품 삭제 이벤트 수신 시 row 삭제 |
+- 상품 임베딩 생성/갱신/삭제
+- 전체 user profile / recommendation snapshot 캐시 무효화
 
----
-
-## 주요 요청 및 이벤트 흐름
+## 주요 흐름
 
 ### 추천 조회 흐름
 
-```
+```text
 RecommendationController
   -> RecommendationService.recommend(userId)
     -> RecommendationRedisRepository.get()
-    -> 캐시 있으면 즉시 반환
-    -> UserVectorService.getOrCreate()
-      -> UserVectorRedisRepository.get()
+    -> snapshot 있으면 즉시 반환
+    -> UserVectorService.getOrCreateState()
+      -> UserVectorRedisRepository.getProfile()
+      -> UserVectorRedisRepository.getExcludedProductIds()
       -> 없으면 UserActivityRepository.findByUserId()
       -> ProductEmbeddingRepository.findAllByProductIds()
-      -> 사용자 벡터 생성 및 정규화
-      -> UserVectorRedisRepository.save()
-    -> CandidateSearchRepository.findTopK()
+      -> userVector / exclude full rebuild
+    -> CandidateSearchRepository.findTopK(userVector, excludedProductIds, 5)
     -> RecommendationRedisRepository.save(PENDING)
     -> RecommendationReasonAsyncService.generateAndCache()
     -> RecommendationResponseDto 반환
@@ -196,63 +139,36 @@ RecommendationReasonAsyncService
   -> 실패 시 RecommendationRedisRepository.save(FAILED)
 ```
 
-### 추천 fallback 흐름
+### 행동 이벤트 흐름
 
+```text
+product.events / order.events
+  -> UserActivityService.recordActivity()
+    -> user_activities INSERT
+    -> RecommendationRedisRepository.delete(userId)
+    -> UserVectorService.updateOnActivity()
+      -> exclude set 갱신
+      -> profile miss면 full rebuild
+      -> profile hit면 decay + embedding * weight 증분 반영
 ```
-RecommendationService.recommend()
-  -> 후보 없음
-  -> CandidateSearchRepository.findPopular()
-  -> "현재 인기 있는 클래스입니다." 사유로 응답 생성
-  -> RecommendationResponseDto 반환
-```
-
-> 추천 캐시 전체 무효화는 Redis `SCAN` 결과를 배치 단위로 삭제해 애플리케이션 메모리 사용량과 대량 `DEL` 호출로 인한 Redis 부하를 줄입니다.
-
-### 상품 임베딩 동기화 흐름
-
-```
-product.events
-  -> eventType = PRODUCT_AI_SYNCED
-  -> ProductAiEventsConsumer.consume()
-    -> ProductEmbeddingSyncService.saveOrUpdate()
-      -> EmbeddingService.embedProductText()
-      -> OpenAI Embeddings API 호출
-      -> ProductEmbeddingRepository.upsert()
-```
-
-### 상품 삭제 반영 흐름
-
-```
-product.events
-  -> eventType = PRODUCT_DELETED
-  -> ProductAiEventsConsumer.consume()
-    -> ProductEmbeddingSyncService.delete(productId)
-      -> product_embeddings DELETE
-```
-
-### 사용자 행동 기록 흐름
-
-```
-product.events
-  -> eventType = PRODUCT_VIEWED
-  -> ProductAiEventsConsumer.consume()
-    -> UserActivityService.recordProductView()
-      -> user_activities INSERT
-```
-
----
 
 ## 추천 알고리즘 개요
 
 ### 1. 사용자 벡터 생성
 
-사용자 벡터는 사용자가 상호작용한 상품 임베딩의 가중합으로 생성합니다.
-이때 반영 대상 상품 ID를 먼저 모은 뒤 상품 임베딩을 벌크 조회하여 사용자 벡터를 계산합니다.
-이 방식으로 활동 수만큼 임베딩 조회 쿼리가 반복되는 N+1 문제를 방지합니다.
+full rebuild:
 
 ```text
 user_vector = normalize(
-  Σ(product_embedding * action_weight)
+  Σ(product_embedding * action_weight * recency_weight)
+)
+```
+
+증분 업데이트:
+
+```text
+updated_vector = normalize(
+  decay(previous_vector) + (product_embedding * action_weight)
 )
 ```
 
@@ -261,92 +177,57 @@ user_vector = normalize(
 | 행동 | 가중치 |
 |------|--------|
 | `VIEW` | `1.0` |
-| `WISHLIST` | `2.0` |
-| `ORDER` | `3.0` |
+| `WISHLIST` | `3.0` |
+| `ORDER` | `5.0` |
+
+추가 규칙:
+
+- 반감기 14일 기준 최근성 가중치를 적용합니다.
+- 상품 임베딩이 없거나 길이가 768이 아니면 건너뜁니다.
+- 마지막에 L2 정규화합니다.
 
 ### 2. 후보 검색
-
-`CandidateSearchRepositoryImpl`는 PostgreSQL `pgvector`의 cosine distance 연산자 `<=>`를 사용합니다.
 
 ```sql
 SELECT id, title, description, price, road_address
 FROM product_embeddings
 WHERE status = 'ENABLE'
+  AND embedding <=> (?::vector) <= ?
+  AND id NOT IN (...)
 ORDER BY embedding <=> (?::vector)
-LIMIT ?
+LIMIT 5
 ```
 
-### 3. 추천 이유 생성
+### 3. 제외 정책
 
-후보 목록이 정해지면 기본 추천 이유로 먼저 응답하고, OpenAI Chat Completions는 백그라운드에서 각 상품별 추천 사유를 생성합니다.
+- `VIEW`, `WISHLIST`, `ORDER` 모두 추천 후보에서 제외합니다.
+- 제외 상품은 Redis `user:exclude:v2:{userId}`에 저장합니다.
 
-출력 목표:
+### 4. 추천 이유 생성
 
-- 상품별 추천 이유 생성
-- 벡터 값 직접 언급 금지
-- 사용자 취향이 반영된 문장
-- 20~60자
-- `~합니다` 형태
+- 첫 응답은 기본 추천 이유와 함께 `PENDING`
+- OpenAI 추천 이유 생성은 비동기 executor에서 수행
+- 성공 시 `COMPLETED`, 실패 시 `FAILED`
+- 프론트는 같은 API를 polling 하며 상태를 확인
 
-### 4. fallback 추천
-
-개인화 후보가 없으면 `popularity DESC` 기준 인기 상품 추천으로 대체합니다.
-
----
-
-## 외부 연동 구조
-
-### OpenAI 연동
-
-| 용도 | 사용 위치 | 엔드포인트 |
-|------|-----------|------------|
-| 상품 임베딩 생성 | `EmbeddingService` | `POST /v1/embeddings` |
-| 추천 이유 생성 | `OpenAiClient` | `POST /v1/chat/completions` |
-
-추천 이유 생성 호출은 요청 스레드가 아니라 `RecommendationReasonAsyncService`의 async executor에서 수행됩니다.
-
-임베딩 입력 텍스트는 아래 필드를 이어붙여 생성합니다.
-
-- `상품명: {title}`
-- `설명: {description}`
-- `주소: {roadAddress}`
-
-### Kafka 연동
-
-현재 `ai` 서비스는 `product.events` 토픽을 소비합니다.
-
-| eventType | 설명 | 처리 |
-|-----------|------|------|
-| `PRODUCT_AI_SYNCED` | 상품 추천용 정보 동기화 | 임베딩 생성 후 upsert |
-| `PRODUCT_DELETED` | 상품 삭제 | 임베딩 row 삭제 |
-| `PRODUCT_VIEWED` | 사용자 상품 조회 | 활동 이력 저장 |
-
-에러 처리:
-
-- Kafka listener는 1초 간격 3회 재시도 후 DLQ로 전송합니다.
-- DLQ 토픽명은 `{원본토픽}.dlq` 규칙을 사용합니다.
-
-### Redis 연동
+## Redis 연동
 
 | 키 | 의미 | TTL |
 |----|------|-----|
-| `user:{userId}:vector` | 사용자 벡터 캐시 | 1시간 |
-| `user:{userId}:recommendation` | 추천 결과 캐시 (`PENDING`, `COMPLETED`, `FAILED`) | 20분 |
+| `user:profile:v2:{userId}` | userVector profile | 6시간 |
+| `user:exclude:v2:{userId}` | 제외 상품 ID 집합 | 6시간 |
+| `user:{userId}:recommendation:v2` | recommendation snapshot (`PENDING`, `COMPLETED`, `FAILED`) | 20분 |
 
-### PostgreSQL 연동
+## PostgreSQL 연동
 
 | 테이블 | 용도 |
 |--------|------|
 | `user_activities` | 사용자 행동 이력 저장 |
 | `product_embeddings` | 추천 대상 상품 및 벡터 저장 |
 
----
-
 ## API 응답 형태
 
 ### GET `/api/v1/recommendations`
-
-응답 DTO:
 
 ```json
 {
@@ -361,104 +242,17 @@ LIMIT ?
 }
 ```
 
-필드 설명:
-
-| 필드 | 설명 |
-|------|------|
-| `status` | 추천 생성 상태. `PENDING`, `COMPLETED`, `FAILED` |
-| `recommendations` | 추천 결과 목록 |
-| `productId` | 추천 상품 ID |
-| `title` | 추천 상품 제목 |
-| `reason` | 생성된 추천 사유 |
-
 클라이언트 연동 규칙:
 
-- `status`가 `PENDING`이면 기본 추천 결과를 먼저 표시합니다.
-- 클라이언트는 동일한 `GET /api/v1/recommendations` API를 polling 하여 `COMPLETED` 또는 `FAILED` 상태를 확인해야 합니다.
-- `FAILED`면 기본 추천 이유를 유지한 채 화면을 표시할 수 있습니다.
+- `status=PENDING`이면 기본 추천 이유를 먼저 표시합니다.
+- 동일한 `GET /api/v1/recommendations` API를 polling 하여 `COMPLETED` 또는 `FAILED`를 확인합니다.
+- 현재 프론트는 `1.5초` 간격, 최대 `5회` polling 합니다.
+- `FAILED`면 기본 추천 이유를 유지합니다.
 
-현재 프론트 구현 기준:
+## 운영 주의사항
 
-- 추천 화면은 `PENDING` 응답을 받으면 기본 추천 이유를 먼저 노출합니다.
-- 이후 동일 API를 `1.5초` 간격으로 다시 호출합니다.
-- polling은 최대 `5회`까지 시도합니다.
-- 그 안에 `COMPLETED`가 오면 GPT 추천 이유로 화면을 갱신합니다.
-- `FAILED`면 기본 추천 이유를 유지하고 상태 안내 문구를 노출합니다.
-
----
-
-## 설정 및 실행 포인트
-
-### 주요 설정
-
-| 항목 | 값 |
-|------|----|
-| 서비스 포트 | `9009` |
-| 프로파일 | `SPRING_PROFILES_ACTIVE` |
-| Kafka 주소 | `KAFKA_BOOTSTRAP_SERVERS` |
-| OpenAI 키 | `OPENAI_API_KEY` |
-| OpenAI connect timeout | `openai.http.connect-timeout` |
-| OpenAI read timeout | `openai.http.read-timeout` |
-
-`application-prod.yml` 기준:
-
-- PostgreSQL datasource 사용
-- `spring.jpa.hibernate.ddl-auto=validate`
-- 운영에서는 스키마를 애플리케이션이 자동 생성하지 않음
-
-### 의존 인프라
-
-- PostgreSQL
-- Redis
-- Kafka
-- OpenAI API
-- PostgreSQL `pgvector` 확장
-
----
-
-## 데이터 및 운영 주의사항
-
-### 스키마 관련
-
-- `product_embeddings.embedding`은 `vector(768)` 컬럼이어야 합니다.
-- OpenAI 임베딩 차원 수와 DB vector 차원 수가 반드시 일치해야 합니다.
-- `user_activities.created_at`은 null이면 안 됩니다.
-- `product_embeddings.status` 값은 추천 대상 필터 조건(`ENABLE`)과 일치해야 합니다.
-
-### 운영 관련
-
-- 사용자 활동이 추가로 적재돼도 기존 사용자 벡터 캐시는 즉시 무효화되지 않습니다.
-- 현재 코드상 `UserVectorRedisRepository.delete()`는 구현돼 있지만 이벤트 기반 무효화 로직은 연결되어 있지 않습니다.
-- 추천 이유 생성은 OpenAI 응답이 JSON 형식을 지켜야 하므로 프롬프트/모델 변경 시 파싱 안정성을 함께 점검해야 합니다.
-- 추천 API 첫 응답은 `PENDING`일 수 있으므로 클라이언트는 polling을 고려해야 합니다.
-- 추천 이유 생성은 비동기 executor에서 동작하므로 OpenAI 장애 시에도 추천 API 자체는 기본 추천 결과를 반환합니다.
-- 비동기 추천 이유 생성 작업이 스레드 풀 포화로 제출되지 못하면, 추천 상태는 `PENDING`으로 유지되지 않고 즉시 `FAILED`로 갱신됩니다.
-- Kafka 문서(`docs/kafka-topics.md`)에는 현재 `ai` 서비스가 소비하는 `PRODUCT_AI_SYNCED`, `PRODUCT_DELETED`, `PRODUCT_VIEWED` 이벤트가 아직 반영되지 않았습니다.
-
----
-
-## 구현 체크리스트
-
-### 추천 기능
-
-- [x] 추천 조회 API 구현
-- [x] 추천 결과 Redis 캐시 구현
-- [x] 후보 검색 pgvector 쿼리 구현
-- [x] 인기 상품 fallback 추천 구현
-- [x] OpenAI 추천 이유 생성 구현
-- [x] 추천 이유 생성 비동기화
-- [x] OpenAI timeout 적용
-
-### 데이터 파이프라인
-
-- [x] 상품 임베딩 생성 및 upsert 구현
-- [x] 상품 삭제 시 임베딩 삭제 구현
-- [x] 상품 조회 이벤트 기반 사용자 행동 저장 구현
-- [x] 사용자 활동 기반 벡터 생성 구현
-- [x] Kafka 재시도 및 DLQ 처리 구현
-
-### 운영 정비 포인트
-
-- [ ] `product.events` 이벤트 문서를 현재 구현 기준으로 갱신
-- [ ] 사용자 행동 누적 시 사용자 벡터 캐시 무효화 전략 추가
-- [ ] 운영 DB에 `pgvector` 확장 및 관련 인덱스 전략 정리
+- recommendation snapshot은 polling 동안 같은 추천 세트를 유지하기 위한 용도입니다.
+- 행동 이벤트가 들어오면 해당 유저 snapshot을 즉시 삭제합니다.
+- 상품 임베딩이 바뀌면 전체 user profile / recommendation snapshot을 삭제합니다.
+- Redis key 버전은 현재 `v2`입니다.
+- `LocalDateTime`은 Redis에 ISO 문자열로 저장합니다.

--- a/docs/ai/recommendation-logic.md
+++ b/docs/ai/recommendation-logic.md
@@ -4,29 +4,30 @@
 
 ```mermaid
 flowchart TD
-    A["GET /api/v1/recommendations"] --> B{"추천 캐시 있음?"}
-    B -- 예 --> C["캐시 응답 반환<br/>PENDING / COMPLETED / FAILED"]
-    B -- 아니오 --> D{"사용자 벡터 캐시 있음?"}
-    D -- 예 --> E["벡터 사용"]
-    D -- 아니오 --> F["행동 로그 조회"]
-    F --> G["사용자 벡터 생성"]
-    G --> H["벡터 캐시 저장"]
-    H --> E
-    E --> I["pgvector 후보 5개 조회"]
-    I --> J{"후보 있음?"}
-    J -- 아니오 --> K["인기 상품 fallback 반환"]
-    J -- 예 --> L["기본 추천 이유로 PENDING 응답 생성"]
-    L --> M["추천 캐시 저장"]
-    M --> N["즉시 응답 반환"]
-    M -. async .-> O["OpenAI 추천 이유 생성"]
-    O --> P{"생성 성공?"}
-    P -- 예 --> Q["COMPLETED로 캐시 갱신"]
-    P -- 아니오 --> R["FAILED로 캐시 갱신"]
+    A["조회/찜/주문 이벤트 수신"] --> B["user_activities 저장"]
+    B --> C["recommendation snapshot 삭제"]
+    C --> D["userVector / exclude 증분 업데이트"]
+
+    E["GET /api/v1/recommendations"] --> F{"snapshot cache 있음?"}
+    F -- 예 --> G["캐시 응답 반환<br/>PENDING / COMPLETED / FAILED"]
+    F -- 아니오 --> H{"user profile / exclude cache 있음?"}
+    H -- 예 --> I["Redis 상태 사용"]
+    H -- 아니오 --> J["user_activities 조회"]
+    J --> K["userVector / exclude full rebuild"]
+    K --> I
+    I --> L["pgvector 후보 5개 조회<br/>조회/찜/주문 상품 제외"]
+    L --> M{"후보 있음?"}
+    M -- 아니오 --> N["인기 상품 fallback 반환<br/>COMPLETED"]
+    M -- 예 --> O["기본 추천 이유로 PENDING 응답 생성"]
+    O --> P["snapshot cache 저장"]
+    P --> Q["즉시 응답 반환"]
+    P -. async .-> R["OpenAI 추천 이유 생성"]
+    R --> S{"생성 성공?"}
+    S -- 예 --> T["COMPLETED로 snapshot 갱신"]
+    S -- 아니오 --> U["FAILED로 snapshot 갱신"]
 ```
 
 ## 2-Phase 흐름
-
-### 시퀀스 다이어그램
 
 ```mermaid
 sequenceDiagram
@@ -34,7 +35,7 @@ sequenceDiagram
     participant Client
     participant Controller as RecommendationController
     participant Service as RecommendationService
-    participant Redis as RecommendationRedisRepository
+    participant Snapshot as RecommendationRedisRepository
     participant Vector as UserVectorService
     participant Search as CandidateSearchRepository
     participant Async as RecommendationReasonAsyncService
@@ -42,23 +43,23 @@ sequenceDiagram
 
     Client->>Controller: GET /api/v1/recommendations
     Controller->>Service: recommend(userId)
-    Service->>Redis: get(userId)
+    Service->>Snapshot: get(userId)
 
-    alt 캐시 존재
-        Redis-->>Service: cached response
+    alt snapshot 존재
+        Snapshot-->>Service: cached response
         Service-->>Controller: cached response
         Controller-->>Client: 200 OK
-    else 캐시 없음
-        Service->>Vector: getOrCreate(userId)
-        Vector-->>Service: userVector
-        Service->>Search: findTopK(userVector, 5)
+    else snapshot 없음
+        Service->>Vector: getOrCreateState(userId)
+        Vector-->>Service: userVector + excludedProductIds
+        Service->>Search: findTopK(userVector, excludedProductIds, 5)
         Search-->>Service: candidates
 
         alt 후보 없음
             Service-->>Controller: fallback response (COMPLETED)
             Controller-->>Client: 200 OK
         else 후보 있음
-            Service->>Redis: save(PENDING + 기본 추천 이유)
+            Service->>Snapshot: save(PENDING + 기본 추천 이유)
             Service->>Async: generateAndCache(userId, userVector, candidates)
             Service-->>Controller: PENDING response
             Controller-->>Client: 200 OK
@@ -67,15 +68,15 @@ sequenceDiagram
                 Async->>OpenAI: generateRecommendationReasons(...)
                 alt 성공
                     OpenAI-->>Async: reasonMap
-                    Async->>Redis: save(COMPLETED + GPT 추천 이유)
+                    Async->>Snapshot: save(COMPLETED + GPT 추천 이유)
                 else 실패 / timeout / 파싱 오류
-                    Async->>Redis: save(FAILED + 기본 추천 이유)
+                    Async->>Snapshot: save(FAILED + 기본 추천 이유)
                 end
             and polling
                 Client->>Controller: GET /api/v1/recommendations
                 Controller->>Service: recommend(userId)
-                Service->>Redis: get(userId)
-                Redis-->>Service: PENDING / COMPLETED / FAILED
+                Service->>Snapshot: get(userId)
+                Snapshot-->>Service: PENDING / COMPLETED / FAILED
                 Service-->>Controller: cached response
                 Controller-->>Client: 200 OK
             end
@@ -83,38 +84,44 @@ sequenceDiagram
     end
 ```
 
-### 빠른 요약
-
-| Phase | 동작 |
-|------|------|
-| Phase 1 | 후보를 계산하고 기본 추천 이유로 `PENDING` 응답을 즉시 반환 |
-| Phase 2 | OpenAI 추천 이유 생성을 비동기로 수행하고 캐시를 `COMPLETED` 또는 `FAILED`로 갱신 |
-
 ## 구현 요약
 
 | 항목 | 현재 구현 |
 |------|-----------|
 | 추천 개수 | 5개 |
-| 추천 캐시 TTL | 20분 |
-| 사용자 벡터 TTL | 1시간 |
+| recommendation snapshot TTL | 20분 |
+| user profile / exclude TTL | 6시간 |
+| user profile version | 2 |
 | 벡터 차원 | 768 |
-| 행동 가중치 | `VIEW=1.0`, `WISHLIST=2.0`, `ORDER=3.0` |
+| 행동 가중치 | `VIEW=1.0`, `WISHLIST=3.0`, `ORDER=5.0` |
 | 최근성 기준 | 반감기 14일 |
-| VIEW 제한 | 같은 상품 최신 3회까지만 반영 |
+| VIEW 제외 여부 | 제외함 |
 | 응답 상태 | `PENDING`, `COMPLETED`, `FAILED` |
 | fallback | 인기 상품 추천 |
 
 ## 1. 캐시 동작
 
-- 추천 결과 캐시: Redis 20분
-- 사용자 벡터 캐시: Redis 1시간
-- 추천 캐시가 있으면 그대로 반환합니다.
-- 캐시 값은 `PENDING`, `COMPLETED`, `FAILED` 중 하나입니다.
-- 추천 캐시가 없으면 사용자 벡터를 조회하고, 그것도 없을 때만 새로 계산합니다.
+- recommendation snapshot 캐시: Redis 20분
+- user profile / exclude 캐시: Redis 6시간
+- 추천 API는 snapshot 캐시가 있으면 그 값을 그대로 반환합니다.
+- snapshot 캐시는 polling 동안 같은 추천 세트를 유지하기 위한 용도입니다.
+- snapshot 캐시가 없으면 user profile / exclude 캐시를 조회합니다.
+- user profile 또는 exclude 캐시가 없거나 버전이 다르면 `user_activities` 기준으로 full rebuild 합니다.
 
-## 2. 사용자 벡터 생성
+## 2. 사용자 벡터 생성 및 갱신
 
-사용자 벡터는 `user_activities` 행동 로그와 상품 임베딩을 합쳐 만듭니다.
+사용자 벡터는 아래 두 방식으로 유지됩니다.
+
+1. 이벤트 수신 시 증분 업데이트
+2. 캐시 miss 또는 버전 불일치 시 full rebuild
+
+```text
+user_vector = normalize(
+  decay(previous_user_vector) + (product_embedding * action_weight)
+)
+```
+
+full rebuild 시에는 전체 행동 로그 기준으로 아래 수식을 사용합니다.
 
 ```text
 user_vector = normalize(
@@ -122,87 +129,55 @@ user_vector = normalize(
 )
 ```
 
-### 반영 규칙
+반영 규칙:
 
 - `VIEW = 1.0`
-- `WISHLIST = 2.0`
-- `ORDER = 3.0`
+- `WISHLIST = 3.0`
+- `ORDER = 5.0`
 - 최근 행동일수록 더 크게 반영합니다.
 - 반감기는 14일입니다.
-- 오래된 `WISHLIST`, `ORDER`도 완전히 제외되지는 않고 점점 약하게 반영됩니다.
-- 같은 상품의 `VIEW`는 최신 3회까지만 반영합니다.
-- `WISHLIST`, `ORDER`는 이 횟수 제한을 받지 않습니다.
 - 상품 임베딩이 없거나 길이가 768이 아니면 그 행동은 건너뜁니다.
 - 마지막에 L2 정규화합니다.
 
-### 행동 반영 이미지
+## 3. 제외 상품 정책
 
-```mermaid
-flowchart LR
-    A["UserActivity"] --> B{"ActionType"}
-    B -->|VIEW| C["기본 가중치 1.0"]
-    B -->|WISHLIST| D["기본 가중치 2.0"]
-    B -->|ORDER| E["기본 가중치 3.0"]
-    C --> F["최근성 가중치 곱셈"]
-    D --> F
-    E --> F
-    F --> G["상품 임베딩에 누적"]
-    G --> H["최종 L2 정규화"]
-```
+- `VIEW`, `WISHLIST`, `ORDER` 모두 추천 후보에서 제외합니다.
+- 제외 상품 ID는 Redis `user:exclude:v2:{userId}`에 저장합니다.
+- full rebuild 시에도 `user_activities` 전체에서 다시 구성합니다.
 
-## 3. 후보 검색
+## 4. 후보 검색
 
 - 테이블: `product_embeddings`
 - 대상 조건: `status = 'ENABLE'`
 - 방식: pgvector 코사인 유사도 Top-K 검색
 - 개수: 5개
+- 제외 조건: Redis exclude set에 포함된 상품 ID는 `NOT IN (...)`으로 제거
 
-```sql
-SELECT id, title, description, price, road_address
-FROM product_embeddings
-WHERE status = 'ENABLE'
-ORDER BY embedding <=> (?::vector)
-LIMIT 5
-```
+## 5. 추천 이유 생성
 
-## 4. 추천 이유 생성
-
-- 후보가 잡히면 기본 추천 이유로 먼저 응답합니다.
+- 후보가 잡히면 기본 추천 이유로 먼저 `PENDING` 응답을 반환합니다.
 - OpenAI 추천 이유 생성은 `RecommendationReasonAsyncService`에서 비동기로 수행합니다.
-- 성공 시 캐시를 `COMPLETED`로 갱신합니다.
+- 성공 시 snapshot을 `COMPLETED`로 갱신합니다.
 - timeout, 5xx, 파싱 실패가 나면 기본 추천 이유를 유지한 채 `FAILED`로 갱신합니다.
-- 비동기 작업 제출 자체가 거절되면 캐시를 즉시 `FAILED`로 갱신해, 클라이언트가 `PENDING` 상태를 계속 polling 하지 않도록 합니다.
+- 비동기 작업 제출 자체가 거절되면 snapshot을 즉시 `FAILED`로 갱신합니다.
 
-## 5. fallback 추천
+## 6. fallback 추천
 
 - 개인화 후보가 없으면 인기 상품 추천으로 대체합니다.
 - 조건: `status = 'ENABLE'` 그리고 `popularity > 0`
 - 정렬: `popularity DESC`
 - fallback 응답 상태는 `COMPLETED`입니다.
 
-## 6. OpenAI 호출 보호
-
-- `RestTemplate`에 connect/read timeout을 설정합니다.
-- 추천 이유 생성은 전용 async executor에서 수행합니다.
-- 요청 스레드는 OpenAI 응답을 기다리지 않습니다.
-
 ## 7. 행동 로그와 캐시 무효화
 
-### 이벤트 -> 행동 타입
+이벤트 -> 행동 타입:
 
 - `PRODUCT_VIEWED` -> `VIEW`
 - `PRODUCT_WISHLISTED` -> `WISHLIST`
 - `ORDER_COMPLETED` -> `ORDER`
 
-### 캐시 정책
+캐시 정책:
 
-- `WISHLIST`, `ORDER`는 사용자 벡터 캐시와 추천 캐시를 즉시 무효화합니다.
-- `VIEW`는 발생 빈도가 높아서 즉시 무효화하지 않고 TTL 만료에 맡깁니다.
-
-```mermaid
-flowchart LR
-    A["행동 로그 적재"] --> B{"행동 타입"}
-    B -->|VIEW| C["캐시 유지"]
-    B -->|WISHLIST| D["벡터/추천 캐시 삭제"]
-    B -->|ORDER| E["벡터/추천 캐시 삭제"]
-```
+- 모든 행동 이벤트는 해당 유저의 recommendation snapshot을 즉시 삭제합니다.
+- 모든 행동 이벤트는 userVector / exclude를 즉시 증분 업데이트합니다.
+- 상품 임베딩이 바뀌면 모든 user profile과 recommendation snapshot을 삭제합니다.

--- a/docs/ai/recommendation-logic.md
+++ b/docs/ai/recommendation-logic.md
@@ -15,7 +15,7 @@ flowchart TD
     H -- 아니오 --> J["user_activities 조회"]
     J --> K["userVector / exclude full rebuild"]
     K --> I
-    I --> L["pgvector 후보 5개 조회<br/>조회/찜/주문 상품 제외"]
+    I --> L["pgvector 후보 5개 조회<br/>찜/주문 상품 제외"]
     L --> M{"후보 있음?"}
     M -- 아니오 --> N["인기 상품 fallback 반환<br/>COMPLETED"]
     M -- 예 --> O["기본 추천 이유로 PENDING 응답 생성"]
@@ -95,7 +95,7 @@ sequenceDiagram
 | 벡터 차원 | 768 |
 | 행동 가중치 | `VIEW=1.0`, `WISHLIST=3.0`, `ORDER=5.0` |
 | 최근성 기준 | 반감기 14일 |
-| VIEW 제외 여부 | 제외함 |
+| VIEW 제외 여부 | 제외하지 않음 |
 | 응답 상태 | `PENDING`, `COMPLETED`, `FAILED` |
 | fallback | 인기 상품 추천 |
 
@@ -141,7 +141,8 @@ user_vector = normalize(
 
 ## 3. 제외 상품 정책
 
-- `VIEW`, `WISHLIST`, `ORDER` 모두 추천 후보에서 제외합니다.
+- `VIEW`는 추천 후보에서 제외하지 않습니다.
+- `WISHLIST`, `ORDER`만 추천 후보에서 제외합니다.
 - 제외 상품 ID는 Redis `user:exclude:v2:{userId}`에 저장합니다.
 - full rebuild 시에도 `user_activities` 전체에서 다시 구성합니다.
 

--- a/service/ai/src/main/java/jabaclass/ai/application/service/ProductEmbeddingSyncService.java
+++ b/service/ai/src/main/java/jabaclass/ai/application/service/ProductEmbeddingSyncService.java
@@ -7,17 +7,22 @@ import org.springframework.transaction.annotation.Transactional;
 
 import jabaclass.ai.domain.repository.ProductEmbeddingRepository;
 import jabaclass.ai.domain.repository.RecommendationCacheRepository;
+import jabaclass.ai.domain.repository.UserVectorCacheRepository;
 import jabaclass.ai.infrastructure.external.openai.EmbeddingService;
 import jabaclass.ai.infrastructure.kafka.ProductAiSyncedEvent;
 import jabaclass.ai.infrastructure.persistence.command.ProductEmbeddingUpsertCommand;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 상품 정보를 OpenAI 임베딩으로 바꿔 product_embeddings에 저장/갱신하는 서비스
+ */
 @Service
 @RequiredArgsConstructor
 public class ProductEmbeddingSyncService {
 
 	private final EmbeddingService embeddingService;
 	private final ProductEmbeddingRepository productEmbeddingRepository;
+	private final UserVectorCacheRepository userVectorCacheRepository;
 	private final RecommendationCacheRepository recommendationCacheRepository;
 
 	@Transactional
@@ -40,12 +45,14 @@ public class ProductEmbeddingSyncService {
 				embedding
 			)
 		);
+		userVectorCacheRepository.deleteAllProfiles();
 		recommendationCacheRepository.deleteAll();
 	}
 
 	@Transactional
 	public void delete(UUID productId) {
 		productEmbeddingRepository.deleteByProductId(productId);
+		userVectorCacheRepository.deleteAllProfiles();
 		recommendationCacheRepository.deleteAll();
 	}
 }

--- a/service/ai/src/main/java/jabaclass/ai/application/service/ProductEmbeddingSyncService.java
+++ b/service/ai/src/main/java/jabaclass/ai/application/service/ProductEmbeddingSyncService.java
@@ -4,6 +4,8 @@ import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import jabaclass.ai.domain.repository.ProductEmbeddingRepository;
 import jabaclass.ai.domain.repository.RecommendationCacheRepository;
@@ -45,14 +47,31 @@ public class ProductEmbeddingSyncService {
 				embedding
 			)
 		);
-		userVectorCacheRepository.deleteAllProfiles();
-		recommendationCacheRepository.deleteAll();
+		invalidateRecommendationCachesAfterCommit();
 	}
 
 	@Transactional
 	public void delete(UUID productId) {
 		productEmbeddingRepository.deleteByProductId(productId);
-		userVectorCacheRepository.deleteAllProfiles();
-		recommendationCacheRepository.deleteAll();
+		invalidateRecommendationCachesAfterCommit();
+	}
+
+	private void invalidateRecommendationCachesAfterCommit() {
+		Runnable invalidateTask = () -> {
+			userVectorCacheRepository.deleteAllProfiles();
+			recommendationCacheRepository.deleteAll();
+		};
+
+		if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+			invalidateTask.run();
+			return;
+		}
+
+		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+			@Override
+			public void afterCommit() {
+				invalidateTask.run();
+			}
+		});
 	}
 }

--- a/service/ai/src/main/java/jabaclass/ai/application/service/RecommendationReasonAsyncService.java
+++ b/service/ai/src/main/java/jabaclass/ai/application/service/RecommendationReasonAsyncService.java
@@ -19,10 +19,12 @@ import jabaclass.ai.presentation.dto.response.RecommendationResponseDto;
 import jabaclass.ai.presentation.dto.response.RecommendationStatus;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * 추천 이유를 비동기로 만드는 서비스
+ */
 @Service
 @Slf4j
 public class RecommendationReasonAsyncService {
-
 	private static final String DEFAULT_REASON = "사용자 취향과 유사한 클래스입니다.";
 
 	private final AiGatewayPort aiGatewayPort;
@@ -59,7 +61,6 @@ public class RecommendationReasonAsyncService {
 					reasonMap.getOrDefault(candidate.productId(), DEFAULT_REASON)
 				))
 				.toList();
-
 			recommendationCacheRepository.save(
 				userId,
 				new RecommendationResponseDto(RecommendationStatus.COMPLETED, items)
@@ -74,7 +75,6 @@ public class RecommendationReasonAsyncService {
 					DEFAULT_REASON
 				))
 				.toList();
-
 			recommendationCacheRepository.save(
 				userId,
 				new RecommendationResponseDto(RecommendationStatus.FAILED, fallbackItems)

--- a/service/ai/src/main/java/jabaclass/ai/application/service/RecommendationService.java
+++ b/service/ai/src/main/java/jabaclass/ai/application/service/RecommendationService.java
@@ -1,111 +1,102 @@
 package jabaclass.ai.application.service;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
-import org.springframework.stereotype.Service;
 import org.springframework.core.task.TaskRejectedException;
+import org.springframework.stereotype.Service;
 
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import jabaclass.ai.application.dto.CandidateClassDto;
 import jabaclass.ai.application.usecase.RecommendationUseCase;
+import jabaclass.ai.domain.model.UserPreferenceState;
 import jabaclass.ai.domain.model.UserVector;
 import jabaclass.ai.domain.repository.CandidateSearchRepository;
 import jabaclass.ai.domain.repository.RecommendationCacheRepository;
 import jabaclass.ai.presentation.dto.response.RecommendationItemDto;
 import jabaclass.ai.presentation.dto.response.RecommendationResponseDto;
 import jabaclass.ai.presentation.dto.response.RecommendationStatus;
+import lombok.extern.slf4j.Slf4j;
 
-/*1. 캐시 조회
-2. 사용자 벡터 조회
-3. 후보 클래스 조회
-4. GPT 호출
-5. 캐싱
-6. 응답 반환*/
+/**
+ * 메인 서비스
+ */
 @Service
+@Slf4j
 public class RecommendationService implements RecommendationUseCase {
 	private static final int RECOMMENDATION_COUNT = 5;
 	private static final String DEFAULT_REASON = "사용자 취향과 유사한 클래스입니다.";
 
-	private final RecommendationCacheRepository recommendationCacheRepository;
 	private final UserVectorService userVectorService;
 	private final CandidateSearchRepository candidateSearchRepository;
 	private final RecommendationReasonAsyncService recommendationReasonAsyncService;
-	private final Counter recommendationCacheHitCounter;
-	private final Counter recommendationCacheMissCounter;
+	private final RecommendationCacheRepository recommendationCacheRepository;
 
 	public RecommendationService(
-		RecommendationCacheRepository recommendationCacheRepository,
 		UserVectorService userVectorService,
 		CandidateSearchRepository candidateSearchRepository,
 		RecommendationReasonAsyncService recommendationReasonAsyncService,
-		MeterRegistry meterRegistry
+		RecommendationCacheRepository recommendationCacheRepository
 	) {
-		this.recommendationCacheRepository = recommendationCacheRepository;
 		this.userVectorService = userVectorService;
 		this.candidateSearchRepository = candidateSearchRepository;
 		this.recommendationReasonAsyncService = recommendationReasonAsyncService;
-		this.recommendationCacheHitCounter = meterRegistry.counter("ai.recommendation.cache.hit");
-		this.recommendationCacheMissCounter = meterRegistry.counter("ai.recommendation.cache.miss");
+		this.recommendationCacheRepository = recommendationCacheRepository;
 	}
 
+	@Override
 	public RecommendationResponseDto recommend(UUID userId) {
-		// 1. 캐시 조회
 		RecommendationResponseDto cached = recommendationCacheRepository.get(userId);
 		if (cached != null) {
-			recommendationCacheHitCounter.increment();
 			return cached;
 		}
-		recommendationCacheMissCounter.increment();
 
-		// 2. 사용자 벡터 조회 (없으면 생성)
-		UserVector userVector = userVectorService.getOrCreate(userId);
+		UserPreferenceState state = userVectorService.getOrCreateState(userId);
+		UserVector userVector = state.userVector();
+		Set<UUID> excludedProductIds = state.excludedProductIds();
 
-		// 3. 후보 조회
-		List<CandidateClassDto> candidates = candidateSearchRepository.findTopK(userVector, RECOMMENDATION_COUNT);
+		List<CandidateClassDto> candidates = candidateSearchRepository.findTopK(
+			userVector,
+			excludedProductIds,
+			RECOMMENDATION_COUNT
+		);
 		if (candidates == null || candidates.isEmpty()) {
-			return createFallback(userId);
+			return createFallback(excludedProductIds);
 		}
 
-		List<RecommendationItemDto> items = candidates.stream()
-			.map(c -> new RecommendationItemDto(
-				c.productId(),
-				c.title(),
-				DEFAULT_REASON
-			))
-			.toList();
-		RecommendationResponseDto response = new RecommendationResponseDto(
-			RecommendationStatus.PENDING,
-			items
-		);
-
-		// 4. 기본 추천 결과를 먼저 캐시에 저장
-		recommendationCacheRepository.save(userId, response);
-
-		// 5. 추천 이유 생성은 비동기로 수행
+		RecommendationResponseDto pendingResponse = buildResponse(RecommendationStatus.PENDING, candidates);
+		recommendationCacheRepository.save(userId, pendingResponse);
 		try {
 			recommendationReasonAsyncService.generateAndCache(userId, userVector, candidates);
 		} catch (TaskRejectedException e) {
-			RecommendationResponseDto failedResponse = new RecommendationResponseDto(
-				RecommendationStatus.FAILED,
-				items
-			);
+			log.warn("추천 이유 비동기 작업 등록 실패. 기본 사유로 응답합니다.", e);
+			RecommendationResponseDto failedResponse = buildResponse(RecommendationStatus.FAILED, candidates);
 			recommendationCacheRepository.save(userId, failedResponse);
 			return failedResponse;
 		}
 
-		// 6. 즉시 반환
-		return response;
+		return pendingResponse;
 	}
 
-	private RecommendationResponseDto createFallback(UUID userId) {
-		List<CandidateClassDto> popular = candidateSearchRepository.findPopular(RECOMMENDATION_COUNT);
+	private RecommendationResponseDto buildResponse(RecommendationStatus status, List<CandidateClassDto> candidates) {
+		List<RecommendationItemDto> items = candidates.stream()
+			.map(candidate -> new RecommendationItemDto(
+				candidate.productId(),
+				candidate.title(),
+				DEFAULT_REASON
+			))
+			.toList();
+
+		return new RecommendationResponseDto(status, items);
+	}
+
+	private RecommendationResponseDto createFallback(Set<UUID> excludedProductIds) {
+		List<CandidateClassDto> popular = candidateSearchRepository.findPopular(excludedProductIds, RECOMMENDATION_COUNT);
 
 		List<RecommendationItemDto> items = popular.stream()
-			.map(p -> new RecommendationItemDto(
-				p.productId(),
-				p.title(),
+			.map(popularItem -> new RecommendationItemDto(
+				popularItem.productId(),
+				popularItem.title(),
 				"현재 인기 있는 클래스입니다."
 			))
 			.toList();

--- a/service/ai/src/main/java/jabaclass/ai/application/service/UserActivityService.java
+++ b/service/ai/src/main/java/jabaclass/ai/application/service/UserActivityService.java
@@ -1,5 +1,7 @@
 package jabaclass.ai.application.service;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -7,30 +9,36 @@ import jabaclass.ai.domain.model.ActionType;
 import jabaclass.ai.domain.model.UserActivity;
 import jabaclass.ai.domain.repository.RecommendationCacheRepository;
 import jabaclass.ai.domain.repository.UserActivityRepository;
-import jabaclass.ai.domain.repository.UserVectorCacheRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+/**
+ * 사용자의 조회/찜/주문 행동 로그를 저장하는 서비스
+ */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserActivityService {
 
 	private final UserActivityRepository userActivityRepository;
-	private final UserVectorCacheRepository userVectorCacheRepository;
+	private final UserVectorService userVectorService;
 	private final RecommendationCacheRepository recommendationCacheRepository;
 
 	@Transactional
-	public void recordActivity(java.util.UUID userId, java.util.UUID productId, ActionType actionType) {
+	public void recordActivity(UUID userId, UUID productId, ActionType actionType) {
 		userActivityRepository.save(UserActivity.create(userId, productId, actionType));
-		if (shouldInvalidateRecommendationCache(actionType)) {
-			userVectorCacheRepository.delete(userId);
-			recommendationCacheRepository.delete(userId);
-		}
-	}
+		recommendationCacheRepository.delete(userId);
 
-	private boolean shouldInvalidateRecommendationCache(ActionType actionType) {
-		return switch (actionType) {
-			case WISHLIST, ORDER -> true;
-			case VIEW -> false;
-		};
+		try {
+			userVectorService.updateOnActivity(userId, productId, actionType);
+		} catch (RuntimeException e) {
+			log.warn(
+				"userVector 증분 업데이트 실패. userId={}, productId={}, actionType={}",
+				userId,
+				productId,
+				actionType,
+				e
+			);
+		}
 	}
 }

--- a/service/ai/src/main/java/jabaclass/ai/application/service/UserVectorService.java
+++ b/service/ai/src/main/java/jabaclass/ai/application/service/UserVectorService.java
@@ -2,9 +2,7 @@ package jabaclass.ai.application.service;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -15,103 +13,141 @@ import org.springframework.stereotype.Service;
 
 import jabaclass.ai.domain.model.ActionType;
 import jabaclass.ai.domain.model.UserActivity;
+import jabaclass.ai.domain.model.UserPreferenceState;
 import jabaclass.ai.domain.model.UserVector;
+import jabaclass.ai.domain.model.UserVectorProfile;
 import jabaclass.ai.domain.repository.ProductEmbeddingRepository;
 import jabaclass.ai.domain.repository.UserActivityRepository;
 import jabaclass.ai.domain.repository.UserVectorCacheRepository;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 사용자 벡터 계산,관리하는 서비스
+ */
 @Service
 @RequiredArgsConstructor
 public class UserVectorService {
 
+	private static final int CACHE_VERSION = 2;
 	private static final int VECTOR_SIZE = 768;
-	private static final int MAX_VIEW_CONTRIBUTIONS_PER_PRODUCT = 3;
 	private static final double RECENCY_HALF_LIFE_DAYS = 14.0;
 
 	private final UserActivityRepository userActivityRepository;
 	private final UserVectorCacheRepository userVectorCacheRepository;
 	private final ProductEmbeddingRepository productEmbeddingRepository;
 
-	// Redis에 있으면 가져오고 없으면 생성
-	public UserVector getOrCreate(UUID userId) {
-		UserVector cached = userVectorCacheRepository.get(userId);
-		if (cached != null && !cached.isEmpty()) {
-			return cached;
+	public UserPreferenceState getOrCreateState(UUID userId) {
+		UserVectorProfile cachedProfile = userVectorCacheRepository.getProfile(userId);
+		Set<UUID> excludedProductIds = userVectorCacheRepository.getExcludedProductIds(userId);
+
+		if (isCacheUsable(cachedProfile, excludedProductIds)) {
+			return new UserPreferenceState(cachedProfile.userVector(), excludedProductIds);
 		}
 
-		UserVector created = generate(userId);
-		userVectorCacheRepository.save(userId, created);
-
-		return created;
+		return rebuildState(userId);
 	}
 
-	// UserActivity 기반 벡터 생성
-	public UserVector generate(UUID userId) {
-		List<UserActivity> activities = userActivityRepository.findByUserId(userId);
-		activities = activities.stream()
-			.sorted(Comparator.comparing(UserActivity::getCreatedAt).reversed())
-			.toList();
-
-		float[] vector = new float[VECTOR_SIZE];
-		Map<UUID, Integer> viewContributionCounts = new HashMap<>();
-		LocalDateTime now = LocalDateTime.now();
-		List<UserActivity> filteredActivities = new ArrayList<>();
-
-		for (UserActivity activity : activities) {
-			if (shouldSkipView(activity, viewContributionCounts)) {
-				continue;
-			}
-
-			filteredActivities.add(activity);
+	public void updateOnActivity(UUID userId, UUID productId, ActionType actionType) {
+		if (shouldExclude(actionType)) {
+			userVectorCacheRepository.addExcludedProductId(userId, productId);
 		}
 
-		Set<UUID> productIds = filteredActivities.stream()
+		UserVectorProfile cachedProfile = userVectorCacheRepository.getProfile(userId);
+		if (cachedProfile == null || cachedProfile.version() != CACHE_VERSION) {
+			rebuildState(userId);
+			return;
+		}
+
+		float[] embedding = productEmbeddingRepository.findAllByProductIds(Set.of(productId)).get(productId);
+		if (embedding == null || embedding.length != VECTOR_SIZE) {
+			return;
+		}
+
+		LocalDateTime now = LocalDateTime.now();
+		float[] updated = applyDecay(cachedProfile.userVector().vector(), cachedProfile.lastUpdatedAt(), now);
+		float weight = getWeight(actionType);
+		for (int i = 0; i < VECTOR_SIZE; i++) {
+			updated[i] += embedding[i] * weight;
+		}
+
+		userVectorCacheRepository.saveProfile(
+			userId,
+			new UserVectorProfile(new UserVector(normalize(updated)), now, CACHE_VERSION)
+		);
+	}
+
+	public UserVector generate(UUID userId) {
+		return generateFromActivities(sortActivities(userActivityRepository.findByUserId(userId)));
+	}
+
+	private UserPreferenceState rebuildState(UUID userId) {
+		List<UserActivity> activities = sortActivities(userActivityRepository.findByUserId(userId));
+		UserVector userVector = generateFromActivities(activities);
+		Set<UUID> excludedProductIds = activities.stream()
+			.filter(activity -> shouldExclude(activity.getActionType()))
+			.map(UserActivity::getProductId)
+			.collect(java.util.stream.Collectors.toUnmodifiableSet());
+
+		LocalDateTime lastUpdatedAt = activities.isEmpty()
+			? LocalDateTime.now()
+			: activities.get(0).getCreatedAt();
+
+		userVectorCacheRepository.saveProfile(
+			userId,
+			new UserVectorProfile(userVector, lastUpdatedAt, CACHE_VERSION)
+		);
+		userVectorCacheRepository.saveExcludedProductIds(userId, excludedProductIds);
+
+		return new UserPreferenceState(userVector, excludedProductIds);
+	}
+
+	private List<UserActivity> sortActivities(List<UserActivity> activities) {
+		return activities.stream()
+			.sorted(Comparator.comparing(UserActivity::getCreatedAt).reversed())
+			.toList();
+	}
+
+	private UserVector generateFromActivities(List<UserActivity> activities) {
+		float[] vector = new float[VECTOR_SIZE];
+		LocalDateTime now = LocalDateTime.now();
+
+		Set<UUID> productIds = activities.stream()
 			.map(UserActivity::getProductId)
 			.collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
 		Map<UUID, float[]> embeddingsByProductId = productEmbeddingRepository.findAllByProductIds(productIds);
 
-		for (UserActivity activity : filteredActivities) {
+		for (UserActivity activity : activities) {
 			float weight = getWeight(activity.getActionType()) * getRecencyWeight(activity.getCreatedAt(), now);
-
 			float[] itemVector = embeddingsByProductId.get(activity.getProductId());
 
-			// null 방어
 			if (itemVector == null || itemVector.length != VECTOR_SIZE) {
 				continue;
 			}
 
-			// 가중치 적용
 			for (int i = 0; i < VECTOR_SIZE; i++) {
 				vector[i] += itemVector[i] * weight;
 			}
 		}
 
-		// 정규화 (코사인 유사도 안정화)
 		return new UserVector(normalize(vector));
 	}
 
-	// 행동 가중치
+	private boolean isCacheUsable(UserVectorProfile cachedProfile, Set<UUID> excludedProductIds) {
+		return cachedProfile != null
+			&& cachedProfile.version() == CACHE_VERSION
+			&& excludedProductIds != null;
+	}
+
 	private float getWeight(ActionType actionType) {
 		return switch (actionType) {
 			case VIEW -> 1.0f;
-			case WISHLIST -> 2.0f;
-			case ORDER -> 3.0f;
+			case WISHLIST -> 3.0f;
+			case ORDER -> 5.0f;
 		};
 	}
 
-	private boolean shouldSkipView(UserActivity activity, Map<UUID, Integer> viewContributionCounts) {
-		if (activity.getActionType() != ActionType.VIEW) {
-			return false;
-		}
-
-		int count = viewContributionCounts.getOrDefault(activity.getProductId(), 0);
-		if (count >= MAX_VIEW_CONTRIBUTIONS_PER_PRODUCT) {
-			return true;
-		}
-
-		viewContributionCounts.put(activity.getProductId(), count + 1);
-		return false;
+	private boolean shouldExclude(ActionType actionType) {
+		return true;
 	}
 
 	private float getRecencyWeight(LocalDateTime createdAt, LocalDateTime now) {
@@ -120,23 +156,33 @@ public class UserVectorService {
 		return (float) Math.pow(0.5, ageHours / halfLifeHours);
 	}
 
-	// 벡터 정규화
+	private float[] applyDecay(float[] vector, LocalDateTime lastUpdatedAt, LocalDateTime now) {
+		float[] decayed = vector.clone();
+		if (lastUpdatedAt == null) {
+			return decayed;
+		}
+
+		float decayFactor = getRecencyWeight(lastUpdatedAt, now);
+		for (int i = 0; i < decayed.length; i++) {
+			decayed[i] *= decayFactor;
+		}
+		return decayed;
+	}
+
 	private float[] normalize(float[] vector) {
-
 		double norm = 0.0;
-
 		for (float v : vector) {
 			norm += v * v;
 		}
 
 		norm = Math.sqrt(norm);
-
-		if (norm == 0) return vector;
+		if (norm == 0) {
+			return vector;
+		}
 
 		for (int i = 0; i < vector.length; i++) {
 			vector[i] /= norm;
 		}
-
 		return vector;
 	}
 }

--- a/service/ai/src/main/java/jabaclass/ai/application/service/UserVectorService.java
+++ b/service/ai/src/main/java/jabaclass/ai/application/service/UserVectorService.java
@@ -147,7 +147,7 @@ public class UserVectorService {
 	}
 
 	private boolean shouldExclude(ActionType actionType) {
-		return true;
+		return actionType == ActionType.WISHLIST || actionType == ActionType.ORDER;
 	}
 
 	private float getRecencyWeight(LocalDateTime createdAt, LocalDateTime now) {

--- a/service/ai/src/main/java/jabaclass/ai/domain/model/UserPreferenceState.java
+++ b/service/ai/src/main/java/jabaclass/ai/domain/model/UserPreferenceState.java
@@ -1,0 +1,10 @@
+package jabaclass.ai.domain.model;
+
+import java.util.Set;
+import java.util.UUID;
+
+public record UserPreferenceState(
+	UserVector userVector,
+	Set<UUID> excludedProductIds
+) {
+}

--- a/service/ai/src/main/java/jabaclass/ai/domain/model/UserVectorProfile.java
+++ b/service/ai/src/main/java/jabaclass/ai/domain/model/UserVectorProfile.java
@@ -1,0 +1,10 @@
+package jabaclass.ai.domain.model;
+
+import java.time.LocalDateTime;
+
+public record UserVectorProfile(
+	UserVector userVector,
+	LocalDateTime lastUpdatedAt,
+	int version
+) {
+}

--- a/service/ai/src/main/java/jabaclass/ai/domain/repository/CandidateSearchRepository.java
+++ b/service/ai/src/main/java/jabaclass/ai/domain/repository/CandidateSearchRepository.java
@@ -1,13 +1,15 @@
 package jabaclass.ai.domain.repository;
 
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 import jabaclass.ai.application.dto.CandidateClassDto;
 import jabaclass.ai.domain.model.UserVector;
 
 public interface CandidateSearchRepository {
 
-	List<CandidateClassDto> findTopK(UserVector userVector, int k); // 사용자 벡터 기반으로 유사한 상품 Top-K 찾기
+	List<CandidateClassDto> findTopK(UserVector userVector, Set<UUID> excludedProductIds, int k); // 사용자 벡터 기반으로 유사한 상품 Top-K 찾기
 
-	List<CandidateClassDto> findPopular(int k); // fallback용
+	List<CandidateClassDto> findPopular(Set<UUID> excludedProductIds, int k); // fallback용
 }

--- a/service/ai/src/main/java/jabaclass/ai/domain/repository/RecommendationCacheRepository.java
+++ b/service/ai/src/main/java/jabaclass/ai/domain/repository/RecommendationCacheRepository.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 
 import jabaclass.ai.presentation.dto.response.RecommendationResponseDto;
 
-// 추천 결과를 Redis에 캐싱해서 빠르게 응답
 public interface RecommendationCacheRepository {
 
 	RecommendationResponseDto get(UUID userId);

--- a/service/ai/src/main/java/jabaclass/ai/domain/repository/UserVectorCacheRepository.java
+++ b/service/ai/src/main/java/jabaclass/ai/domain/repository/UserVectorCacheRepository.java
@@ -1,14 +1,28 @@
 package jabaclass.ai.domain.repository;
 
+import java.util.Set;
 import java.util.UUID;
 
 import jabaclass.ai.domain.model.UserVector;
+import jabaclass.ai.domain.model.UserVectorProfile;
 
 public interface UserVectorCacheRepository {
 
 	UserVector get(UUID userId);
 
+	UserVectorProfile getProfile(UUID userId);
+
 	void save(UUID userId, UserVector userVector);
 
-	void delete(UUID userId); // 캐시 무효화용
+	void saveProfile(UUID userId, UserVectorProfile profile);
+
+	Set<UUID> getExcludedProductIds(UUID userId);
+
+	void saveExcludedProductIds(UUID userId, Set<UUID> excludedProductIds);
+
+	void addExcludedProductId(UUID userId, UUID productId);
+
+	void delete(UUID userId); // 프로필 캐시 무효화용
+
+	void deleteAllProfiles();
 }

--- a/service/ai/src/main/java/jabaclass/ai/infrastructure/persistence/CandidateSearchRepositoryImpl.java
+++ b/service/ai/src/main/java/jabaclass/ai/infrastructure/persistence/CandidateSearchRepositoryImpl.java
@@ -1,6 +1,9 @@
 package jabaclass.ai.infrastructure.persistence;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -21,13 +24,14 @@ public class CandidateSearchRepositoryImpl implements CandidateSearchRepository 
 	private final JdbcTemplate jdbcTemplate;
 
 	@Override
-	public List<CandidateClassDto> findTopK(UserVector userVector, int k) {
+	public List<CandidateClassDto> findTopK(UserVector userVector, Set<UUID> excludedProductIds, int k) {
 
 		if (userVector == null || userVector.isEmpty()) {
 			return List.of();
 		}
 
 		String vector = toPgVector(userVector.vector());
+		String exclusionClause = buildExclusionClause(excludedProductIds);
 
 		String sql = """
             SELECT 
@@ -39,18 +43,21 @@ public class CandidateSearchRepositoryImpl implements CandidateSearchRepository 
             FROM product_embeddings
             WHERE status = 'ENABLE'
               AND embedding <=> (?::vector) <= ?
+        """ + exclusionClause + """
             ORDER BY embedding <=> (?::vector)  -- cosine distance (pgvector)
             LIMIT ?
         """;
 
+		List<Object> params = new ArrayList<>();
+		params.add(vector);
+		params.add(MAX_COSINE_DISTANCE);
+		addExcludedProductIds(params, excludedProductIds);
+		params.add(vector);
+		params.add(k);
+
 		return jdbcTemplate.query(
 			sql,
-			ps -> {
-				ps.setString(1, vector);
-				ps.setDouble(2, MAX_COSINE_DISTANCE);
-				ps.setString(3, vector);
-				ps.setInt(4, k);
-			},
+			params.toArray(),
 			(rs, rowNum) -> new CandidateClassDto(
 				rs.getObject("id", java.util.UUID.class),
 				rs.getString("title"),
@@ -62,7 +69,8 @@ public class CandidateSearchRepositoryImpl implements CandidateSearchRepository 
 	}
 
 	@Override
-	public List<CandidateClassDto> findPopular(int k) {
+	public List<CandidateClassDto> findPopular(Set<UUID> excludedProductIds, int k) {
+		String exclusionClause = buildExclusionClause(excludedProductIds);
 
 		String sql = """
             SELECT 
@@ -74,13 +82,18 @@ public class CandidateSearchRepositoryImpl implements CandidateSearchRepository 
             FROM product_embeddings
             WHERE status = 'ENABLE'
               AND COALESCE(popularity, 0) > 0
+        """ + exclusionClause + """
             ORDER BY popularity DESC
             LIMIT ?
         """;
 
+		List<Object> params = new ArrayList<>();
+		addExcludedProductIds(params, excludedProductIds);
+		params.add(k);
+
 		return jdbcTemplate.query(
 			sql,
-			ps -> ps.setInt(1, k),
+			params.toArray(),
 			(rs, rowNum) -> new CandidateClassDto(
 				rs.getObject("id", java.util.UUID.class),
 				rs.getString("title"),
@@ -89,6 +102,22 @@ public class CandidateSearchRepositoryImpl implements CandidateSearchRepository 
 				rs.getString("road_address")
 			)
 		);
+	}
+
+	private String buildExclusionClause(Set<UUID> excludedProductIds) {
+		if (excludedProductIds == null || excludedProductIds.isEmpty()) {
+			return "";
+		}
+
+		return "\n              AND id NOT IN (" + "?,".repeat(excludedProductIds.size() - 1) + "?" + ")";
+	}
+
+	private void addExcludedProductIds(List<Object> params, Set<UUID> excludedProductIds) {
+		if (excludedProductIds == null || excludedProductIds.isEmpty()) {
+			return;
+		}
+
+		params.addAll(excludedProductIds);
 	}
 
 	private String toPgVector(float[] vector) {

--- a/service/ai/src/main/java/jabaclass/ai/infrastructure/persistence/RecommendationRedisRepository.java
+++ b/service/ai/src/main/java/jabaclass/ai/infrastructure/persistence/RecommendationRedisRepository.java
@@ -10,17 +10,18 @@ import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import jabaclass.ai.domain.repository.RecommendationCacheRepository;
 import jabaclass.ai.presentation.dto.response.RecommendationResponseDto;
 import lombok.RequiredArgsConstructor;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Repository
 @RequiredArgsConstructor
 public class RecommendationRedisRepository implements RecommendationCacheRepository {
 
-	private static final String KEY_FORMAT = "user:%s:recommendation";
+	private static final String KEY_FORMAT = "user:%s:recommendation:v2";
 	private static final Duration TTL = Duration.ofMinutes(20);
 	private static final int DELETE_BATCH_SIZE = 100;
 
@@ -29,9 +30,7 @@ public class RecommendationRedisRepository implements RecommendationCacheReposit
 
 	@Override
 	public RecommendationResponseDto get(UUID userId) {
-		String key = KEY_FORMAT.formatted(userId);
-
-		String value = redisTemplate.opsForValue().get(key);
+		String value = redisTemplate.opsForValue().get(KEY_FORMAT.formatted(userId));
 		if (value == null) {
 			return null;
 		}
@@ -45,11 +44,9 @@ public class RecommendationRedisRepository implements RecommendationCacheReposit
 
 	@Override
 	public void save(UUID userId, RecommendationResponseDto response) {
-		String key = KEY_FORMAT.formatted(userId);
-
 		try {
 			String value = objectMapper.writeValueAsString(response);
-			redisTemplate.opsForValue().set(key, value, TTL);
+			redisTemplate.opsForValue().set(KEY_FORMAT.formatted(userId), value, TTL);
 		} catch (JsonProcessingException e) {
 			throw new IllegalStateException("추천 캐시 직렬화 실패", e);
 		}
@@ -57,8 +54,7 @@ public class RecommendationRedisRepository implements RecommendationCacheReposit
 
 	@Override
 	public void delete(UUID userId) {
-		String key = KEY_FORMAT.formatted(userId);
-		redisTemplate.delete(key);
+		redisTemplate.delete(KEY_FORMAT.formatted(userId));
 	}
 
 	@Override

--- a/service/ai/src/main/java/jabaclass/ai/infrastructure/persistence/UserVectorRedisRepository.java
+++ b/service/ai/src/main/java/jabaclass/ai/infrastructure/persistence/UserVectorRedisRepository.java
@@ -1,64 +1,161 @@
 package jabaclass.ai.infrastructure.persistence;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import jabaclass.ai.domain.model.UserVector;
+import jabaclass.ai.domain.model.UserVectorProfile;
 import jabaclass.ai.domain.repository.UserVectorCacheRepository;
 import lombok.RequiredArgsConstructor;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Repository
 @RequiredArgsConstructor
 public class UserVectorRedisRepository implements UserVectorCacheRepository {
 
-	private static final String KEY_FORMAT = "user:%s:vector";
-	private static final Duration TTL = Duration.ofHours(1);
+	private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+	private static final String PROFILE_KEY_FORMAT = "user:profile:v2:%s";
+	private static final String EXCLUDE_KEY_FORMAT = "user:exclude:v2:%s";
+	private static final Duration TTL = Duration.ofHours(6);
+	private static final int DELETE_BATCH_SIZE = 100;
 
 	private final StringRedisTemplate redisTemplate;
 	private final ObjectMapper objectMapper;
 
 	@Override
 	public UserVector get(UUID userId) {
-		String key = KEY_FORMAT.formatted(userId);
+		UserVectorProfile profile = getProfile(userId);
+		return profile == null ? null : profile.userVector();
+	}
 
-		String value = redisTemplate.opsForValue().get(key);
-
+	@Override
+	public UserVectorProfile getProfile(UUID userId) {
+		String value = redisTemplate.opsForValue().get(profileKey(userId));
 		if (value == null) {
 			return null;
 		}
 
 		try {
-			float[] vector = objectMapper.readValue(value, float[].class);
-			return new UserVector(vector);
+			CachedUserProfile cached = objectMapper.readValue(value, CachedUserProfile.class);
+			return new UserVectorProfile(
+				new UserVector(cached.vector()),
+				LocalDateTime.parse(cached.lastUpdatedAt(), DATE_TIME_FORMATTER),
+				cached.version()
+			);
 		} catch (JsonProcessingException e) {
-			throw new IllegalStateException("user vector 역직렬화 실패", e);
+			throw new IllegalStateException("user profile 역직렬화 실패", e);
 		}
 	}
 
 	@Override
 	public void save(UUID userId, UserVector userVector) {
-		String key = KEY_FORMAT.formatted(userId);
+		saveProfile(userId, new UserVectorProfile(userVector, LocalDateTime.now(), 1));
+	}
 
+	@Override
+	public void saveProfile(UUID userId, UserVectorProfile profile) {
 		try {
-			String value = objectMapper.writeValueAsString(userVector.vector());
-			redisTemplate.opsForValue().set(key, value, TTL);
+			String value = objectMapper.writeValueAsString(
+				new CachedUserProfile(
+					profile.userVector().vector(),
+					profile.lastUpdatedAt().format(DATE_TIME_FORMATTER),
+					profile.version()
+				)
+			);
+			redisTemplate.opsForValue().set(profileKey(userId), value, TTL);
 		} catch (JsonProcessingException e) {
-			throw new IllegalStateException("user vector 직렬화 실패", e);
+			throw new IllegalStateException("user profile 직렬화 실패", e);
 		}
 	}
 
 	@Override
-	public void delete(UUID userId) {
-		String key = KEY_FORMAT.formatted(userId);
-		redisTemplate.delete(key);
+	public Set<UUID> getExcludedProductIds(UUID userId) {
+		String value = redisTemplate.opsForValue().get(excludeKey(userId));
+		if (value == null) {
+			return null;
+		}
+
+		try {
+			List<UUID> excluded = objectMapper.readValue(value, new TypeReference<List<UUID>>() {
+			});
+			return new LinkedHashSet<>(excluded);
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("excluded product ids 역직렬화 실패", e);
+		}
 	}
 
+	@Override
+	public void saveExcludedProductIds(UUID userId, Set<UUID> excludedProductIds) {
+		try {
+			String value = objectMapper.writeValueAsString(excludedProductIds == null ? Set.of() : excludedProductIds);
+			redisTemplate.opsForValue().set(excludeKey(userId), value, TTL);
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("excluded product ids 직렬화 실패", e);
+		}
+	}
 
+	@Override
+	public void addExcludedProductId(UUID userId, UUID productId) {
+		Set<UUID> excludedProductIds = getExcludedProductIds(userId);
+		Set<UUID> updated = excludedProductIds == null ? new LinkedHashSet<>() : new LinkedHashSet<>(excludedProductIds);
+		updated.add(productId);
+		saveExcludedProductIds(userId, updated);
+	}
 
+	@Override
+	public void delete(UUID userId) {
+		redisTemplate.delete(profileKey(userId));
+	}
+
+	@Override
+	public void deleteAllProfiles() {
+		ScanOptions options = ScanOptions.scanOptions()
+			.match(PROFILE_KEY_FORMAT.formatted("*"))
+			.count(DELETE_BATCH_SIZE)
+			.build();
+
+		try (Cursor<String> cursor = redisTemplate.scan(options)) {
+			List<String> batch = new ArrayList<>(DELETE_BATCH_SIZE);
+			while (cursor.hasNext()) {
+				batch.add(cursor.next());
+				if (batch.size() >= DELETE_BATCH_SIZE) {
+					redisTemplate.delete(batch);
+					batch.clear();
+				}
+			}
+
+			if (!batch.isEmpty()) {
+				redisTemplate.delete(batch);
+			}
+		}
+	}
+
+	private String profileKey(UUID userId) {
+		return PROFILE_KEY_FORMAT.formatted(userId);
+	}
+
+	private String excludeKey(UUID userId) {
+		return EXCLUDE_KEY_FORMAT.formatted(userId);
+	}
+
+	private record CachedUserProfile(
+		float[] vector,
+		String lastUpdatedAt,
+		int version
+	) {
+	}
 }

--- a/service/ai/src/main/java/jabaclass/ai/infrastructure/persistence/UserVectorRedisRepository.java
+++ b/service/ai/src/main/java/jabaclass/ai/infrastructure/persistence/UserVectorRedisRepository.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -15,7 +14,6 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jabaclass.ai.domain.model.UserVector;
@@ -84,36 +82,37 @@ public class UserVectorRedisRepository implements UserVectorCacheRepository {
 
 	@Override
 	public Set<UUID> getExcludedProductIds(UUID userId) {
-		String value = redisTemplate.opsForValue().get(excludeKey(userId));
-		if (value == null) {
+		Set<String> members = redisTemplate.opsForSet().members(excludeKey(userId));
+		if (members == null) {
 			return null;
 		}
 
-		try {
-			List<UUID> excluded = objectMapper.readValue(value, new TypeReference<List<UUID>>() {
-			});
-			return new LinkedHashSet<>(excluded);
-		} catch (JsonProcessingException e) {
-			throw new IllegalStateException("excluded product ids 역직렬화 실패", e);
-		}
+		return members.stream()
+			.map(UUID::fromString)
+			.collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
 	}
 
 	@Override
 	public void saveExcludedProductIds(UUID userId, Set<UUID> excludedProductIds) {
-		try {
-			String value = objectMapper.writeValueAsString(excludedProductIds == null ? Set.of() : excludedProductIds);
-			redisTemplate.opsForValue().set(excludeKey(userId), value, TTL);
-		} catch (JsonProcessingException e) {
-			throw new IllegalStateException("excluded product ids 직렬화 실패", e);
+		String key = excludeKey(userId);
+		redisTemplate.delete(key);
+
+		if (excludedProductIds == null || excludedProductIds.isEmpty()) {
+			return;
 		}
+
+		String[] members = excludedProductIds.stream()
+			.map(UUID::toString)
+			.toArray(String[]::new);
+		redisTemplate.opsForSet().add(key, members);
+		redisTemplate.expire(key, TTL);
 	}
 
 	@Override
 	public void addExcludedProductId(UUID userId, UUID productId) {
-		Set<UUID> excludedProductIds = getExcludedProductIds(userId);
-		Set<UUID> updated = excludedProductIds == null ? new LinkedHashSet<>() : new LinkedHashSet<>(excludedProductIds);
-		updated.add(productId);
-		saveExcludedProductIds(userId, updated);
+		String key = excludeKey(userId);
+		redisTemplate.opsForSet().add(key, productId.toString());
+		redisTemplate.expire(key, TTL);
 	}
 
 	@Override

--- a/service/ai/src/test/java/jabaclass/ai/application/service/ProductEmbeddingSyncServiceTest.java
+++ b/service/ai/src/test/java/jabaclass/ai/application/service/ProductEmbeddingSyncServiceTest.java
@@ -1,7 +1,6 @@
 package jabaclass.ai.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
@@ -15,8 +14,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import jabaclass.ai.domain.repository.RecommendationCacheRepository;
 import jabaclass.ai.domain.repository.ProductEmbeddingRepository;
+import jabaclass.ai.domain.repository.RecommendationCacheRepository;
+import jabaclass.ai.domain.repository.UserVectorCacheRepository;
 import jabaclass.ai.infrastructure.external.openai.EmbeddingService;
 import jabaclass.ai.infrastructure.kafka.ProductAiSyncedEvent;
 import jabaclass.ai.infrastructure.persistence.command.ProductEmbeddingUpsertCommand;
@@ -34,10 +34,13 @@ class ProductEmbeddingSyncServiceTest {
 	private ProductEmbeddingRepository productEmbeddingRepository;
 
 	@Mock
+	private UserVectorCacheRepository userVectorCacheRepository;
+
+	@Mock
 	private RecommendationCacheRepository recommendationCacheRepository;
 
 	@Test
-	void 상품_동기화시_임베딩을_생성하고_upsert한_뒤_추천캐시를_삭제한다() {
+	void 상품_동기화시_임베딩을_생성하고_profile과_snapshot캐시를_무효화한다() {
 		UUID eventId = UUID.fromString("11111111-2222-3333-4444-555555555555");
 		UUID productId = UUID.fromString("66666666-7777-8888-9999-000000000000");
 		ProductAiSyncedEvent payload = new ProductAiSyncedEvent(
@@ -69,16 +72,18 @@ class ProductEmbeddingSyncServiceTest {
 		assertThat(command.status()).isEqualTo("ENABLE");
 		assertThat(command.popularity()).isEqualTo(12);
 		assertThat(command.embedding()).isSameAs(embedding);
+		then(userVectorCacheRepository).should().deleteAllProfiles();
 		then(recommendationCacheRepository).should().deleteAll();
 	}
 
 	@Test
-	void 상품_삭제시_임베딩과_추천캐시를_삭제한다() {
+	void 상품_삭제시_profile과_snapshot캐시를_무효화한다() {
 		UUID productId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
 
 		productEmbeddingSyncService.delete(productId);
 
 		then(productEmbeddingRepository).should().deleteByProductId(productId);
+		then(userVectorCacheRepository).should().deleteAllProfiles();
 		then(recommendationCacheRepository).should().deleteAll();
 		then(embeddingService).shouldHaveNoInteractions();
 	}

--- a/service/ai/src/test/java/jabaclass/ai/application/service/RecommendationServiceTest.java
+++ b/service/ai/src/test/java/jabaclass/ai/application/service/RecommendationServiceTest.java
@@ -3,35 +3,30 @@ package jabaclass.ai.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import jabaclass.ai.application.dto.CandidateClassDto;
-import jabaclass.ai.application.port.external.AiGatewayPort;
+import jabaclass.ai.domain.model.UserPreferenceState;
 import jabaclass.ai.domain.model.UserVector;
 import jabaclass.ai.domain.repository.CandidateSearchRepository;
 import jabaclass.ai.domain.repository.RecommendationCacheRepository;
-import jabaclass.ai.presentation.dto.response.RecommendationItemDto;
 import jabaclass.ai.presentation.dto.response.RecommendationResponseDto;
+import jabaclass.ai.presentation.dto.response.RecommendationStatus;
 
 @ExtendWith(MockitoExtension.class)
 class RecommendationServiceTest {
 
-	@InjectMocks
 	private RecommendationService recommendationService;
-
-	@Mock
-	private RecommendationCacheRepository recommendationCacheRepository;
 
 	@Mock
 	private UserVectorService userVectorService;
@@ -40,111 +35,94 @@ class RecommendationServiceTest {
 	private CandidateSearchRepository candidateSearchRepository;
 
 	@Mock
-	private AiGatewayPort aiGatewayPort;
+	private RecommendationReasonAsyncService recommendationReasonAsyncService;
+
+	@Mock
+	private RecommendationCacheRepository recommendationCacheRepository;
 
 	private static final UUID USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
 	private static final UUID PRODUCT_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+	private static final UUID EXCLUDED_PRODUCT_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");
+
+	@BeforeEach
+	void setUp() {
+		recommendationService = new RecommendationService(
+			userVectorService,
+			candidateSearchRepository,
+			recommendationReasonAsyncService,
+			recommendationCacheRepository
+		);
+	}
 
 	@Test
-	void 캐시에_추천이_있으면_캐시를_바로_반환한다() {
+	void snapshot_캐시가_없으면_pending으로_응답하고_비동기_생성을_시작한다() {
+		UserVector userVector = new UserVector(new float[] { 0.1f, 0.2f });
+		UserPreferenceState state = new UserPreferenceState(userVector, Set.of(EXCLUDED_PRODUCT_ID));
+		CandidateClassDto candidate = candidate("도예 클래스");
+
+		given(recommendationCacheRepository.get(USER_ID)).willReturn(null);
+		given(userVectorService.getOrCreateState(USER_ID)).willReturn(state);
+		given(candidateSearchRepository.findTopK(userVector, Set.of(EXCLUDED_PRODUCT_ID), 5))
+			.willReturn(List.of(candidate));
+
+		RecommendationResponseDto result = recommendationService.recommend(USER_ID);
+
+		assertThat(result.status()).isEqualTo(RecommendationStatus.PENDING);
+		assertThat(result.recommendations()).hasSize(1);
+		assertThat(result.recommendations().get(0).reason()).isEqualTo("사용자 취향과 유사한 클래스입니다.");
+		then(recommendationCacheRepository).should().save(
+			org.mockito.ArgumentMatchers.eq(USER_ID),
+			org.mockito.ArgumentMatchers.any(RecommendationResponseDto.class)
+		);
+		then(recommendationReasonAsyncService).should().generateAndCache(USER_ID, userVector, List.of(candidate));
+	}
+
+	@Test
+	void snapshot_캐시가_있으면_그대로_반환한다() {
 		RecommendationResponseDto cached = new RecommendationResponseDto(
-			List.of(new RecommendationItemDto(PRODUCT_ID, "클래스", "캐시된 추천입니다."))
+			RecommendationStatus.COMPLETED,
+			List.of(new jabaclass.ai.presentation.dto.response.RecommendationItemDto(
+				PRODUCT_ID,
+				"향수 클래스",
+				"차분한 취향에 잘 맞는 클래스입니다."
+			))
 		);
 		given(recommendationCacheRepository.get(USER_ID)).willReturn(cached);
 
 		RecommendationResponseDto result = recommendationService.recommend(USER_ID);
 
 		assertThat(result).isEqualTo(cached);
-		then(recommendationCacheRepository).should().get(USER_ID);
 		then(userVectorService).shouldHaveNoInteractions();
-		then(candidateSearchRepository).shouldHaveNoInteractions();
-		then(aiGatewayPort).shouldHaveNoInteractions();
+		then(recommendationReasonAsyncService).shouldHaveNoInteractions();
 	}
 
 	@Test
-	void 후보가_있으면_GPT_사유를_포함해_추천을_반환하고_캐시한다() {
-		UserVector userVector = new UserVector(new float[] { 0.1f, 0.2f });
-		CandidateClassDto candidate = new CandidateClassDto(
-			PRODUCT_ID,
-			"도예 클래스",
-			"핸드빌딩 원데이 클래스",
-			new BigDecimal("50000"),
-			"서울 성수동"
-		);
-		given(recommendationCacheRepository.get(USER_ID)).willReturn(null);
-		given(userVectorService.getOrCreate(USER_ID)).willReturn(userVector);
-		given(candidateSearchRepository.findTopK(userVector, 5)).willReturn(List.of(candidate));
-		given(aiGatewayPort.generateRecommendationReasons(userVector, List.of(candidate)))
-			.willReturn(Map.of(PRODUCT_ID, "차분한 취향에 잘 맞는 클래스입니다."));
-
-		RecommendationResponseDto result = recommendationService.recommend(USER_ID);
-
-		assertThat(result.recommendations()).hasSize(1);
-		assertThat(result.recommendations().get(0).productId()).isEqualTo(PRODUCT_ID);
-		assertThat(result.recommendations().get(0).title()).isEqualTo("도예 클래스");
-		assertThat(result.recommendations().get(0).reason()).isEqualTo("차분한 취향에 잘 맞는 클래스입니다.");
-		then(recommendationCacheRepository).should().save(USER_ID, result);
-	}
-
-	@Test
-	void GPT_사유가_없으면_기본_사유를_사용한다() {
-		UserVector userVector = new UserVector(new float[] { 0.3f, 0.4f });
-		CandidateClassDto candidate = new CandidateClassDto(
-			PRODUCT_ID,
-			"향수 클래스",
-			"조향 입문 클래스",
-			new BigDecimal("70000"),
-			"서울 연남동"
-		);
-		given(recommendationCacheRepository.get(USER_ID)).willReturn(null);
-		given(userVectorService.getOrCreate(USER_ID)).willReturn(userVector);
-		given(candidateSearchRepository.findTopK(userVector, 5)).willReturn(List.of(candidate));
-		given(aiGatewayPort.generateRecommendationReasons(userVector, List.of(candidate)))
-			.willReturn(Map.of());
-
-		RecommendationResponseDto result = recommendationService.recommend(USER_ID);
-
-		assertThat(result.recommendations()).hasSize(1);
-		assertThat(result.recommendations().get(0).reason()).isEqualTo("사용자 취향과 유사한 클래스입니다.");
-		then(recommendationCacheRepository).should().save(USER_ID, result);
-	}
-
-	@Test
-	void 후보가_없으면_인기상품_fallback_추천을_반환하되_캐시하지_않는다() {
+	void 후보가_없으면_인기상품_fallback을_반환한다() {
 		UserVector userVector = new UserVector(new float[] { 0.5f, 0.6f });
-		CandidateClassDto popular = new CandidateClassDto(
-			PRODUCT_ID,
-			"베이킹 클래스",
-			"디저트 만들기",
-			new BigDecimal("45000"),
-			"서울 망원동"
-		);
+		UserPreferenceState state = new UserPreferenceState(userVector, Set.of(EXCLUDED_PRODUCT_ID));
+		CandidateClassDto popular = candidate("베이킹 클래스");
+
 		given(recommendationCacheRepository.get(USER_ID)).willReturn(null);
-		given(userVectorService.getOrCreate(USER_ID)).willReturn(userVector);
-		given(candidateSearchRepository.findTopK(userVector, 5)).willReturn(List.of());
-		given(candidateSearchRepository.findPopular(5)).willReturn(List.of(popular));
+		given(userVectorService.getOrCreateState(USER_ID)).willReturn(state);
+		given(candidateSearchRepository.findTopK(userVector, Set.of(EXCLUDED_PRODUCT_ID), 5)).willReturn(List.of());
+		given(candidateSearchRepository.findPopular(Set.of(EXCLUDED_PRODUCT_ID), 5)).willReturn(List.of(popular));
 
 		RecommendationResponseDto result = recommendationService.recommend(USER_ID);
 
+		assertThat(result.status()).isEqualTo(RecommendationStatus.COMPLETED);
 		assertThat(result.recommendations()).hasSize(1);
 		assertThat(result.recommendations().get(0).title()).isEqualTo("베이킹 클래스");
 		assertThat(result.recommendations().get(0).reason()).isEqualTo("현재 인기 있는 클래스입니다.");
-		then(aiGatewayPort).shouldHaveNoInteractions();
-		then(recommendationCacheRepository).should(never()).save(USER_ID, result);
+		then(recommendationReasonAsyncService).shouldHaveNoInteractions();
 	}
 
-	@Test
-	void fallback_대상도_없으면_빈_추천을_반환한다() {
-		UserVector userVector = new UserVector(new float[] { 0.7f, 0.8f });
-		given(recommendationCacheRepository.get(USER_ID)).willReturn(null);
-		given(userVectorService.getOrCreate(USER_ID)).willReturn(userVector);
-		given(candidateSearchRepository.findTopK(userVector, 5)).willReturn(List.of());
-		given(candidateSearchRepository.findPopular(5)).willReturn(List.of());
-
-		RecommendationResponseDto result = recommendationService.recommend(USER_ID);
-
-		assertThat(result.recommendations()).isEmpty();
-		then(aiGatewayPort).shouldHaveNoInteractions();
-		then(recommendationCacheRepository).should(never()).save(USER_ID, result);
+	private CandidateClassDto candidate(String title) {
+		return new CandidateClassDto(
+			PRODUCT_ID,
+			title,
+			"설명",
+			new BigDecimal("50000"),
+			"서울"
+		);
 	}
 }

--- a/service/ai/src/test/java/jabaclass/ai/application/service/UserActivityServiceTest.java
+++ b/service/ai/src/test/java/jabaclass/ai/application/service/UserActivityServiceTest.java
@@ -1,7 +1,6 @@
 package jabaclass.ai.application.service;
 
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
 
 import java.util.UUID;
 
@@ -14,7 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import jabaclass.ai.domain.model.ActionType;
 import jabaclass.ai.domain.repository.RecommendationCacheRepository;
 import jabaclass.ai.domain.repository.UserActivityRepository;
-import jabaclass.ai.domain.repository.UserVectorCacheRepository;
 
 @ExtendWith(MockitoExtension.class)
 class UserActivityServiceTest {
@@ -23,7 +21,7 @@ class UserActivityServiceTest {
 	private UserActivityRepository userActivityRepository;
 
 	@Mock
-	private UserVectorCacheRepository userVectorCacheRepository;
+	private UserVectorService userVectorService;
 
 	@Mock
 	private RecommendationCacheRepository recommendationCacheRepository;
@@ -32,7 +30,7 @@ class UserActivityServiceTest {
 	private UserActivityService userActivityService;
 
 	@Test
-	void 공통_행동_저장_메서드로_조회_외_행동도_저장할_수_있다() {
+	void 행동_로그를_저장하고_userVector를_증분_업데이트한다() {
 		UUID userId = UUID.randomUUID();
 		UUID productId = UUID.randomUUID();
 
@@ -44,24 +42,7 @@ class UserActivityServiceTest {
 					&& activity.getProductId().equals(productId)
 					&& activity.getActionType() == ActionType.ORDER
 			));
-		then(userVectorCacheRepository).should().delete(userId);
 		then(recommendationCacheRepository).should().delete(userId);
-	}
-
-	@Test
-	void VIEW_행동은_저장만하고_추천_캐시는_유지한다() {
-		UUID userId = UUID.randomUUID();
-		UUID productId = UUID.randomUUID();
-
-		userActivityService.recordActivity(userId, productId, ActionType.VIEW);
-
-		then(userActivityRepository).should()
-			.save(org.mockito.ArgumentMatchers.argThat(activity ->
-				activity.getUserId().equals(userId)
-					&& activity.getProductId().equals(productId)
-					&& activity.getActionType() == ActionType.VIEW
-			));
-		then(userVectorCacheRepository).should(never()).delete(userId);
-		then(recommendationCacheRepository).should(never()).delete(userId);
+		then(userVectorService).should().updateOnActivity(userId, productId, ActionType.ORDER);
 	}
 }

--- a/service/ai/src/test/java/jabaclass/ai/application/service/UserVectorServiceTest.java
+++ b/service/ai/src/test/java/jabaclass/ai/application/service/UserVectorServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.then;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import jabaclass.ai.domain.model.ActionType;
 import jabaclass.ai.domain.model.UserActivity;
+import jabaclass.ai.domain.model.UserPreferenceState;
 import jabaclass.ai.domain.model.UserVector;
+import jabaclass.ai.domain.model.UserVectorProfile;
 import jabaclass.ai.domain.repository.ProductEmbeddingRepository;
 import jabaclass.ai.domain.repository.UserActivityRepository;
 import jabaclass.ai.domain.repository.UserVectorCacheRepository;
@@ -42,34 +45,59 @@ class UserVectorServiceTest {
 	private static final UUID PRODUCT_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
 
 	@Test
-	void 캐시에_벡터가_있으면_생성하지_않고_반환한다() {
+	void 프로필과_제외목록_캐시가_있으면_DB조회없이_반환한다() {
 		UserVector cached = new UserVector(new float[] { 1.0f, 0.0f });
-		given(userVectorCacheRepository.get(USER_ID)).willReturn(cached);
+		UserVectorProfile profile = new UserVectorProfile(cached, LocalDateTime.now(), 2);
+		given(userVectorCacheRepository.getProfile(USER_ID)).willReturn(profile);
+		given(userVectorCacheRepository.getExcludedProductIds(USER_ID)).willReturn(Set.of(PRODUCT_ID));
 
-		UserVector result = userVectorService.getOrCreate(USER_ID);
+		UserPreferenceState result = userVectorService.getOrCreateState(USER_ID);
 
-		assertThat(result).isEqualTo(cached);
-		then(userVectorCacheRepository).should().get(USER_ID);
+		assertThat(result.userVector().vector()).containsExactly(cached.vector());
+		assertThat(result.excludedProductIds()).containsExactly(PRODUCT_ID);
 		then(userActivityRepository).shouldHaveNoInteractions();
 		then(productEmbeddingRepository).shouldHaveNoInteractions();
 	}
 
 	@Test
-	void 캐시에_벡터가_없으면_생성후_저장한다() {
+	void 캐시가_없으면_DB로그로_full_rebuild하고_저장한다() {
 		float[] embedding = new float[768];
 		embedding[0] = 3.0f;
 		embedding[1] = 4.0f;
-		given(userVectorCacheRepository.get(USER_ID)).willReturn(null);
+		given(userVectorCacheRepository.getProfile(USER_ID)).willReturn(null);
+		given(userVectorCacheRepository.getExcludedProductIds(USER_ID)).willReturn(null);
 		given(userActivityRepository.findByUserId(USER_ID))
-			.willReturn(List.of(UserActivity.create(USER_ID, PRODUCT_ID, ActionType.VIEW)));
+			.willReturn(List.of(UserActivity.create(USER_ID, PRODUCT_ID, ActionType.WISHLIST)));
 		given(productEmbeddingRepository.findAllByProductIds(anyCollection()))
 			.willReturn(Map.of(PRODUCT_ID, embedding));
 
-		UserVector result = userVectorService.getOrCreate(USER_ID);
+		UserPreferenceState result = userVectorService.getOrCreateState(USER_ID);
 
-		assertThat(result.vector()[0]).isEqualTo(0.6f);
-		assertThat(result.vector()[1]).isEqualTo(0.8f);
-		then(userVectorCacheRepository).should().save(USER_ID, result);
+		assertThat(result.userVector().vector()[0]).isEqualTo(0.6f);
+		assertThat(result.userVector().vector()[1]).isEqualTo(0.8f);
+		assertThat(result.excludedProductIds()).containsExactly(PRODUCT_ID);
+		then(userVectorCacheRepository).should().saveProfile(
+			org.mockito.ArgumentMatchers.eq(USER_ID),
+			org.mockito.ArgumentMatchers.any(UserVectorProfile.class)
+		);
+		then(userVectorCacheRepository).should().saveExcludedProductIds(USER_ID, Set.of(PRODUCT_ID));
+	}
+
+	@Test
+	void 조회와_주문_모두_제외목록에_추가한다() {
+		UserVector cached = new UserVector(new float[768]);
+		UserVectorProfile profile = new UserVectorProfile(cached, LocalDateTime.now().minusHours(1), 2);
+		float[] embedding = new float[768];
+		embedding[0] = 1.0f;
+		given(userVectorCacheRepository.getProfile(USER_ID)).willReturn(profile);
+		given(productEmbeddingRepository.findAllByProductIds(anyCollection()))
+			.willReturn(Map.of(PRODUCT_ID, embedding));
+
+		userVectorService.updateOnActivity(USER_ID, PRODUCT_ID, ActionType.VIEW);
+		userVectorService.updateOnActivity(USER_ID, PRODUCT_ID, ActionType.ORDER);
+
+		then(userVectorCacheRepository).should(org.mockito.Mockito.times(2))
+			.addExcludedProductId(USER_ID, PRODUCT_ID);
 	}
 
 	@Test
@@ -93,52 +121,8 @@ class UserVectorServiceTest {
 
 		UserVector result = userVectorService.generate(USER_ID);
 
-		assertThat(result.vector()[0]).isCloseTo((float) (1.0 / Math.sqrt(37.0)), within(0.0001f));
-		assertThat(result.vector()[1]).isCloseTo((float) (6.0 / Math.sqrt(37.0)), within(0.0001f));
-	}
-
-	@Test
-	void 차원이_다르거나_null_임베딩은_무시한다() {
-		UUID invalidProductId = UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
-		given(userActivityRepository.findByUserId(USER_ID))
-			.willReturn(List.of(UserActivity.create(USER_ID, invalidProductId, ActionType.WISHLIST)));
-		given(productEmbeddingRepository.findAllByProductIds(anyCollection()))
-			.willReturn(Map.of(invalidProductId, new float[] { 1.0f, 2.0f }));
-
-		UserVector result = userVectorService.generate(USER_ID);
-
-		assertThat(result.vector()[0]).isEqualTo(0.0f);
-		assertThat(result.vector()[1]).isEqualTo(0.0f);
-	}
-
-	@Test
-	void 같은_상품의_반복_VIEW는_최대_세번까지만_반영한다() {
-		UUID heavilyViewedProductId = UUID.fromString("11111111-1111-1111-1111-111111111111");
-		UUID orderedProductId = UUID.fromString("22222222-2222-2222-2222-222222222222");
-		LocalDateTime now = LocalDateTime.now();
-
-		float[] viewedEmbedding = new float[768];
-		float[] orderedEmbedding = new float[768];
-		viewedEmbedding[0] = 1.0f;
-		orderedEmbedding[1] = 1.0f;
-
-		given(userActivityRepository.findByUserId(USER_ID)).willReturn(List.of(
-			UserActivity.create(USER_ID, heavilyViewedProductId, ActionType.VIEW, now.minusMinutes(1)),
-			UserActivity.create(USER_ID, heavilyViewedProductId, ActionType.VIEW, now.minusMinutes(2)),
-			UserActivity.create(USER_ID, heavilyViewedProductId, ActionType.VIEW, now.minusMinutes(3)),
-			UserActivity.create(USER_ID, heavilyViewedProductId, ActionType.VIEW, now.minusMinutes(4)),
-			UserActivity.create(USER_ID, heavilyViewedProductId, ActionType.VIEW, now.minusMinutes(5)),
-			UserActivity.create(USER_ID, orderedProductId, ActionType.ORDER, now.minusMinutes(6))
-		));
-		given(productEmbeddingRepository.findAllByProductIds(anyCollection()))
-			.willReturn(Map.of(
-				heavilyViewedProductId, viewedEmbedding,
-				orderedProductId, orderedEmbedding
-			));
-
-		UserVector result = userVectorService.generate(USER_ID);
-
-		assertThat(result.vector()[0]).isCloseTo(result.vector()[1], within(0.02f));
+		assertThat(result.vector()[0]).isCloseTo((float) (1.0 / Math.sqrt(101.0)), within(0.0001f));
+		assertThat(result.vector()[1]).isCloseTo((float) (10.0 / Math.sqrt(101.0)), within(0.0001f));
 	}
 
 	@Test
@@ -165,18 +149,6 @@ class UserVectorServiceTest {
 		UserVector result = userVectorService.generate(USER_ID);
 
 		assertThat(result.vector()[0]).isGreaterThan(result.vector()[1]);
-	}
-
-	@Test
-	void 활동이_없으면_0벡터를_반환하고_빈_벡터로_취급한다() {
-		given(userActivityRepository.findByUserId(USER_ID)).willReturn(List.of());
-		given(productEmbeddingRepository.findAllByProductIds(anyCollection())).willReturn(Map.of());
-
-		UserVector result = userVectorService.generate(USER_ID);
-
-		assertThat(result.isEmpty()).isTrue();
-		assertThat(result.vector()).hasSize(768);
-		assertThat(result.vector()).containsOnly(0.0f);
 	}
 
 	private static org.assertj.core.data.Offset<Float> within(float value) {

--- a/service/ai/src/test/java/jabaclass/ai/application/service/UserVectorServiceTest.java
+++ b/service/ai/src/test/java/jabaclass/ai/application/service/UserVectorServiceTest.java
@@ -84,7 +84,7 @@ class UserVectorServiceTest {
 	}
 
 	@Test
-	void 조회와_주문_모두_제외목록에_추가한다() {
+	void 조회는_제외목록에_넣지_않고_주문만_제외목록에_추가한다() {
 		UserVector cached = new UserVector(new float[768]);
 		UserVectorProfile profile = new UserVectorProfile(cached, LocalDateTime.now().minusHours(1), 2);
 		float[] embedding = new float[768];
@@ -96,7 +96,7 @@ class UserVectorServiceTest {
 		userVectorService.updateOnActivity(USER_ID, PRODUCT_ID, ActionType.VIEW);
 		userVectorService.updateOnActivity(USER_ID, PRODUCT_ID, ActionType.ORDER);
 
-		then(userVectorCacheRepository).should(org.mockito.Mockito.times(2))
+		then(userVectorCacheRepository).should(org.mockito.Mockito.times(1))
 			.addExcludedProductId(USER_ID, PRODUCT_ID);
 	}
 


### PR DESCRIPTION
## 관련 이슈
- Close #363 

## 변경 요약
기존 userVector 캐시를 확장해 매 요청마다 DB를 조회하지 않도록 개선했습니다.
또한 사용자가 이미 조회/찜/주문한 상품은 추천 후보에서 제외되도록 변경했습니다.

## 주요 변경점
- 사용자 벡터 캐시에 메타데이터와 제외 상품 관리 추가
- 조회/찜/주문 이벤트 발생 시 userVector 증분 업데이트
- 조회/찜/주문한 상품을 추천 후보에서 제외하도록 변경
- recommendation 결과를 polling용 snapshot cache로 관리
- 추천 이유 생성은 비동기로 수행하고 상태를 PENDING, COMPLETED, FAILED로 관리(2-phase)
- 사용자 행동 발생 시 해당 유저의 recommendation snapshot 무효화
- 상품 임베딩 변경 시 user profile / recommendation snapshot 전체 무효화

## 테스트
- [x] 로컬 실행 확인
- [x] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트
