### PR TITLE
feat: 상품 일괄 생성 API 추가

### DIFF
--- a/service/product/src/main/java/jabaclass/product/application/service/ProductBatchCreateService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/ProductBatchCreateService.java
@@ -1,0 +1,53 @@
+package jabaclass.product.application.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jabaclass.product.application.usecase.ProductBatchCreateUseCase;
+import jabaclass.product.application.usecase.ProductUseCase;
+import jabaclass.product.presentation.dto.request.CreateProductBatchRequestDto;
+import jabaclass.product.presentation.dto.request.CreateProductRequestDto;
+import jabaclass.product.presentation.dto.response.ProductBatchCreateResponseDto;
+import jabaclass.product.presentation.dto.response.ProductResponseDto;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProductBatchCreateService implements ProductBatchCreateUseCase {
+
+	private final ProductUseCase productUseCase;
+
+	@Override
+	@Transactional
+	public ProductBatchCreateResponseDto createBatch(CreateProductBatchRequestDto requestDto, UUID sellerId) {
+		List<ProductResponseDto> createdProducts = requestDto.products().stream()
+			.map(product -> overwriteSeller(product, sellerId))
+			.map(product -> productUseCase.create(product, sellerId))
+			.toList();
+
+		return ProductBatchCreateResponseDto.of(createdProducts);
+	}
+
+	private CreateProductRequestDto overwriteSeller(
+		CreateProductRequestDto requestDto,
+		UUID sellerId
+	) {
+		return new CreateProductRequestDto(
+			sellerId,
+			requestDto.title(),
+			requestDto.maxCapacity(),
+			requestDto.description(),
+			requestDto.imageIds(),
+			requestDto.price(),
+			requestDto.status(),
+			requestDto.roadAddress(),
+			requestDto.detailAddress(),
+			requestDto.zonecode(),
+			requestDto.latitude(),
+			requestDto.longitude()
+		);
+	}
+}

--- a/service/product/src/main/java/jabaclass/product/application/usecase/ProductBatchCreateUseCase.java
+++ b/service/product/src/main/java/jabaclass/product/application/usecase/ProductBatchCreateUseCase.java
@@ -1,0 +1,11 @@
+package jabaclass.product.application.usecase;
+
+import java.util.UUID;
+
+import jabaclass.product.presentation.dto.request.CreateProductBatchRequestDto;
+import jabaclass.product.presentation.dto.response.ProductBatchCreateResponseDto;
+
+public interface ProductBatchCreateUseCase {
+
+	ProductBatchCreateResponseDto createBatch(CreateProductBatchRequestDto requestDto, UUID sellerId);
+}

--- a/service/product/src/main/java/jabaclass/product/presentation/controller/ProductBatchCreateController.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/controller/ProductBatchCreateController.java
@@ -1,0 +1,37 @@
+package jabaclass.product.presentation.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jabaclass.product.application.usecase.ProductBatchCreateUseCase;
+import jabaclass.product.common.auth.CurrentUser;
+import jabaclass.product.common.exception.ApiResponseDto;
+import jabaclass.product.presentation.dto.request.CreateProductBatchRequestDto;
+import jabaclass.product.presentation.dto.response.ProductBatchCreateResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/products/batch")
+@RequiredArgsConstructor
+public class ProductBatchCreateController {
+
+	private final ProductBatchCreateUseCase productBatchCreateUseCase;
+
+	@PostMapping
+	public ResponseEntity<ApiResponseDto<ProductBatchCreateResponseDto>> createBatchProducts(
+		@RequestBody @Valid CreateProductBatchRequestDto request,
+		@CurrentUser UUID userId
+	) {
+		ProductBatchCreateResponseDto response = productBatchCreateUseCase.createBatch(request, userId);
+
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(ApiResponseDto.success(HttpStatus.CREATED, "성공적으로 상품이 일괄 생성되었습니다.", response));
+	}
+}

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/request/CreateProductBatchRequestDto.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/request/CreateProductBatchRequestDto.java
@@ -1,0 +1,19 @@
+package jabaclass.product.presentation.dto.request;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "상품 일괄 생성 요청")
+public record CreateProductBatchRequestDto(
+	@NotEmpty(message = "생성할 상품 목록은 비어 있을 수 없습니다.")
+	@Size(max = 20, message = "한 번에 최대 20개까지만 생성할 수 있습니다.")
+	@Valid
+	@ArraySchema(schema = @Schema(implementation = CreateProductRequestDto.class))
+	List<CreateProductRequestDto> products
+) {
+}

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/response/ProductBatchCreateResponseDto.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/response/ProductBatchCreateResponseDto.java
@@ -1,0 +1,18 @@
+package jabaclass.product.presentation.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "상품 일괄 생성 응답")
+public record ProductBatchCreateResponseDto(
+	@Schema(description = "생성된 상품 수", example = "3")
+	int createdCount,
+
+	@Schema(description = "생성된 상품 목록")
+	List<ProductResponseDto> products
+) {
+	public static ProductBatchCreateResponseDto of(List<ProductResponseDto> products) {
+		return new ProductBatchCreateResponseDto(products.size(), products);
+	}
+}


