### PR TITLE
refactor: product ES 장애 대응 - Circuit Breaker + DB Fallback + 자동 복구

### DIFF
--- a/service/product/build.gradle
+++ b/service/product/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.3.0'
 
     implementation platform('software.amazon.awssdk:bom:2.25.0')
     implementation 'software.amazon.awssdk:s3'

--- a/service/product/src/main/java/jabaclass/product/application/service/ProductService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/ProductService.java
@@ -174,7 +174,7 @@ public class ProductService implements ProductUseCase {
 	}
 
 	private SearchProductResponseDto searchAllFallback(SearchProductRequestDto requestDto, Throwable t) {
-		log.warn("ES 장애 감지 — DB fallback 실행. circuit: elasticsearchCB, 원인: {}", t.getMessage());
+		log.warn("ES 장애 감지 — DB fallback 실행. circuit: elasticsearchCB", t);
 		Pageable pageable = PageRequest.of(requestDto.thisPage(), requestDto.pageSize());
 
 		Page<Product> page;
@@ -223,7 +223,7 @@ public class ProductService implements ProductUseCase {
 	}
 
 	private SearchProductResponseDto searchMyFallback(SearchProductRequestDto requestDto, UUID sellerId, Throwable t) {
-		log.warn("ES 장애 감지 — DB fallback 실행. circuit: elasticsearchCB, 원인: {}", t.getMessage());
+		log.warn("ES 장애 감지 — DB fallback 실행. circuit: elasticsearchCB", t);
 		Pageable pageable = PageRequest.of(requestDto.thisPage(), requestDto.pageSize());
 
 		Page<Product> page;

--- a/service/product/src/main/java/jabaclass/product/application/service/ProductService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/ProductService.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -153,6 +154,7 @@ public class ProductService implements ProductUseCase {
 
 	// es 추가
 	@Override
+	@CircuitBreaker(name = "elasticsearchCB", fallbackMethod = "searchAllFallback")
 	public SearchProductResponseDto searchAll(SearchProductRequestDto requestDto) {
 		Pageable pageable = PageRequest.of(requestDto.thisPage(), requestDto.pageSize());
 
@@ -171,7 +173,33 @@ public class ProductService implements ProductUseCase {
 		return SearchProductResponseDto.fromEs(page, content);
 	}
 
+	private SearchProductResponseDto searchAllFallback(SearchProductRequestDto requestDto, Throwable t) {
+		log.warn("ES 장애 감지 — DB fallback 실행. circuit: elasticsearchCB, 원인: {}", t.getMessage());
+		Pageable pageable = PageRequest.of(requestDto.thisPage(), requestDto.pageSize());
+
+		Page<Product> page;
+		if (requestDto.title() == null || requestDto.title().isBlank()) {
+			page = productRepository.findByStatusAndDeleteDtIsNull(ProductStatus.ENABLE, pageable);
+		} else {
+			page = productRepository.findByStatusAndTitleContainingAndDeleteDtIsNull(ProductStatus.ENABLE,
+				requestDto.title(), pageable);
+		}
+
+		List<UUID> sellerIds = page.getContent().stream().map(Product::getSellerId).distinct().toList();
+		Map<UUID, String> sellerNameMap = sellerRepository.findSellerList(sellerIds)
+			.map(list -> list.stream()
+				.collect(Collectors.toMap(UserResponseDto::userId, UserResponseDto::name)))
+			.orElse(Map.of());
+
+		List<ProductResponseDto> content = page.getContent().stream()
+			.map(p -> ProductResponseDto.from(p, sellerNameMap.getOrDefault(p.getSellerId(), "")))
+			.toList();
+
+		return SearchProductResponseDto.from(page, content);
+	}
+
 	@Override
+	@CircuitBreaker(name = "elasticsearchCB", fallbackMethod = "searchMyFallback")
 	public SearchProductResponseDto searchMy(SearchProductRequestDto requestDto, UUID sellerId) {
 		Pageable pageable = PageRequest.of(requestDto.thisPage(), requestDto.pageSize());
 		String sellerIdStr = sellerId.toString();
@@ -188,6 +216,26 @@ public class ProductService implements ProductUseCase {
 			.toList();
 
 		return SearchProductResponseDto.fromEs(page, content);
+	}
+
+	private SearchProductResponseDto searchMyFallback(SearchProductRequestDto requestDto, UUID sellerId, Throwable t) {
+		log.warn("ES 장애 감지 — DB fallback 실행. circuit: elasticsearchCB, 원인: {}", t.getMessage());
+		Pageable pageable = PageRequest.of(requestDto.thisPage(), requestDto.pageSize());
+
+		Page<Product> page;
+		if (requestDto.title() == null || requestDto.title().isBlank()) {
+			page = productRepository.findBySellerIdAndStatusAndDeleteDtIsNull(sellerId, ProductStatus.ENABLE, pageable);
+		} else {
+			page = productRepository.findBySellerIdAndStatusAndTitleContainingAndDeleteDtIsNull(sellerId,
+				ProductStatus.ENABLE, requestDto.title(), pageable);
+		}
+
+		UserResponseDto seller = findBySellerIdOrThrow(sellerId);
+		List<ProductResponseDto> content = page.getContent().stream()
+			.map(p -> ProductResponseDto.from(p, seller.name()))
+			.toList();
+
+		return SearchProductResponseDto.from(page, content);
 	}
 
 	@Override

--- a/service/product/src/main/java/jabaclass/product/application/service/ProductService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/ProductService.java
@@ -185,10 +185,14 @@ public class ProductService implements ProductUseCase {
 				requestDto.title(), pageable);
 		}
 
+		if (page.isEmpty()) {
+			return SearchProductResponseDto.from(page, List.of());
+		}
+
 		List<UUID> sellerIds = page.getContent().stream().map(Product::getSellerId).distinct().toList();
 		Map<UUID, String> sellerNameMap = sellerRepository.findSellerList(sellerIds)
 			.map(list -> list.stream()
-				.collect(Collectors.toMap(UserResponseDto::userId, UserResponseDto::name)))
+				.collect(Collectors.toMap(UserResponseDto::userId, UserResponseDto::name, (existing, replacement) -> existing)))
 			.orElse(Map.of());
 
 		List<ProductResponseDto> content = page.getContent().stream()
@@ -228,6 +232,10 @@ public class ProductService implements ProductUseCase {
 		} else {
 			page = productRepository.findBySellerIdAndStatusAndTitleContainingAndDeleteDtIsNull(sellerId,
 				ProductStatus.ENABLE, requestDto.title(), pageable);
+		}
+
+		if (page.isEmpty()) {
+			return SearchProductResponseDto.from(page, List.of());
 		}
 
 		UserResponseDto seller = findBySellerIdOrThrow(sellerId);

--- a/service/product/src/main/java/jabaclass/product/config/SchedulingConfig.java
+++ b/service/product/src/main/java/jabaclass/product/config/SchedulingConfig.java
@@ -1,6 +1,7 @@
 package jabaclass.product.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 /*
@@ -8,5 +9,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
  * */
 @Configuration
 @EnableScheduling
+@EnableAsync
 public class SchedulingConfig {
 }

--- a/service/product/src/main/java/jabaclass/product/domain/repository/ProductRepository.java
+++ b/service/product/src/main/java/jabaclass/product/domain/repository/ProductRepository.java
@@ -33,4 +33,11 @@ public interface ProductRepository {
 
 	// ES 초기 마이그레이션용 — 삭제되지 않은 전체 상품 배치 조회
 	Page<Product> findAllByDeleteDtIsNull(Pageable pageable);
+
+	// ES 장애 시 DB fallback — 판매자별 전체 조회
+	Page<Product> findBySellerIdAndStatusAndDeleteDtIsNull(UUID sellerId, ProductStatus status, Pageable pageable);
+
+	// ES 장애 시 DB fallback — 판매자별 키워드 검색
+	Page<Product> findBySellerIdAndStatusAndTitleContainingAndDeleteDtIsNull(UUID sellerId, ProductStatus status,
+		String keyword, Pageable pageable);
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ElasticsearchCircuitBreakerEventListener.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ElasticsearchCircuitBreakerEventListener.java
@@ -1,0 +1,28 @@
+package jabaclass.product.infrastructure.elasticsearch;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ElasticsearchCircuitBreakerEventListener {
+
+	private final CircuitBreakerRegistry circuitBreakerRegistry;
+	private final ElasticsearchRecoveryService recoveryService;
+
+	@PostConstruct
+	public void registerListener() {
+		circuitBreakerRegistry.circuitBreaker("elasticsearchCB")
+			.getEventPublisher()
+			.onStateTransition(event -> {
+				if (event.getStateTransition().getToState() == CircuitBreaker.State.CLOSED) {
+					recoveryService.retryFailedEsEvents(); // 외부 빈 호출 → 프록시 경유 → @Async 정상 동작
+				}
+			});
+	}
+}

--- a/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ElasticsearchRecoveryService.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/elasticsearch/ElasticsearchRecoveryService.java
@@ -1,0 +1,23 @@
+package jabaclass.product.infrastructure.elasticsearch;
+
+import jabaclass.product.infrastructure.outbox.OutboxService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ElasticsearchRecoveryService {
+
+	private final OutboxService outboxService;
+
+	@Async
+	public void retryFailedEsEvents() {
+		int count = outboxService.resetFailedEsEvents();
+		if (count > 0) {
+			log.info("ES 복구 감지 — FAILED 아웃박스 이벤트 {}건 재처리 예약", count);
+		}
+	}
+}

--- a/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxEvent.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxEvent.java
@@ -82,4 +82,9 @@ public class OutboxEvent extends EntityBase {
 	public boolean isRetryExceeded() {
 		return this.retryCount >= 5;
 	}
+
+	public void resetForRetry() {
+		this.status = OutboxStatus.PENDING;
+		this.retryCount = 0;
+	}
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxRepository.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxRepository.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OutboxRepository extends JpaRepository<OutboxEvent, UUID> {
 
@@ -20,12 +21,12 @@ public interface OutboxRepository extends JpaRepository<OutboxEvent, UUID> {
 	""", nativeQuery = true)
 	List<OutboxEvent> findProcessableEvents(LocalDateTime threshold, int limit);
 
-	@Modifying
+	@Modifying(clearAutomatically = true)
 	@Query(value = """
 		UPDATE product_outbox_events
 		SET status = 'PENDING', retry_count = 0
 		WHERE status = 'FAILED'
-		  AND event_type IN ('ES_SAVE', 'ES_DELETE')
+		  AND event_type IN (:esEventTypes)
 	""", nativeQuery = true)
-	int resetFailedEsEvents();
+	int resetFailedEsEvents(@Param("esEventTypes") List<String> esEventTypes);
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxRepository.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface OutboxRepository extends JpaRepository<OutboxEvent, UUID> {
@@ -19,10 +20,12 @@ public interface OutboxRepository extends JpaRepository<OutboxEvent, UUID> {
 	""", nativeQuery = true)
 	List<OutboxEvent> findProcessableEvents(LocalDateTime threshold, int limit);
 
+	@Modifying
 	@Query(value = """
-		SELECT * FROM product_outbox_events
+		UPDATE product_outbox_events
+		SET status = 'PENDING', retry_count = 0
 		WHERE status = 'FAILED'
 		  AND event_type IN ('ES_SAVE', 'ES_DELETE')
 	""", nativeQuery = true)
-	List<OutboxEvent> findFailedEsEvents();
+	int resetFailedEsEvents();
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxRepository.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxRepository.java
@@ -18,4 +18,11 @@ public interface OutboxRepository extends JpaRepository<OutboxEvent, UUID> {
 		FOR UPDATE SKIP LOCKED
 	""", nativeQuery = true)
 	List<OutboxEvent> findProcessableEvents(LocalDateTime threshold, int limit);
+
+	@Query(value = """
+		SELECT * FROM product_outbox_events
+		WHERE status = 'FAILED'
+		  AND event_type IN ('ES_SAVE', 'ES_DELETE')
+	""", nativeQuery = true)
+	List<OutboxEvent> findFailedEsEvents();
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxService.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxService.java
@@ -51,6 +51,7 @@ public class OutboxService {
 
 	@Transactional
 	public int resetFailedEsEvents() {
-		return outboxRepository.resetFailedEsEvents();
+		List<String> esEventTypes = List.of(EsEventType.ES_SAVE.name(), EsEventType.ES_DELETE.name());
+		return outboxRepository.resetFailedEsEvents(esEventTypes);
 	}
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxService.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxService.java
@@ -48,4 +48,12 @@ public class OutboxService {
 		}
 		outboxRepository.save(event);
 	}
+
+	@Transactional
+	public int resetFailedEsEvents() {
+		List<OutboxEvent> failed = outboxRepository.findFailedEsEvents();
+		failed.forEach(OutboxEvent::resetForRetry);
+		outboxRepository.saveAll(failed);
+		return failed.size();
+	}
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxService.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxService.java
@@ -51,9 +51,6 @@ public class OutboxService {
 
 	@Transactional
 	public int resetFailedEsEvents() {
-		List<OutboxEvent> failed = outboxRepository.findFailedEsEvents();
-		failed.forEach(OutboxEvent::resetForRetry);
-		outboxRepository.saveAll(failed);
-		return failed.size();
+		return outboxRepository.resetFailedEsEvents();
 	}
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ProductJpaRepository.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ProductJpaRepository.java
@@ -24,4 +24,9 @@ public interface ProductJpaRepository extends JpaRepository<Product, UUID> {
 	List<Product> findAllByIdInAndDeleteDtIsNull(List<UUID> productIds);
 
 	Page<Product> findAllByDeleteDtIsNull(Pageable pageable);
+
+	Page<Product> findBySellerIdAndStatusAndDeleteDtIsNull(UUID sellerId, ProductStatus status, Pageable pageable);
+
+	Page<Product> findBySellerIdAndStatusAndTitleContainingAndDeleteDtIsNull(UUID sellerId, ProductStatus status,
+		String keyword, Pageable pageable);
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ProductRepositoryAdapter.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ProductRepositoryAdapter.java
@@ -61,4 +61,17 @@ public class ProductRepositoryAdapter implements ProductRepository {
 		return productJpaRepository.findAllByDeleteDtIsNull(pageable);
 	}
 
+	@Override
+	public Page<Product> findBySellerIdAndStatusAndDeleteDtIsNull(UUID sellerId, ProductStatus status,
+		Pageable pageable) {
+		return productJpaRepository.findBySellerIdAndStatusAndDeleteDtIsNull(sellerId, status, pageable);
+	}
+
+	@Override
+	public Page<Product> findBySellerIdAndStatusAndTitleContainingAndDeleteDtIsNull(UUID sellerId,
+		ProductStatus status, String keyword, Pageable pageable) {
+		return productJpaRepository.findBySellerIdAndStatusAndTitleContainingAndDeleteDtIsNull(sellerId, status,
+			keyword, pageable);
+	}
+
 }

--- a/service/product/src/main/resources/application.yml
+++ b/service/product/src/main/resources/application.yml
@@ -28,8 +28,21 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,circuitbreakers
   endpoint:
     health:
       probes:
         enabled: true
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      elasticsearchCB:
+        registerHealthIndicator: true
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        permittedNumberOfCallsInHalfOpenState: 3
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+        waitDurationInOpenState: 30s
+        failureRateThreshold: 50
+        eventConsumerBufferSize: 10


### PR DESCRIPTION
## 관련 이슈
  - Close #361 
  
  ## 변경 요약
  - Resilience4j Circuit Breaker 적용으로 ES 장애 시 DB로 자동 fallback
  - ES 복구 시 장애 중 누락된 색인 이벤트 자동 재처리

  ## 주요 변경점
  - `searchAll` / `searchMy` 에 `@CircuitBreaker` 적용 — ES 실패 누적 시 DB 조회로 전환
  - `ElasticsearchCircuitBreakerEventListener` — Circuit CLOSED 전환 감지
  - `ElasticsearchRecoveryService` — ES 복구 시 FAILED OutboxEvent를 PENDING으로 리셋, 기존 OutboxPublisher가 자동 재발행하여 ES 재색인
  - `ProductRepository` 에 판매자별 DB 조회 메서드 추가 (searchMy fallback용)

  ## 테스트
  - [ ] 로컬 실행 확인
  - [ ] 테스트 통과
  - [ ] (해당 시) Postman/Swagger로 API 확인

  ## 리뷰 포인트
  - Circuit Breaker 임계치 설정값 (slidingWindowSize: 10, failureRateThreshold: 50%,  waitDuration: 30s) 프로젝트 상황에 맞는지
  - `ElasticsearchRecoveryService` 를 별도 빈으로 분리한 이유 — `@Async` self-invocation  버그 방지
  - ES 복구 시 전체 재색인 대신 FAILED 이벤트만 재처리하는 방식으로 부하 최소화