### PR DESCRIPTION
## 관련 이슈
- Close #368 

## 변경 요약
- 여러 상품을 한 번에 생성할 수 있는 상품 일괄 생성 API를 추가했습니다.
- 기존 단건 상품 생성 로직을 재사용하도록 분리해 상품 저장 후 이벤트 발행 및 후속 흐름이 동일하게 동작하도록 구성했습니다.

## 주요 변경점
- `ProductBatchCreateController`를 추가해 `ProductRestController`와 분리된 일괄 생성 전용 엔드포인트를 구성했습니다.
- 배치 생성 시 요청 바디의 각 상품을 순회하며 기존 `productUseCase.create()`를 재사용하도록 구현했습니다.
- 배치 생성 요청은 **최대 20개까지** 허용하도록 제한했습니다.

## 테스트
- [x] 로컬 실행 확인
- [ ] 테스트 통과
- [x] (해당 시) Postman/Swagger로 API 확인

## 사용 방법 
- **Postman** 사용 
- POST /api/v1/products/batch
- Authorization Bearer Token 넣고, 
- Body raw Json으로 데이터 넣기 
  ex) 
  ```
  {
    "products": [
      {
        "sellerId": "87dacc5c-0fe6-40c7-8032-eae2a4ac155b",
        "title": "시트러스 향수 만들기 클래스",
        "maxCapacity": 6,
        "description": "레몬, 오렌지, 베르가못 등 상큼한 시트러스 계열 향료를 활용하는 클래스입니다.\n향의 첫인상과 지속력을 고려한 조향 기초를 배울 수 있습니다.\n가볍고 산뜻한 데일리 향수를 직접 제작하는 과정이 포함됩니다.\n향료 간의 조합과 균형을 실습 중심으로 익힐 수 있습니다.\n향수 입문자도 부담 없이 참여할 수 있는 구성입니다.",
        "imageIds": [],
        "price": 85000,
        "status": "ENABLE",
        "roadAddress": "서울 성동구 성수이로 120",
        "detailAddress": "3층",
        "zonecode": "04790",
        "latitude": 37.5451,
        "longitude": 127.0565
      },
      {
        "sellerId": "87dacc5c-0fe6-40c7-8032-eae2a4ac155b",
        "title": "플로럴 향수 블렌딩 클래스",
        "maxCapacity": 6,
        "description": "장미, 자스민, 라벤더 등 다양한 꽃 향을 활용하는 클래스입니다.\n부드럽고 우아한 향을 중심으로 조향을 진행합니다.\n향료의 농도와 확산력을 고려한 블렌딩 방법을 배웁니다.\n자신의 취향에 맞는 향 조합을 직접 실험할 수 있습니다.\n감성적인 향을 선호하는 분들에게 적합한 과정입니다.",
        "imageIds": [],
        "price": 90000,
        "status": "ENABLE",
        "roadAddress": "서울 성동구 성수이로 122",
        "detailAddress": "2층",
        "zonecode": "04791",
        "latitude": 37.5453,
        "longitude": 127.0567
      }
  }
  ```