### PR TITLE
refactor: redis 장애 대응을 위한 CircuitBreaker 도입 및 DB를 활용하여 redis 대체할 수 있도록 변경

### DIFF
--- a/.github/k3s/gateway-rules-config.yml
+++ b/.github/k3s/gateway-rules-config.yml
@@ -124,3 +124,6 @@ data:
           path: /api/v1/admins/**
           allowedRoles:
             - ADMIN
+        - method: GET
+          path: /api/v1/auth/internal/**
+          allowedRoles: []

--- a/api-gateway/build.gradle
+++ b/api-gateway/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // CircuitBreaker
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
     testCompileOnly 'org.projectlombok:lombok'

--- a/api-gateway/src/main/java/jabaclass/apigateway/client/TokenStatusClient.java
+++ b/api-gateway/src/main/java/jabaclass/apigateway/client/TokenStatusClient.java
@@ -1,0 +1,43 @@
+package jabaclass.apigateway.client;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import reactor.core.publisher.Mono;
+
+import jabaclass.apigateway.dto.TokenStatusResult;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TokenStatusClient {
+
+	private final WebClient.Builder webClientBuilder;
+
+	@Value("${internal.user-service-url}")
+	private String userServiceUrl;
+
+	@Value("${internal.secret}")
+	private String internalSecret;
+
+	public Mono<TokenStatusResult> check(String token, UUID userId, long issuedAtMillis) {
+		return webClientBuilder.build()
+			.get()
+			.uri(userServiceUrl + "/api/v1/auth/internal/token-status")
+			.header("X-Token", token)
+			.header("X-User-Id", userId.toString())
+			.header("X-Token-Iat", String.valueOf(issuedAtMillis))
+			.header("X-Internal-Secret", internalSecret)
+			.retrieve()
+			.bodyToMono(TokenStatusResult.class)
+			.timeout(Duration.ofSeconds(3))
+			.doOnError(e -> log.error("[GATEWAY] UserService token-status 호출 실패: {}", e.getMessage()));
+	}
+}

--- a/api-gateway/src/main/java/jabaclass/apigateway/client/TokenStatusClient.java
+++ b/api-gateway/src/main/java/jabaclass/apigateway/client/TokenStatusClient.java
@@ -3,7 +3,6 @@ package jabaclass.apigateway.client;
 import java.time.Duration;
 import java.util.UUID;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -15,22 +14,26 @@ import reactor.core.publisher.Mono;
 import jabaclass.apigateway.dto.TokenStatusResult;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class TokenStatusClient {
 
-	private final WebClient.Builder webClientBuilder;
+	private final WebClient webClient;
+	private final String internalSecret;
 
-	@Value("${internal.user-service-url}")
-	private String userServiceUrl;
-
-	@Value("${internal.secret}")
-	private String internalSecret;
+	public TokenStatusClient(
+		WebClient.Builder webClientBuilder,
+		@Value("${internal.user-service-url}") String userServiceUrl,
+		@Value("${internal.secret}") String internalSecret
+	) {
+		this.webClient = webClientBuilder
+			.baseUrl(userServiceUrl)
+			.build();
+		this.internalSecret = internalSecret;
+	}
 
 	public Mono<TokenStatusResult> check(String token, UUID userId, long issuedAtMillis) {
-		return webClientBuilder.build()
-			.get()
-			.uri(userServiceUrl + "/api/v1/auth/internal/token-status")
+		return webClient.get()
+			.uri("/api/v1/auth/internal/token-status")
 			.header("X-Token", token)
 			.header("X-User-Id", userId.toString())
 			.header("X-Token-Iat", String.valueOf(issuedAtMillis))

--- a/api-gateway/src/main/java/jabaclass/apigateway/dto/TokenStatusResult.java
+++ b/api-gateway/src/main/java/jabaclass/apigateway/dto/TokenStatusResult.java
@@ -1,3 +1,3 @@
 package jabaclass.apigateway.dto;
 
-public record TokenStatusResult(boolean valid, String reason) {}
+public record TokenStatusResult(boolean tokenValid, String reason) {}

--- a/api-gateway/src/main/java/jabaclass/apigateway/dto/TokenStatusResult.java
+++ b/api-gateway/src/main/java/jabaclass/apigateway/dto/TokenStatusResult.java
@@ -1,0 +1,3 @@
+package jabaclass.apigateway.dto;
+
+public record TokenStatusResult(boolean valid, String reason) {}

--- a/api-gateway/src/main/java/jabaclass/apigateway/exception/RedisCircuitOpenException.java
+++ b/api-gateway/src/main/java/jabaclass/apigateway/exception/RedisCircuitOpenException.java
@@ -1,0 +1,8 @@
+package jabaclass.apigateway.exception;
+
+public class RedisCircuitOpenException extends RuntimeException{
+
+	public RedisCircuitOpenException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/api-gateway/src/main/java/jabaclass/apigateway/filter/JwtAuthenticationFilter.java
+++ b/api-gateway/src/main/java/jabaclass/apigateway/filter/JwtAuthenticationFilter.java
@@ -70,8 +70,9 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
     private static final String BLACKLIST_PREFIX = "blacklist:";
     private static final String FORCE_LOGOUT_PREFIX = "force_logout:";
 	private static final Duration WHITELIST_TIMEOUT = Duration.ofSeconds(2);
-	private static final Duration OPTIONAL_AUTH_ENRICHMENT_TIMEOUT = Duration.ofMillis(200);
-	private static final Duration REQUIRED_AUTH_BLACKLIST_TIMEOUT = Duration.ofSeconds(2);
+	private static final Duration OPTIONAL_AUTH_ENRICHMENT_TIMEOUT = Duration.ofMillis(300);
+	private static final Duration REQUIRED_AUTH_BLACKLIST_TIMEOUT = Duration.ofMillis(300);
+	private static final Duration FORCED_LOGOUT_TIMEOUT = Duration.ofMillis(300);
 	private static final Duration RBAC_TIMEOUT = Duration.ofSeconds(3);
 
 	private static final byte[] FORBIDDEN_BODY =
@@ -282,7 +283,7 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 					return Mono.just(TokenCheckResult.BLACKLISTED);
 				}
 				return redisTemplate.opsForValue().get(FORCE_LOGOUT_PREFIX + userId)
-					.timeout(Duration.ofMillis(200))
+					.timeout(FORCED_LOGOUT_TIMEOUT)
 					.defaultIfEmpty("")
 					.map(forceLogoutTime -> {
 						if (forceLogoutTime.isEmpty()) return TokenCheckResult.OK;

--- a/api-gateway/src/main/java/jabaclass/apigateway/filter/JwtAuthenticationFilter.java
+++ b/api-gateway/src/main/java/jabaclass/apigateway/filter/JwtAuthenticationFilter.java
@@ -46,6 +46,7 @@ import jabaclass.apigateway.exception.RedisBlacklistException;
 import jabaclass.apigateway.exception.SystemErrorCode;
 import jabaclass.apigateway.security.JwtProvider;
 import jabaclass.apigateway.security.JwtTokenResolver;
+import reactor.util.retry.Retry;
 
 @Component
 @RequiredArgsConstructor
@@ -136,7 +137,8 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 
 			return redisCircuitBreaker.run(
 					redisTemplate.hasKey(BLACKLIST_PREFIX + token)
-						.timeout(OPTIONAL_AUTH_ENRICHMENT_TIMEOUT),
+						.timeout(OPTIONAL_AUTH_ENRICHMENT_TIMEOUT)
+						.retryWhen(Retry.fixedDelay(2, Duration.ofMillis(30))),
 					throwable -> Mono.just(false)
 				)
 				.flatMap(isBlacklisted -> {
@@ -187,7 +189,8 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 			String role = jwtProvider.getRole(claims);
 
 			return redisCircuitBreaker.run(
-					checkTokenViaRedis(token, userId, claims),
+					checkTokenViaRedis(token, userId, claims)
+						.retryWhen(Retry.fixedDelay(1, Duration.ofMillis(50))),
 					throwable -> {
 						if (throwable instanceof CallNotPermittedException) {
 							return Mono.error(new RedisCircuitOpenException(throwable));
@@ -206,6 +209,7 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 					log.warn("[GATEWAY] Redis CB OPEN - UserService fallback. userId={}", userId);
 					long iat = claims.getIssuedAt() != null ? claims.getIssuedAt().getTime() : 0L;
 					return tokenStatusClient.check(token, userId, iat)
+						.retryWhen(Retry.fixedDelay(1, Duration.ofMillis(100)))
 						.flatMap(status -> {
 							if (!status.valid()) {
 								log.warn("[GATEWAY] Fallback 차단. reason={}, userId={}", status.reason(), userId);

--- a/api-gateway/src/main/java/jabaclass/apigateway/filter/JwtAuthenticationFilter.java
+++ b/api-gateway/src/main/java/jabaclass/apigateway/filter/JwtAuthenticationFilter.java
@@ -211,7 +211,7 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 					return tokenStatusClient.check(token, userId, iat)
 						.retryWhen(Retry.fixedDelay(1, Duration.ofMillis(100)))
 						.flatMap(status -> {
-							if (!status.valid()) {
+							if (!status.tokenValid()) {
 								log.warn("[GATEWAY] Fallback 차단. reason={}, userId={}", status.reason(), userId);
 								return onError(exchange, JwtErrorCode.INVALID_TOKEN);
 							}

--- a/api-gateway/src/main/java/jabaclass/apigateway/filter/JwtAuthenticationFilter.java
+++ b/api-gateway/src/main/java/jabaclass/apigateway/filter/JwtAuthenticationFilter.java
@@ -293,8 +293,9 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 						if (forceLogoutTime.isEmpty()) return TokenCheckResult.OK;
 						try {
 							LocalDateTime forceLogoutDt = LocalDateTime.parse(forceLogoutTime);
-							LocalDateTime tokenIssuedAt = claims.getIssuedAt().toInstant()
-								.atZone(ZoneId.systemDefault()).toLocalDateTime();
+							LocalDateTime tokenIssuedAt = claims.getIssuedAt() != null
+								? claims.getIssuedAt().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
+								: LocalDateTime.MIN;
 							if (!tokenIssuedAt.isAfter(forceLogoutDt)) {
 								return TokenCheckResult.FORCE_LOGOUT;
 							}

--- a/api-gateway/src/main/java/jabaclass/apigateway/filter/JwtAuthenticationFilter.java
+++ b/api-gateway/src/main/java/jabaclass/apigateway/filter/JwtAuthenticationFilter.java
@@ -2,14 +2,16 @@ package jabaclass.apigateway.filter;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Date;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeoutException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.cloud.client.circuitbreaker.ReactiveCircuitBreaker;
+import org.springframework.cloud.client.circuitbreaker.ReactiveCircuitBreakerFactory;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
@@ -25,10 +27,15 @@ import org.springframework.web.server.ServerWebExchange;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.jsonwebtoken.Claims;
 
 import reactor.core.publisher.Mono;
 
+import jakarta.annotation.PostConstruct;
+
+import jabaclass.apigateway.client.TokenStatusClient;
+import jabaclass.apigateway.exception.RedisCircuitOpenException;
 import jabaclass.apigateway.application.service.RbacService;
 import jabaclass.apigateway.application.service.WhitelistService;
 import jabaclass.apigateway.exception.AuthorizationServiceException;
@@ -51,6 +58,14 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 	private final ReactiveStringRedisTemplate redisTemplate;
 	private final WhitelistService whitelistService;
 	private final RbacService rbacService;
+	private final ReactiveCircuitBreakerFactory<?, ?> circuitBreakerFactory;
+	private final TokenStatusClient tokenStatusClient;
+	private ReactiveCircuitBreaker redisCircuitBreaker;
+
+	@PostConstruct
+	void init() {
+		this.redisCircuitBreaker = circuitBreakerFactory.create("redis-auth");
+	}
 
     private static final String BLACKLIST_PREFIX = "blacklist:";
     private static final String FORCE_LOGOUT_PREFIX = "force_logout:";
@@ -118,44 +133,32 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 			UUID userId = jwtProvider.getUserId(claims);
 			String role = jwtProvider.getRole(claims);
 
-			long blacklistStart = System.currentTimeMillis(); // 로그
-
-			return redisTemplate.hasKey(BLACKLIST_PREFIX + token)
-				//.timeout(Duration.ofMillis(200))
-				.timeout(OPTIONAL_AUTH_ENRICHMENT_TIMEOUT)
-				.doOnNext(r -> log.debug("[GATEWAY] blacklist check: {}ms",
-					System.currentTimeMillis() - blacklistStart)) // 로그
+			return redisCircuitBreaker.run(
+					redisTemplate.hasKey(BLACKLIST_PREFIX + token)
+						.timeout(OPTIONAL_AUTH_ENRICHMENT_TIMEOUT),
+					throwable -> Mono.just(false)
+				)
 				.flatMap(isBlacklisted -> {
-					if (isBlacklisted) {
-						log.debug("[GATEWAY] Ignore blacklisted token on whitelisted path: {} {}", httpMethod, path);
+					if (Boolean.TRUE.equals(isBlacklisted)) {
+						log.debug("[GATEWAY] Blacklisted token on whitelist path, skip enrichment: {} {}", httpMethod,
+							path);
 						return chain.filter(exchange);
 					}
-
 					ServerWebExchange mutatedExchange = exchange.mutate()
 						.request(r -> {
 							r.header("X-User-Id", userId.toString());
-							if (role != null) {
+							if (role != null)
 								r.header("X-User-Role", role);
-							}
 						})
 						.build();
-
 					return chain.filter(mutatedExchange);
 				})
-				.onErrorResume(TimeoutException.class, e -> {
-					log.warn("[GATEWAY] Optional auth enrichment timed out, continuing without user context: {} {}",
-						httpMethod,
-						path);
-					return chain.filter(exchange);
-				})
 				.onErrorResume(e -> {
-					log.warn("[GATEWAY] Optional auth enrichment failed, continuing without user context: {} {}",
-						httpMethod,
-						path, e);
+					log.warn("[GATEWAY] Optional auth enrichment 실패: {} {}", httpMethod, path);
 					return chain.filter(exchange);
 				});
 		} catch (Exception e) {
-			log.debug("[GATEWAY] Ignore invalid token on whitelisted path: {} {}", httpMethod, path);
+			log.debug("[GATEWAY] Invalid token on whitelisted path, skip enrichment: {} {}", httpMethod, path);
 			return chain.filter(exchange);
 		}
 	}
@@ -164,6 +167,7 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 		GatewayFilterChain chain,
 		String path,
 		HttpMethod httpMethod) {
+
 		String token = tokenResolver.resolveToken(exchange);
 
 		if (token == null) {
@@ -178,69 +182,51 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 				return onError(exchange, JwtErrorCode.INVALID_TOKEN);
 			}
 
-			return redisTemplate.hasKey(BLACKLIST_PREFIX + token)
-				//	.timeout(Duration.ofMillis(200))
-				.timeout(REQUIRED_AUTH_BLACKLIST_TIMEOUT)
-				.onErrorMap(RedisBlacklistException::new)
-				.flatMap(isBlacklisted -> {
-					if (isBlacklisted) {
-						log.warn("[GATEWAY] Blacklisted token. Path: {} {}", httpMethod, path);
+			UUID userId = jwtProvider.getUserId(claims);
+			String role = jwtProvider.getRole(claims);
+
+			return redisCircuitBreaker.run(
+					checkTokenViaRedis(token, userId, claims),
+					throwable -> {
+						if (throwable instanceof CallNotPermittedException) {
+							return Mono.error(new RedisCircuitOpenException(throwable));
+						}
+						return Mono.error(new RedisBlacklistException(throwable));
+					}
+				)
+				.flatMap(result -> {
+					if (result != TokenCheckResult.OK) {
+						log.warn("[GATEWAY] Token rejected. result={}, path={} {}", result, httpMethod, path);
 						return onError(exchange, JwtErrorCode.INVALID_TOKEN);
 					}
-
-					UUID userId = jwtProvider.getUserId(claims);
-					String role = jwtProvider.getRole(claims);
-
-					return redisTemplate.opsForValue().get(FORCE_LOGOUT_PREFIX + userId)
-						.timeout(Duration.ofMillis(200))
-						.onErrorMap(RedisBlacklistException::new)
-						.defaultIfEmpty("")
-						.flatMap(forceLogoutTime -> {
-							if (!forceLogoutTime.isEmpty()) {
-								try {
-									long forceLogoutMillis = Long.parseLong(forceLogoutTime);
-									Date issuedAt = claims.getIssuedAt();
-									if (issuedAt == null || issuedAt.getTime() <= forceLogoutMillis) {
-										log.warn("[GATEWAY] Force logout detected. Path: {} {}, userId: {}", httpMethod, path, userId);
-										return onError(exchange, JwtErrorCode.INVALID_TOKEN);
-									}
-								} catch (NumberFormatException e) {
-									log.error("[GATEWAY] Invalid forceLogoutTime format in Redis, userId: {}", userId);
-								}
+					return proceedAfterAuth(exchange, chain, path, httpMethod, userId, role);
+				})
+				.onErrorResume(RedisCircuitOpenException.class, e -> {
+					log.warn("[GATEWAY] Redis CB OPEN - UserService fallback. userId={}", userId);
+					long iat = claims.getIssuedAt() != null ? claims.getIssuedAt().getTime() : 0L;
+					return tokenStatusClient.check(token, userId, iat)
+						.flatMap(status -> {
+							if (!status.valid()) {
+								log.warn("[GATEWAY] Fallback 차단. reason={}, userId={}", status.reason(), userId);
+								return onError(exchange, JwtErrorCode.INVALID_TOKEN);
 							}
-
-							return rbacService.isAllowed(path, httpMethod, role)
-								.timeout(RBAC_TIMEOUT)
-								.onErrorMap(AuthorizationServiceException::new)
-								.flatMap(isAllowed -> {
-									if (!isAllowed) {
-										log.warn("[GATEWAY] Role not allowed. Path: {} {}, Role: {}", httpMethod, path, role);
-										return onForbidden(exchange);
-									}
-
-									ServerWebExchange mutatedExchange = exchange.mutate()
-										.request(r -> {
-											r.header("X-User-Id", userId.toString());
-											if (role != null) {
-												r.header("X-User-Role", role);
-											}
-										})
-										.build();
-
-									return chain.filter(mutatedExchange);
-								});
+							return proceedAfterAuth(exchange, chain, path, httpMethod, userId, role);
+						})
+						.onErrorResume(e2 -> {
+							log.error("[GATEWAY] UserService fallback 실패. fail-closed. userId={}", userId);
+							return onError(exchange, SystemErrorCode.AUTH_SERVICE_UNAVAILABLE);
 						});
 				})
 				.onErrorResume(RedisBlacklistException.class, e -> {
-					log.error("[GATEWAY] Redis blacklist check failed: {}", extractMessage(e));
+					log.error("[GATEWAY] Redis 오류: {}", extractMessage(e));
 					return onError(exchange, SystemErrorCode.AUTH_SERVICE_UNAVAILABLE);
 				})
 				.onErrorResume(AuthorizationServiceException.class, e -> {
-					log.error("[GATEWAY] RBAC system error: {}", extractMessage(e));
+					log.error("[GATEWAY] RBAC 오류: {}", extractMessage(e));
 					return onError(exchange, SystemErrorCode.INTERNAL_ERROR);
 				})
 				.onErrorResume(e -> {
-					log.error("[GATEWAY] Unexpected error: {}", extractMessage(e));
+					log.error("[GATEWAY] 예상치 못한 오류: {}", extractMessage(e));
 					return onError(exchange, SystemErrorCode.INTERNAL_ERROR);
 				});
 
@@ -282,5 +268,56 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 
 	private String extractMessage(Throwable e) {
 		return e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
+	}
+
+	private enum TokenCheckResult {
+		OK, BLACKLISTED, FORCE_LOGOUT
+	}
+
+	private Mono<TokenCheckResult> checkTokenViaRedis(String token, UUID userId, Claims claims) {
+		return redisTemplate.hasKey(BLACKLIST_PREFIX + token)
+			.timeout(REQUIRED_AUTH_BLACKLIST_TIMEOUT)
+			.flatMap(isBlacklisted -> {
+				if (Boolean.TRUE.equals(isBlacklisted)) {
+					return Mono.just(TokenCheckResult.BLACKLISTED);
+				}
+				return redisTemplate.opsForValue().get(FORCE_LOGOUT_PREFIX + userId)
+					.timeout(Duration.ofMillis(200))
+					.defaultIfEmpty("")
+					.map(forceLogoutTime -> {
+						if (forceLogoutTime.isEmpty()) return TokenCheckResult.OK;
+						try {
+							LocalDateTime forceLogoutDt = LocalDateTime.parse(forceLogoutTime);
+							LocalDateTime tokenIssuedAt = claims.getIssuedAt().toInstant()
+								.atZone(ZoneId.systemDefault()).toLocalDateTime();
+							if (!tokenIssuedAt.isAfter(forceLogoutDt)) {
+								return TokenCheckResult.FORCE_LOGOUT;
+							}
+						} catch (Exception e) {
+							log.error("[GATEWAY] force_logout 파싱 실패. userId={}", userId);
+						}
+						return TokenCheckResult.OK;
+					});
+			});
+	}
+
+	private Mono<Void> proceedAfterAuth(ServerWebExchange exchange, GatewayFilterChain chain,
+		String path, HttpMethod httpMethod, UUID userId, String role) {
+		return rbacService.isAllowed(path, httpMethod, role)
+			.timeout(RBAC_TIMEOUT)
+			.onErrorMap(AuthorizationServiceException::new)
+			.flatMap(isAllowed -> {
+				if (!isAllowed) {
+					log.warn("[GATEWAY] Role not allowed. path={} {}, role={}", httpMethod, path, role);
+					return onForbidden(exchange);
+				}
+				ServerWebExchange mutated = exchange.mutate()
+					.request(r -> {
+						r.header("X-User-Id", userId.toString());
+						if (role != null) r.header("X-User-Role", role);
+					})
+					.build();
+				return chain.filter(mutated);
+			});
 	}
 }

--- a/api-gateway/src/main/resources/application-prod.yml
+++ b/api-gateway/src/main/resources/application-prod.yml
@@ -16,3 +16,7 @@ logging:
     root: WARN
     jabaclass.apigateway: INFO
     org.springframework.cloud.gateway: WARN
+
+internal:
+  secret: ${USER_INTERNAL_SECRET}
+  user-service-url: ${USER_SERVICE_URL}

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -89,4 +89,16 @@ management:
     health:
       probes:
         enabled: true
+resilience4j:
+  circuitbreaker:
+    instances:
+      redis-auth:
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+        permitted-number-of-calls-in-half-open-state: 5
 
+internal:
+  secret: ${USER_INTERNAL_SECRET}
+  user-service-url: ${USER_SERVICE_URL:http://localhost:9003}

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -94,10 +94,11 @@ resilience4j:
     instances:
       redis-auth:
         sliding-window-type: COUNT_BASED
-        sliding-window-size: 10
-        failure-rate-threshold: 50
+        sliding-window-size: 3
+        minimum-number-of-calls: 1
+        failure-rate-threshold: 34
         wait-duration-in-open-state: 30s
-        permitted-number-of-calls-in-half-open-state: 5
+        permitted-number-of-calls-in-half-open-state: 2
 
 internal:
   secret: ${USER_INTERNAL_SECRET}

--- a/api-gateway/src/main/resources/gateway-rules.yml
+++ b/api-gateway/src/main/resources/gateway-rules.yml
@@ -118,3 +118,6 @@ gateway:
       path: /api/v1/admins/**
       allowedRoles:
         - ADMIN
+    - method: GET
+      path: /api/v1/auth/internal/**
+      allowedRoles: []

--- a/docs/api-gateway.md
+++ b/docs/api-gateway.md
@@ -137,6 +137,43 @@ kubectl exec -it <pod-name> -- cat /etc/config/gateway-rules.yml
 
 ---
 
+### Redis 장애 대응 (Circuit Breaker + Fallback)
+
+`JwtAuthenticationFilter`의 Redis 조회(blacklist / force_logout)는 Circuit Breaker로 보호되며, CB OPEN 시 User 서비스의 내부 API로 fallback한다.
+
+**Circuit Breaker 설정 (redis-auth)**
+
+| 항목 | 값 |
+|------|----|
+| slidingWindowType | COUNT_BASED |
+| slidingWindowSize | 3 |
+| failureRateThreshold | 34% |
+| waitDurationInOpenState | 30s |
+
+**정상 경로 (Redis CLOSED)**
+```
+Redis blacklist 조회 → force_logout 조회 → 통과 or 차단
+  각 조회: 300ms timeout, 1회 retry (50ms delay)
+```
+
+**CB OPEN 경로 (Redis 장애)**
+```
+RedisCircuitOpenException 발생
+  → TokenStatusClient.check() (UserService 내부 API)
+      POST /api/v1/auth/internal/token-status
+      헤더: X-Internal-Secret
+      timeout: 3s
+  → TokenStatusResult.valid() → 통과
+  → TokenStatusResult.blacklisted() / forceLogout() → 차단
+```
+
+**enrichIfAuthenticated (화이트리스트 경로 선택적 인증)**
+
+화이트리스트 경로에서 유효한 JWT가 있을 때 user context를 주입하는 `enrichIfAuthenticated()`는 fail-open으로 동작한다.
+Redis 또는 CB 장애 시 인증 없이 통과하며, 이 경로는 인증이 필수가 아니므로 가용성을 우선한다.
+
+---
+
 ### WhitelistService — 화이트리스트 (JWT 불필요 경로)
 
 `GatewayRulesProperties`에서 직접 조회한다. DB I/O와 캐시가 없으므로 정책 변경이 즉시 반영된다.

--- a/docs/user-auth.md
+++ b/docs/user-auth.md
@@ -21,7 +21,8 @@ POST /api/v1/auth/login
   → AuthService: (email, SocialType.SYSTEM)으로 유저 조회 → 비밀번호 검증
   → AuthService.handleLoginSecurity(): 새 기기 감지 → 보안 알림 이메일 발송 (비동기)
   → JwtProvider: Access Token + Refresh Token 생성
-  → Redis: Refresh Token 저장 (key: "refresh:{userId}")
+  → DB: User.refreshToken 저장 (DB-first — Redis 장애와 무관하게 항상 기록)
+  → Redis: Refresh Token 저장 (key: "refresh:{userId}") — write CB 적용, 실패 시 swallow
   → 응답: Access Token (body) + Refresh Token (HttpOnly Cookie)
 ```
 
@@ -46,8 +47,7 @@ GET /login/oauth2/code/{provider}?code=AUTH_CODE&state=...
   → OAuth2SuccessHandler.onAuthenticationSuccess()
        - ClientIpUtils.extractIp(): X-Real-IP 헤더 → 없으면 remoteAddr
        - AuthService.handleLoginSecurity(): 새 기기 감지 → 보안 알림 이메일 발송 (비동기)
-       - Access Token + Refresh Token 생성
-       - Redis: Refresh Token 저장 (key: "refresh:{userId}")
+       - AuthService.issueOAuth2Tokens(): 일반 로그인과 동일한 DB-first + write CB 경로
        - Refresh Token → HttpOnly Cookie
        - 브라우저를 프론트엔드로 리다이렉트: {OAUTH2_REDIRECT_URI}#token={accessToken}
 
@@ -59,9 +59,16 @@ GET /login/oauth2/code/{provider}?code=AUTH_CODE&state=...
 ```
 POST /api/v1/auth/reissue
   → Cookie에서 Refresh Token 추출
-  → Redis에서 Refresh Token 검증
+  → Redis read CB → Redis에서 Refresh Token 조회 (1회 retry, 50ms delay)
+       → CB OPEN 또는 Redis 장애 시: DB fallback (User.refreshToken 필드)
+  → RTR 감지 (stored ≠ provided):
+       - User.forceLogout() + refreshToken = null → DB commit 보장
+         (@Transactional(noRollbackFor = AuthException.class) — 예외 발생해도 rollback 없음)
+       - force_logout:{userId} → Redis write CB 적용
+       - SUSPECTED_TOKEN_THEFT 예외 반환
   → 새 Access Token + Refresh Token 발급
-  → Redis: 새 Refresh Token으로 교체
+  → DB: User.refreshToken 업데이트 (DB-first)
+  → Redis: 새 Refresh Token으로 교체 — write CB 적용
   → 응답: 새 Access Token (body) + 새 Refresh Token (HttpOnly Cookie)
 ```
 
@@ -69,8 +76,11 @@ POST /api/v1/auth/reissue
 
 ```
 POST /api/v1/auth/logout
-  → Access Token → Redis 블랙리스트 등록 (만료 시간까지 유지)
-  → Redis에서 Refresh Token 삭제
+  → DB: User.refreshToken = null
+  → Redis: Refresh Token 삭제 (key: "refresh:{userId}") — write CB 적용
+  → DB: TokenBlacklist에 sha256(accessToken) + expiresAt 저장 (DB-first)
+  → Redis: blacklist:{accessToken} 등록 (만료 시간까지) — write CB 적용
+  → Caffeine: @CacheEvict("tokenStatus", key=accessToken) — 즉시 무효화
   → Refresh Token Cookie 만료 처리
 ```
 
@@ -89,6 +99,44 @@ GET /api/v1/auth/report-theft?token={token}
   → force_logout:{userId} 설정 → Redis에서 Refresh Token 삭제
   → 이후 해당 userId의 모든 기존 Access Token 차단
 ```
+
+---
+
+## Redis 장애 대응 (Circuit Breaker)
+
+Redis 장애 시에도 로그인/재발급/로그아웃 기능이 정상 동작하도록 DB-first 패턴과 Circuit Breaker를 도입했다.
+
+### 설계 원칙
+
+- **DB-first**: Refresh Token은 항상 `User.refreshToken` 필드(DB)에 먼저 저장된다. Redis는 캐시 역할이며 장애 시 swallow.
+- **Redis-first + DB fallback**: `reissue()`는 Redis를 우선 조회하고, CB OPEN 또는 장애 시 DB에서 조회한다.
+- **read/write Circuit Breaker 분리**: read 장애(가용성 저하)와 write 장애(정합성 저하)는 성격이 다르므로 독립적으로 관리한다.
+
+### Circuit Breaker 설정
+
+| 구분 | 이름 | failureRateThreshold | waitDuration | slidingWindowSize | minimumCalls |
+|------|------|---------------------|--------------|-------------------|--------------|
+| read | `redis-read` | 60% | 20s | 5 | 3 |
+| write | `redis-write` | 80% | 30s | 5 | 3 |
+
+- read CB: OPEN → `reissue()` DB fallback, `reportTheft()` THEFT_REPORT_TOKEN_EXPIRED 반환 (graceful)
+- write CB: OPEN → Redis write 스킵, DB는 이미 저장된 상태이므로 기능 영향 없음
+- HALF-OPEN: 2회 테스트 요청 → 성공 시 CLOSED 복귀
+
+### retry 전략
+
+read 작업만 `executeWithRedisRetry()`로 1회 재시도 (50ms delay)를 한다.
+write 작업은 retry 없이 CB만 적용한다. write 재시도는 멱등성이 보장되지 않는 경우가 있어 배제했다.
+
+### Caffeine 캐시 연동
+
+`checkTokenStatus()` 결과는 Caffeine에 60초 TTL로 캐싱된다 (key: accessToken).
+`logout()` 시 `@CacheEvict`로 즉시 무효화하여 로그아웃 직후 요청에서 stale 캐시가 반환되는 것을 방지한다.
+
+### RTR 감지 시 트랜잭션 보장
+
+`reissue()`에서 RTR(Refresh Token Reuse) 감지 시 `AuthException`을 던져 응답은 4xx를 반환하지만,
+`@Transactional(noRollbackFor = AuthException.class)`를 적용하여 `forceLogout()` 및 `refreshToken = null` DB write는 rollback되지 않고 커밋된다.
 
 ---
 

--- a/service/user/build.gradle
+++ b/service/user/build.gradle
@@ -83,6 +83,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
 
+    // CircuitBreaker
+    implementation 'io.github.resilience4j:resilience4j-circuitbreaker:2.3.0'
+
 }
 
 tasks.named('test') {

--- a/service/user/build.gradle
+++ b/service/user/build.gradle
@@ -79,6 +79,10 @@ dependencies {
     // OAuth2
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+    // Caffeine
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
 }
 
 tasks.named('test') {

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -225,9 +225,15 @@ public class AuthService
     @Override
     @Transactional
     public void reportTheft(String token) {
-        String userIdStr = redisTemplate.opsForValue().get(THEFT_REPORT_PREFIX + token);
+		String userIdStr = null;
+		try {
+			userIdStr = redisTemplate.opsForValue().get(THEFT_REPORT_PREFIX + token);
+		} catch (Exception e) {
+            log.warn("[AUTH] Redis 장애, theft_report 조회 실패. 만료 처리.");
+            throw new AuthException(AuthErrorCode.THEFT_REPORT_TOKEN_EXPIRED);
+		}
 
-        if (userIdStr == null) {
+		if (userIdStr == null) {
             throw new AuthException(AuthErrorCode.THEFT_REPORT_TOKEN_EXPIRED);
         }
 

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -387,6 +387,22 @@ public class AuthService
         log.info("[AUTH] 로그인 성공. userId={}, ip={}", user.getId(), clientIp);
     }
 
+    @Transactional
+    public TokenResult issueOAuth2Tokens(UUID userId, UserRole role) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+        String accessToken = tokenProvider.generateAccessToken(userId, role);
+        String refreshToken = tokenProvider.generateRefreshToken(userId, role);
+
+        user.updateRefreshToken(refreshToken);
+        executeWriteWithCb(() -> redisTemplate.opsForValue().set(
+            "refresh:" + userId, refreshToken, Duration.ofMillis(refreshTokenValidity)
+        ), "refresh:" + userId);
+
+        return new TokenResult(accessToken, refreshToken);
+    }
+
     private static String sha256(String input) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -86,6 +86,8 @@ public class AuthService
         String accessToken = tokenProvider.generateAccessToken(user.getId(), user.getRole());
         String refreshToken = tokenProvider.generateRefreshToken(user.getId(), user.getRole());
 
+        user.updateRefreshToken(refreshToken);
+
         redisTemplate.opsForValue().set(
             "refresh:" + user.getId(),
             refreshToken,
@@ -107,16 +109,30 @@ public class AuthService
         UUID userId = jwtProvider.getUserId(claims);
         String role = jwtProvider.getRole(claims);
 
-        String stored = redisTemplate.opsForValue().get("refresh:" + userId);
+        String stored;
+
+        try {
+            stored = redisTemplate.opsForValue().get("refresh:" + userId);
+        } catch (Exception e) {
+            log.warn("[AUTH] Redis 장애, DB fallback. userId={}", userId);
+            stored = null;
+        }
 
         if (stored == null) {
-            throw new AuthException(AuthErrorCode.ALREADY_LOGGED_OUT);
+            User fallbackUser = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+            if (fallbackUser.getRefreshToken() == null) {
+                throw new AuthException(AuthErrorCode.ALREADY_LOGGED_OUT);
+            }
+
+            stored = fallbackUser.getRefreshToken();
         }
 
         if (!stored.equals(refreshToken)) {
             User targetuser = userRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
             targetuser.forceLogout();
+            targetuser.updateRefreshToken(null);
 
             redisTemplate.opsForValue().set(
                 FORCE_LOGOUT_PREFIX + userId,
@@ -138,6 +154,10 @@ public class AuthService
         String newAccessToken = tokenProvider.generateAccessToken(userId, userRole);
         String newRefreshToken = tokenProvider.generateRefreshToken(userId, userRole);
 
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+        user.updateRefreshToken(newRefreshToken);
+
         redisTemplate.opsForValue().set("refresh:" + userId, newRefreshToken,
             Duration.ofMillis(refreshTokenValidity));
 
@@ -147,6 +167,11 @@ public class AuthService
     @Override
     @Transactional
     public void logout(UUID userId, String accessToken) {
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+        user.updateRefreshToken(null);
+
         redisTemplate.delete("refresh:" + userId);
 
         try {
@@ -189,6 +214,7 @@ public class AuthService
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
         user.forceLogout();
+        user.updateRefreshToken(null);
 
         redisTemplate.opsForValue().set(
             FORCE_LOGOUT_PREFIX + userId,

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -130,7 +130,8 @@ public class AuthService
         }
 
         if (!stored.equals(refreshToken)) {
-            User targetuser = userRepository.findById(userId)...;
+            User targetuser = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
             targetuser.forceLogout();
             targetuser.updateRefreshToken(null);
 

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -130,17 +130,22 @@ public class AuthService
         }
 
         if (!stored.equals(refreshToken)) {
-            User targetuser = userRepository.findById(userId)
-                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+            User targetuser = userRepository.findById(userId)...;
             targetuser.forceLogout();
             targetuser.updateRefreshToken(null);
 
-            redisTemplate.opsForValue().set(
-                FORCE_LOGOUT_PREFIX + userId,
-                LocalDateTime.now().toString(),
-                Duration.ofMillis(accessTokenValidity)
-            );
-            redisTemplate.delete("refresh:" + userId);
+            try {
+                redisTemplate.opsForValue().set(
+                    FORCE_LOGOUT_PREFIX + userId,
+                    LocalDateTime.now().toString(),
+                    Duration.ofMillis(accessTokenValidity)
+                );
+            } catch (Exception e) {
+                log.warn("[AUTH] Redis force_logout 캐싱 실패, DB에는 저장됨. userId={}", userId);
+            }
+            try { redisTemplate.delete("refresh:" + userId); }
+            catch (Exception e) { log.warn("[AUTH] Redis delete 실패, 무시. userId={}", userId); }
+
             log.warn("[AUTH] RTR 재사용 감지 - force_logout 설정. userId={}", userId);
             throw new AuthException(AuthErrorCode.SUSPECTED_TOKEN_THEFT);
         }

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -81,8 +81,8 @@ public class AuthService
 
     @PostConstruct
     void init() {
-        this.redisReadCb = circuitBreakerRegistry.circuitBreaker("redis-read");
-        this.redisWriteCb = circuitBreakerRegistry.circuitBreaker("redis-write");
+        this.redisReadCb = circuitBreakerRegistry.circuitBreaker("redis-read", "redis-read");
+        this.redisWriteCb = circuitBreakerRegistry.circuitBreaker("redis-write", "redis-write");
     }
 
     @Override
@@ -109,7 +109,7 @@ public class AuthService
 		return new TokenResult(accessToken, refreshToken);
     }
 
-    @Transactional
+    @Transactional(noRollbackFor = AuthException.class)
     @Override
     public TokenResult reissue(String refreshToken) {
         Claims claims = jwtProvider.parseClaims(refreshToken);

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -1,22 +1,32 @@
 package jabaclass.user.auth.application.service;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import io.jsonwebtoken.Claims;
 
-import jabaclass.user.user.domain.model.SocialType;
+import jabaclass.user.auth.application.usecase.TokenStatusUseCase;
+import jabaclass.user.auth.domain.model.TokenBlacklist;
+import jabaclass.user.auth.presentation.dto.response.TokenStatusResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import jabaclass.user.auth.domain.repository.TokenBlacklistRepository;
+import jabaclass.user.user.domain.model.SocialType;
 import jabaclass.user.user.domain.model.UserRole;
 import jabaclass.user.auth.infrastructure.jwt.JwtProvider;
 import jabaclass.user.auth.application.exception.AuthErrorCode;
@@ -36,13 +46,15 @@ import jabaclass.user.mail.application.service.MailService;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class AuthService implements LoginUseCase, LogoutUseCase, ReissueUseCase, ReportTheftUseCase {
+public class AuthService
+    implements LoginUseCase, LogoutUseCase, ReissueUseCase, ReportTheftUseCase, TokenStatusUseCase {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
     private final JwtProvider jwtProvider;
     private final MailService mailService;
+    private final TokenBlacklistRepository tokenBlacklistRepository;
 
     private static final String BLACKLIST_PREFIX = "blacklist:";
     private static final String FORCE_LOGOUT_PREFIX = "force_logout:";
@@ -83,6 +95,7 @@ public class AuthService implements LoginUseCase, LogoutUseCase, ReissueUseCase,
         return new TokenResult(accessToken, refreshToken);
     }
 
+    @Transactional
     @Override
     public TokenResult reissue(String refreshToken) {
         Claims claims = jwtProvider.parseClaims(refreshToken);
@@ -101,9 +114,13 @@ public class AuthService implements LoginUseCase, LogoutUseCase, ReissueUseCase,
         }
 
         if (!stored.equals(refreshToken)) {
+            User targetuser = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+            targetuser.forceLogout();
+
             redisTemplate.opsForValue().set(
                 FORCE_LOGOUT_PREFIX + userId,
-                String.valueOf(Instant.now().toEpochMilli()),
+                LocalDateTime.now().toString(),
                 Duration.ofMillis(accessTokenValidity)
             );
             redisTemplate.delete("refresh:" + userId);
@@ -128,6 +145,7 @@ public class AuthService implements LoginUseCase, LogoutUseCase, ReissueUseCase,
     }
 
     @Override
+    @Transactional
     public void logout(UUID userId, String accessToken) {
         redisTemplate.delete("refresh:" + userId);
 
@@ -136,6 +154,13 @@ public class AuthService implements LoginUseCase, LogoutUseCase, ReissueUseCase,
             long remainingMillis = claims.getExpiration().getTime() - System.currentTimeMillis();
 
             if (remainingMillis > 0) {
+                String hash = sha256(accessToken);
+                LocalDateTime expiresAt = LocalDateTime.ofInstant(
+                    Instant.ofEpochMilli(claims.getExpiration().getTime()),
+                    ZoneId.systemDefault()
+                );
+                tokenBlacklistRepository.save(TokenBlacklist.of(hash, expiresAt));
+
                 log.info("[AUTH] Blacklist 등록. key={}, ttl={}ms", BLACKLIST_PREFIX + accessToken, remainingMillis);
                 redisTemplate.opsForValue().set(
                     BLACKLIST_PREFIX + accessToken,
@@ -151,6 +176,7 @@ public class AuthService implements LoginUseCase, LogoutUseCase, ReissueUseCase,
     }
 
     @Override
+    @Transactional
     public void reportTheft(String token) {
         String userIdStr = redisTemplate.opsForValue().get(THEFT_REPORT_PREFIX + token);
 
@@ -159,14 +185,39 @@ public class AuthService implements LoginUseCase, LogoutUseCase, ReissueUseCase,
         }
 
         UUID userId = UUID.fromString(userIdStr);
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+        user.forceLogout();
+
         redisTemplate.opsForValue().set(
             FORCE_LOGOUT_PREFIX + userId,
-            String.valueOf(Instant.now().toEpochMilli()),
+            LocalDateTime.now().toString(),
             Duration.ofMillis(accessTokenValidity)
         );
         redisTemplate.delete("refresh:" + userId);
         redisTemplate.delete(THEFT_REPORT_PREFIX + token);
         log.warn("[AUTH] 본인 아님 신고 처리 완료. userId={}", userId);
+    }
+
+    @Override
+    @Cacheable(cacheNames = "tokenStatus", key = "#token")
+    public TokenStatusResult checkTokenStatus(String token, UUID userId, long tokenIssuedAtMillis) {
+        String hash = sha256(token);
+        if (tokenBlacklistRepository.existsByTokenHashAndExpiresAtAfter(hash, LocalDateTime.now())) {
+            return TokenStatusResult.blacklisted();
+        }
+
+        User user = userRepository.findById(userId).orElse(null);
+        if (user != null && user.getForceLogoutAt() != null) {
+            long forceLogoutMillis = user.getForceLogoutAt()
+                .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+            if (tokenIssuedAtMillis <= forceLogoutMillis) {
+                return TokenStatusResult.forceLogout();
+            }
+        }
+
+        return TokenStatusResult.valid();
     }
 
     private void sendSecurityAlertAsync(String email, String name, String ip, String userAgent, String token) {
@@ -272,5 +323,17 @@ public class AuthService implements LoginUseCase, LogoutUseCase, ReissueUseCase,
 
         user.updateLastLogin(clientIp, userAgent);
         log.info("[AUTH] 로그인 성공. userId={}, ip={}", user.getId(), clientIp);
+    }
+
+    private static String sha256(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder();
+            for (byte b : hash) hex.append(String.format("%02x", b));
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
     }
 }

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -222,6 +222,7 @@ public class AuthService
         }
     }
 
+    @CacheEvict(cacheNames = "tokenStatus", allEntries = true)
     @Override
     @Transactional
     public void reportTheft(String token) {

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -165,10 +165,14 @@ public class AuthService
             .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
         user.updateRefreshToken(newRefreshToken);
 
-        redisTemplate.opsForValue().set("refresh:" + userId, newRefreshToken,
-            Duration.ofMillis(refreshTokenValidity));
+		try {
+			redisTemplate.opsForValue().set("refresh:" + userId, newRefreshToken,
+				Duration.ofMillis(refreshTokenValidity));
+		} catch (Exception e) {
+            log.warn("[AUTH] Redis refresh token 캐싱 실패, DB에는 저장됨. userId={}", userId);
+		}
 
-        return new TokenResult(newAccessToken, newRefreshToken);
+		return new TokenResult(newAccessToken, newRefreshToken);
     }
 
     @CacheEvict(cacheNames = "tokenStatus", key = "#accessToken")

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -234,14 +234,29 @@ public class AuthService
         user.forceLogout();
         user.updateRefreshToken(null);
 
-        redisTemplate.opsForValue().set(
-            FORCE_LOGOUT_PREFIX + userId,
-            LocalDateTime.now().toString(),
-            Duration.ofMillis(accessTokenValidity)
-        );
-        redisTemplate.delete("refresh:" + userId);
-        redisTemplate.delete(THEFT_REPORT_PREFIX + token);
-        log.warn("[AUTH] 본인 아님 신고 처리 완료. userId={}", userId);
+		try {
+			redisTemplate.opsForValue().set(
+				FORCE_LOGOUT_PREFIX + userId,
+				LocalDateTime.now().toString(),
+				Duration.ofMillis(accessTokenValidity)
+			);
+		} catch (Exception e) {
+            log.warn("[AUTH] Redis force_logout 캐싱 실패, DB에는 저장됨. userId={}", userId);
+		}
+
+		try {
+			redisTemplate.delete("refresh:" + userId);
+		} catch (Exception e) {
+            log.warn("[AUTH] Redis delete 실패, 무시. key=refresh:{}", userId);
+        }
+
+		try {
+			redisTemplate.delete(THEFT_REPORT_PREFIX + token);
+		} catch (Exception e) {
+            log.warn("[AUTH] Redis delete 실패, 무시. key=theft_report:{}", token);
+		}
+
+		log.warn("[AUTH] 본인 아님 신고 처리 완료. userId={}", userId);
     }
 
     @Override

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -12,19 +12,20 @@ import java.util.concurrent.CompletableFuture;
 
 import io.jsonwebtoken.Claims;
 
-import jabaclass.user.auth.application.usecase.TokenStatusUseCase;
-import jabaclass.user.auth.domain.model.TokenBlacklist;
-import jabaclass.user.auth.presentation.dto.response.TokenStatusResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import jabaclass.user.auth.application.usecase.TokenStatusUseCase;
+import jabaclass.user.auth.domain.model.TokenBlacklist;
+import jabaclass.user.auth.presentation.dto.response.TokenStatusResult;
 import jabaclass.user.auth.domain.repository.TokenBlacklistRepository;
 import jabaclass.user.user.domain.model.SocialType;
 import jabaclass.user.user.domain.model.UserRole;
@@ -164,6 +165,7 @@ public class AuthService
         return new TokenResult(newAccessToken, newRefreshToken);
     }
 
+    @CacheEvict(cacheNames = "tokenStatus", key = "#accessToken")
     @Override
     @Transactional
     public void logout(UUID userId, String accessToken) {
@@ -172,7 +174,11 @@ public class AuthService
             .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
         user.updateRefreshToken(null);
 
-        redisTemplate.delete("refresh:" + userId);
+        try {
+            redisTemplate.delete("refresh:" + userId);
+        } catch (Exception e) {
+            log.warn("[AUTH] Redis delete 실패, 무시. key=refresh:{}", userId);
+        }
 
         try {
             Claims claims = jwtProvider.parseClaims(accessToken);
@@ -186,12 +192,14 @@ public class AuthService
                 );
                 tokenBlacklistRepository.save(TokenBlacklist.of(hash, expiresAt));
 
-                log.info("[AUTH] Blacklist 등록. key={}, ttl={}ms", BLACKLIST_PREFIX + accessToken, remainingMillis);
-                redisTemplate.opsForValue().set(
-                    BLACKLIST_PREFIX + accessToken,
-                    "logout",
-                    Duration.ofMillis(remainingMillis)
-                );
+                log.info("[AUTH] Blacklist DB 등록. ttl={}ms", remainingMillis);
+
+                try {
+                    redisTemplate.opsForValue().set(
+                        BLACKLIST_PREFIX + accessToken, "logout", Duration.ofMillis(remainingMillis));
+                } catch (Exception e) {
+                    log.warn("[AUTH] Blacklist Redis 캐싱 실패, DB에는 저장됨.");
+                }
             } else {
                 log.warn("[AUTH] 토큰 이미 만료. remainingMillis={}", remainingMillis);
             }

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -382,11 +382,10 @@ public class AuthService
 					user.getId().toString(),
 					Duration.ofMillis(refreshTokenValidity)
 				);
+			    sendSecurityAlertAsync(user.getEmail(), user.getName(), clientIp, userAgent, theftReportToken);
 			} catch (Exception e) {
                 log.warn("[AUTH] 새 기기 보안 알림 등록 실패, 로그인 계속 진행. userId={}", userId);
             }
-
-			sendSecurityAlertAsync(user.getEmail(), user.getName(), clientIp, userAgent, theftReportToken);
         }
 
         user.updateLastLogin(clientIp, userAgent);

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -8,10 +8,15 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.jsonwebtoken.Claims;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -56,6 +61,9 @@ public class AuthService
     private final JwtProvider jwtProvider;
     private final MailService mailService;
     private final TokenBlacklistRepository tokenBlacklistRepository;
+    private final CircuitBreakerRegistry circuitBreakerRegistry;
+    private CircuitBreaker redisReadCb;
+    private CircuitBreaker redisWriteCb;
 
     private static final String BLACKLIST_PREFIX = "blacklist:";
     private static final String FORCE_LOGOUT_PREFIX = "force_logout:";
@@ -70,6 +78,12 @@ public class AuthService
 
     @Value("${app.base-url}")
     private String baseUrl;
+
+    @PostConstruct
+    void init() {
+        this.redisReadCb = circuitBreakerRegistry.circuitBreaker("redis-read");
+        this.redisWriteCb = circuitBreakerRegistry.circuitBreaker("redis-write");
+    }
 
     @Override
     @Transactional
@@ -88,16 +102,9 @@ public class AuthService
         String refreshToken = tokenProvider.generateRefreshToken(user.getId(), user.getRole());
 
         user.updateRefreshToken(refreshToken);
-
-		try {
-			redisTemplate.opsForValue().set(
-				"refresh:" + user.getId(),
-				refreshToken,
-				Duration.ofMillis(refreshTokenValidity)
-			);
-		} catch (Exception e) {
-            log.warn("[AUTH] Redis refresh token 캐싱 실패, DB에는 저장됨. userId={}", user.getId());
-        }
+        executeWriteWithCb(() -> redisTemplate.opsForValue().set(
+            "refresh:" + user.getId(), refreshToken, Duration.ofMillis(refreshTokenValidity)
+        ), "refresh:" + user.getId());
 
 		return new TokenResult(accessToken, refreshToken);
     }
@@ -115,9 +122,13 @@ public class AuthService
         String role = jwtProvider.getRole(claims);
 
         String stored;
-
         try {
-            stored = redisTemplate.opsForValue().get("refresh:" + userId);
+            stored = redisReadCb.executeCallable(
+                () -> executeWithRedisRetry(() -> redisTemplate.opsForValue().get("refresh:" + userId))
+            );
+        } catch (CallNotPermittedException e) {
+            log.warn("[AUTH] Redis read CB OPEN, DB fallback. userId={}", userId);
+            stored = null;
         } catch (Exception e) {
             log.warn("[AUTH] Redis 장애, DB fallback. userId={}", userId);
             stored = null;
@@ -139,17 +150,13 @@ public class AuthService
             targetuser.forceLogout();
             targetuser.updateRefreshToken(null);
 
-            try {
-                redisTemplate.opsForValue().set(
-                    FORCE_LOGOUT_PREFIX + userId,
-                    LocalDateTime.now().toString(),
-                    Duration.ofMillis(accessTokenValidity)
-                );
-            } catch (Exception e) {
-                log.warn("[AUTH] Redis force_logout 캐싱 실패, DB에는 저장됨. userId={}", userId);
-            }
-            try { redisTemplate.delete("refresh:" + userId); }
-            catch (Exception e) { log.warn("[AUTH] Redis delete 실패, 무시. userId={}", userId); }
+            executeWriteWithCb(() -> redisTemplate.opsForValue().set(
+                FORCE_LOGOUT_PREFIX + userId,
+                LocalDateTime.now().toString(),
+                Duration.ofMillis(accessTokenValidity)
+            ), FORCE_LOGOUT_PREFIX + userId);
+
+            executeWriteWithCb(() -> redisTemplate.delete("refresh:" + userId), "refresh:" + userId);
 
             log.warn("[AUTH] RTR 재사용 감지 - force_logout 설정. userId={}", userId);
             throw new AuthException(AuthErrorCode.SUSPECTED_TOKEN_THEFT);
@@ -167,14 +174,11 @@ public class AuthService
 
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
-        user.updateRefreshToken(newRefreshToken);
 
-		try {
-			redisTemplate.opsForValue().set("refresh:" + userId, newRefreshToken,
-				Duration.ofMillis(refreshTokenValidity));
-		} catch (Exception e) {
-            log.warn("[AUTH] Redis refresh token 캐싱 실패, DB에는 저장됨. userId={}", userId);
-		}
+        user.updateRefreshToken(newRefreshToken);
+        executeWriteWithCb(() -> redisTemplate.opsForValue().set(
+            "refresh:" + userId, newRefreshToken, Duration.ofMillis(refreshTokenValidity)
+        ), "refresh:" + userId);
 
 		return new TokenResult(newAccessToken, newRefreshToken);
     }
@@ -188,11 +192,7 @@ public class AuthService
             .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
         user.updateRefreshToken(null);
 
-        try {
-            redisTemplate.delete("refresh:" + userId);
-        } catch (Exception e) {
-            log.warn("[AUTH] Redis delete 실패, 무시. key=refresh:{}", userId);
-        }
+        executeWriteWithCb(() -> redisTemplate.delete("refresh:" + userId), "refresh:" + userId);
 
         try {
             Claims claims = jwtProvider.parseClaims(accessToken);
@@ -201,19 +201,14 @@ public class AuthService
             if (remainingMillis > 0) {
                 String hash = sha256(accessToken);
                 LocalDateTime expiresAt = LocalDateTime.ofInstant(
-                    Instant.ofEpochMilli(claims.getExpiration().getTime()),
-                    ZoneId.systemDefault()
-                );
+                    Instant.ofEpochMilli(claims.getExpiration().getTime()), ZoneId.systemDefault());
                 tokenBlacklistRepository.save(TokenBlacklist.of(hash, expiresAt));
 
                 log.info("[AUTH] Blacklist DB 등록. ttl={}ms", remainingMillis);
 
-                try {
-                    redisTemplate.opsForValue().set(
-                        BLACKLIST_PREFIX + accessToken, "logout", Duration.ofMillis(remainingMillis));
-                } catch (Exception e) {
-                    log.warn("[AUTH] Blacklist Redis 캐싱 실패, DB에는 저장됨.");
-                }
+                executeWriteWithCb(() -> redisTemplate.opsForValue().set(
+                    BLACKLIST_PREFIX + accessToken, "logout", Duration.ofMillis(remainingMillis)
+                ), BLACKLIST_PREFIX + "***");
             } else {
                 log.warn("[AUTH] 토큰 이미 만료. remainingMillis={}", remainingMillis);
             }
@@ -225,48 +220,40 @@ public class AuthService
     @Override
     @Transactional
     public void reportTheft(String token) {
-		String userIdStr = null;
-		try {
-			userIdStr = redisTemplate.opsForValue().get(THEFT_REPORT_PREFIX + token);
-		} catch (Exception e) {
+
+        String userIdStr;
+        try {
+            userIdStr = redisReadCb.executeCallable(
+                () -> executeWithRedisRetry(() -> redisTemplate.opsForValue().get(THEFT_REPORT_PREFIX + token))
+            );
+        } catch (CallNotPermittedException e) {
+            log.warn("[AUTH] Redis read CB OPEN, theft_report 조회 불가.");
+            throw new AuthException(AuthErrorCode.THEFT_REPORT_TOKEN_EXPIRED);
+        } catch (Exception e) {
             log.warn("[AUTH] Redis 장애, theft_report 조회 실패. 만료 처리.");
             throw new AuthException(AuthErrorCode.THEFT_REPORT_TOKEN_EXPIRED);
-		}
+        }
 
-		if (userIdStr == null) {
+        if (userIdStr == null) {
             throw new AuthException(AuthErrorCode.THEFT_REPORT_TOKEN_EXPIRED);
         }
 
         UUID userId = UUID.fromString(userIdStr);
-
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
         user.forceLogout();
         user.updateRefreshToken(null);
 
-		try {
-			redisTemplate.opsForValue().set(
-				FORCE_LOGOUT_PREFIX + userId,
-				LocalDateTime.now().toString(),
-				Duration.ofMillis(accessTokenValidity)
-			);
-		} catch (Exception e) {
-            log.warn("[AUTH] Redis force_logout 캐싱 실패, DB에는 저장됨. userId={}", userId);
-		}
+        executeWriteWithCb(() -> redisTemplate.opsForValue().set(
+            FORCE_LOGOUT_PREFIX + userId,
+            LocalDateTime.now().toString(),
+            Duration.ofMillis(accessTokenValidity)
+        ), FORCE_LOGOUT_PREFIX + userId);
 
-		try {
-			redisTemplate.delete("refresh:" + userId);
-		} catch (Exception e) {
-            log.warn("[AUTH] Redis delete 실패, 무시. key=refresh:{}", userId);
-        }
+        executeWriteWithCb(() -> redisTemplate.delete("refresh:" + userId), "refresh:" + userId);
+        executeWriteWithCb(() -> redisTemplate.delete(THEFT_REPORT_PREFIX + token), THEFT_REPORT_PREFIX + "***");
 
-		try {
-			redisTemplate.delete(THEFT_REPORT_PREFIX + token);
-		} catch (Exception e) {
-            log.warn("[AUTH] Redis delete 실패, 무시. key=theft_report:{}", token);
-		}
-
-		log.warn("[AUTH] 본인 아님 신고 처리 완료. userId={}", userId);
+        log.warn("[AUTH] 본인 아님 신고 처리 완료. userId={}", userId);
     }
 
     @Override
@@ -382,14 +369,16 @@ public class AuthService
         if (isNewDevice) {
             log.warn("[AUTH] 새 기기 로그인 감지. userId={}, ip={}", user.getId(), clientIp);
             String theftReportToken = UUID.randomUUID().toString();
-			try {
-				redisTemplate.opsForValue().set(
-					THEFT_REPORT_PREFIX + theftReportToken,
-					user.getId().toString(),
-					Duration.ofMillis(refreshTokenValidity)
-				);
-			    sendSecurityAlertAsync(user.getEmail(), user.getName(), clientIp, userAgent, theftReportToken);
-			} catch (Exception e) {
+            try {
+                redisWriteCb.executeRunnable(() -> redisTemplate.opsForValue().set(
+                    THEFT_REPORT_PREFIX + theftReportToken,
+                    user.getId().toString(),
+                    Duration.ofMillis(refreshTokenValidity)
+                ));
+                sendSecurityAlertAsync(user.getEmail(), user.getName(), clientIp, userAgent, theftReportToken);
+            } catch (CallNotPermittedException e) {
+                log.warn("[AUTH] Redis write CB OPEN, 새 기기 보안 알림 스킵. userId={}", userId);
+            } catch (Exception e) {
                 log.warn("[AUTH] 새 기기 보안 알림 등록 실패, 로그인 계속 진행. userId={}", userId);
             }
         }
@@ -407,6 +396,32 @@ public class AuthService
             return hex.toString();
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    private <T> T executeWithRedisRetry(Callable<T> action) throws Exception {
+        Exception last = null;
+        for (int i = 0; i < 2; i++) {
+            try {
+                return action.call();
+            } catch (Exception e) {
+                last = e;
+                if (i < 1) {
+                    try { Thread.sleep(50); }
+                    catch (InterruptedException ie) { Thread.currentThread().interrupt(); throw e; }
+                }
+            }
+        }
+        throw last;
+    }
+
+    private void executeWriteWithCb(Runnable action, String keyHint) {
+        try {
+            redisWriteCb.executeRunnable(action);
+        } catch (CallNotPermittedException e) {
+            log.warn("[AUTH] Redis write CB OPEN, 스킵. key={}", keyHint);
+        } catch (Exception e) {
+            log.warn("[AUTH] Redis write 실패, 무시. key={}", keyHint);
         }
     }
 }

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -145,10 +145,10 @@ public class AuthService
         }
 
         if (!stored.equals(refreshToken)) {
-            User targetuser = userRepository.findById(userId)
+            User targetUser = userRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
-            targetuser.forceLogout();
-            targetuser.updateRefreshToken(null);
+            targetUser.forceLogout();
+            targetUser.updateRefreshToken(null);
 
             executeWriteWithCb(() -> redisTemplate.opsForValue().set(
                 FORCE_LOGOUT_PREFIX + userId,

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -89,13 +89,17 @@ public class AuthService
 
         user.updateRefreshToken(refreshToken);
 
-        redisTemplate.opsForValue().set(
-            "refresh:" + user.getId(),
-            refreshToken,
-            Duration.ofMillis(refreshTokenValidity)
-        );
+		try {
+			redisTemplate.opsForValue().set(
+				"refresh:" + user.getId(),
+				refreshToken,
+				Duration.ofMillis(refreshTokenValidity)
+			);
+		} catch (Exception e) {
+            log.warn("[AUTH] Redis refresh token 캐싱 실패, DB에는 저장됨. userId={}", user.getId());
+        }
 
-        return new TokenResult(accessToken, refreshToken);
+		return new TokenResult(accessToken, refreshToken);
     }
 
     @Transactional
@@ -372,12 +376,17 @@ public class AuthService
         if (isNewDevice) {
             log.warn("[AUTH] 새 기기 로그인 감지. userId={}, ip={}", user.getId(), clientIp);
             String theftReportToken = UUID.randomUUID().toString();
-            redisTemplate.opsForValue().set(
-                THEFT_REPORT_PREFIX + theftReportToken,
-                user.getId().toString(),
-                Duration.ofMillis(refreshTokenValidity)
-            );
-            sendSecurityAlertAsync(user.getEmail(), user.getName(), clientIp, userAgent, theftReportToken);
+			try {
+				redisTemplate.opsForValue().set(
+					THEFT_REPORT_PREFIX + theftReportToken,
+					user.getId().toString(),
+					Duration.ofMillis(refreshTokenValidity)
+				);
+			} catch (Exception e) {
+                log.warn("[AUTH] 새 기기 보안 알림 등록 실패, 로그인 계속 진행. userId={}", userId);
+            }
+
+			sendSecurityAlertAsync(user.getEmail(), user.getName(), clientIp, userAgent, theftReportToken);
         }
 
         user.updateLastLogin(clientIp, userAgent);

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -1,15 +1,14 @@
 package jabaclass.user.auth.application.service;
 
-import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletableFuture;
+import java.nio.charset.StandardCharsets;
 
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
@@ -17,6 +16,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.jsonwebtoken.Claims;
 
 import jakarta.annotation.PostConstruct;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -122,9 +122,11 @@ public class AuthService
         String role = jwtProvider.getRole(claims);
 
         String stored;
+        User user = null;
+
         try {
             stored = redisReadCb.executeCallable(
-                () -> executeWithRedisRetry(() -> redisTemplate.opsForValue().get("refresh:" + userId))
+                () -> redisTemplate.opsForValue().get("refresh:" + userId)
             );
         } catch (CallNotPermittedException e) {
             log.warn("[AUTH] Redis read CB OPEN, DB fallback. userId={}", userId);
@@ -135,20 +137,21 @@ public class AuthService
         }
 
         if (stored == null) {
-            User fallbackUser = userRepository.findById(userId)
+            user = userRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
-            if (fallbackUser.getRefreshToken() == null) {
+            if (user.getRefreshToken() == null) {
                 throw new AuthException(AuthErrorCode.ALREADY_LOGGED_OUT);
             }
-
-            stored = fallbackUser.getRefreshToken();
+            stored = user.getRefreshToken();
         }
 
         if (!stored.equals(refreshToken)) {
-            User targetUser = userRepository.findById(userId)
-                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
-            targetUser.forceLogout();
-            targetUser.updateRefreshToken(null);
+            if (user == null) {
+                user = userRepository.findById(userId)
+                    .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+            }
+            user.forceLogout();
+            user.updateRefreshToken(null);
 
             executeWriteWithCb(() -> redisTemplate.opsForValue().set(
                 FORCE_LOGOUT_PREFIX + userId,
@@ -172,8 +175,10 @@ public class AuthService
         String newAccessToken = tokenProvider.generateAccessToken(userId, userRole);
         String newRefreshToken = tokenProvider.generateRefreshToken(userId, userRole);
 
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+        if (user == null) {
+            user = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+        }
 
         user.updateRefreshToken(newRefreshToken);
         executeWriteWithCb(() -> redisTemplate.opsForValue().set(
@@ -224,7 +229,7 @@ public class AuthService
         String userIdStr;
         try {
             userIdStr = redisReadCb.executeCallable(
-                () -> executeWithRedisRetry(() -> redisTemplate.opsForValue().get(THEFT_REPORT_PREFIX + token))
+                () -> redisTemplate.opsForValue().get(THEFT_REPORT_PREFIX + token)
             );
         } catch (CallNotPermittedException e) {
             log.warn("[AUTH] Redis read CB OPEN, theft_report 조회 불가.");
@@ -413,22 +418,6 @@ public class AuthService
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("SHA-256 not available", e);
         }
-    }
-
-    private <T> T executeWithRedisRetry(Callable<T> action) throws Exception {
-        Exception last = null;
-        for (int i = 0; i < 2; i++) {
-            try {
-                return action.call();
-            } catch (Exception e) {
-                last = e;
-                if (i < 1) {
-                    try { Thread.sleep(50); }
-                    catch (InterruptedException ie) { Thread.currentThread().interrupt(); throw e; }
-                }
-            }
-        }
-        throw last;
     }
 
     private void executeWriteWithCb(Runnable action, String keyHint) {

--- a/service/user/src/main/java/jabaclass/user/auth/application/usecase/TokenStatusUseCase.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/usecase/TokenStatusUseCase.java
@@ -1,0 +1,10 @@
+package jabaclass.user.auth.application.usecase;
+
+import java.util.UUID;
+
+import jabaclass.user.auth.presentation.dto.response.TokenStatusResult;
+
+public interface TokenStatusUseCase {
+
+	TokenStatusResult checkTokenStatus(String token, UUID userId, long tokenIssuedAtMillis);
+}

--- a/service/user/src/main/java/jabaclass/user/auth/domain/model/TokenBlacklist.java
+++ b/service/user/src/main/java/jabaclass/user/auth/domain/model/TokenBlacklist.java
@@ -1,0 +1,45 @@
+package jabaclass.user.auth.domain.model;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "token_blacklist")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TokenBlacklist {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long Id;
+
+	@Column(name = "token_hash", nullable = false, length = 64, unique = true)
+	private String tokenHash;
+
+	@Column(name = "expires_at", nullable = false)
+	private LocalDateTime expiresAt;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@PrePersist
+	void prePersist() {
+		this.createdAt = LocalDateTime.now();
+	}
+
+	public static TokenBlacklist of(String tokenHash, LocalDateTime expiresAt) {
+		TokenBlacklist t = new TokenBlacklist();
+		t.tokenHash = tokenHash;
+		t.expiresAt = expiresAt;
+		return t;
+	}
+}

--- a/service/user/src/main/java/jabaclass/user/auth/domain/model/TokenBlacklist.java
+++ b/service/user/src/main/java/jabaclass/user/auth/domain/model/TokenBlacklist.java
@@ -22,7 +22,7 @@ public class TokenBlacklist {
 	@Id
 	@GeneratedValue(strategy = GenerationType.UUID)
 	@Column(name = "id", updatable = false, nullable = false)
-	private UUID Id;
+	private UUID id;
 
 	@Column(name = "token_hash", nullable = false, length = 64, unique = true)
 	private String tokenHash;

--- a/service/user/src/main/java/jabaclass/user/auth/domain/model/TokenBlacklist.java
+++ b/service/user/src/main/java/jabaclass/user/auth/domain/model/TokenBlacklist.java
@@ -1,5 +1,6 @@
 package jabaclass.user.auth.domain.model;
 
+import java.util.UUID;
 import java.time.LocalDateTime;
 
 import lombok.AccessLevel;
@@ -19,8 +20,9 @@ import jakarta.persistence.Table;
 public class TokenBlacklist {
 
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long Id;
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "id", updatable = false, nullable = false)
+	private UUID Id;
 
 	@Column(name = "token_hash", nullable = false, length = 64, unique = true)
 	private String tokenHash;

--- a/service/user/src/main/java/jabaclass/user/auth/domain/repository/TokenBlacklistRepository.java
+++ b/service/user/src/main/java/jabaclass/user/auth/domain/repository/TokenBlacklistRepository.java
@@ -1,0 +1,8 @@
+package jabaclass.user.auth.domain.repository;
+
+import java.time.LocalDateTime;
+
+public interface TokenBlacklistRepository {
+
+	boolean existsByTokenHashAndExpiresAtAfter(String tokenHash, LocalDateTime now);
+}

--- a/service/user/src/main/java/jabaclass/user/auth/domain/repository/TokenBlacklistRepository.java
+++ b/service/user/src/main/java/jabaclass/user/auth/domain/repository/TokenBlacklistRepository.java
@@ -1,8 +1,13 @@
 package jabaclass.user.auth.domain.repository;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
-public interface TokenBlacklistRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import jabaclass.user.auth.domain.model.TokenBlacklist;
+
+public interface TokenBlacklistRepository extends JpaRepository<TokenBlacklist, UUID> {
 
 	boolean existsByTokenHashAndExpiresAtAfter(String tokenHash, LocalDateTime now);
 }

--- a/service/user/src/main/java/jabaclass/user/auth/infrastructure/oauth2/OAuth2SuccessHandler.java
+++ b/service/user/src/main/java/jabaclass/user/auth/infrastructure/oauth2/OAuth2SuccessHandler.java
@@ -1,7 +1,6 @@
 package jabaclass.user.auth.infrastructure.oauth2;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Optional;
 
 import jabaclass.user.auth.application.service.AuthService;
@@ -9,14 +8,12 @@ import jabaclass.user.common.util.ClientIpUtils;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
-import jabaclass.user.auth.infrastructure.jwt.TokenProvider;
 import jabaclass.user.auth.presentation.dto.response.TokenResult;
 import jabaclass.user.user.domain.model.User;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,15 +22,9 @@ import jakarta.servlet.http.HttpServletResponse;
 @Component
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
-	private final TokenProvider tokenProvider;
-	private final StringRedisTemplate redisTemplate;
 	private final AuthService authService;
 
-	public OAuth2SuccessHandler(TokenProvider tokenProvider,
-								StringRedisTemplate redisTemplate,
-								@Lazy AuthService authService) {
-		this.tokenProvider = tokenProvider;
-		this.redisTemplate = redisTemplate;
+	public OAuth2SuccessHandler(@Lazy AuthService authService) {
 		this.authService = authService;
 	}
 
@@ -58,16 +49,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 		String userAgent = Optional.ofNullable(request.getHeader("User-Agent")).orElse("unknown");
 		authService.handleLoginSecurity(user.getId(), clientIp, userAgent);
 
-		TokenResult tokens = new TokenResult(
-			tokenProvider.generateAccessToken(user.getId(), user.getRole()),
-			tokenProvider.generateRefreshToken(user.getId(), user.getRole())
-		);
-
-		redisTemplate.opsForValue().set(
-			"refresh:" + user.getId(),
-			tokens.getRefreshToken(),
-			Duration.ofMillis(refreshTokenValidity)
-		);
+		TokenResult tokens = authService.issueOAuth2Tokens(user.getId(), user.getRole());
 
 		response.addHeader(HttpHeaders.SET_COOKIE,
 			ResponseCookie.from("refresh_token", tokens.getRefreshToken())

--- a/service/user/src/main/java/jabaclass/user/auth/presentation/controller/AuthController.java
+++ b/service/user/src/main/java/jabaclass/user/auth/presentation/controller/AuthController.java
@@ -3,8 +3,6 @@ package jabaclass.user.auth.presentation.controller;
 import java.util.Optional;
 import java.util.UUID;
 
-import jabaclass.user.auth.application.usecase.ReportTheftUseCase;
-import jabaclass.user.common.util.ClientIpUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -20,10 +18,12 @@ import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import jabaclass.user.auth.application.usecase.TokenStatusUseCase;
 import jabaclass.user.auth.presentation.dto.response.TokenResult;
 import jabaclass.user.auth.presentation.dto.response.TokenResponseDto;
 import jabaclass.user.auth.application.exception.AuthErrorCode;
@@ -34,6 +34,9 @@ import jabaclass.user.auth.application.usecase.ReissueUseCase;
 import jabaclass.user.auth.presentation.dto.request.LoginRequestDto;
 import jabaclass.user.common.dto.ApiResponseDto;
 import jabaclass.user.common.auth.CurrentUser;
+import jabaclass.user.auth.application.usecase.ReportTheftUseCase;
+import jabaclass.user.auth.presentation.dto.response.TokenStatusResult;
+import jabaclass.user.common.util.ClientIpUtils;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -44,12 +47,30 @@ public class AuthController {
     private final LogoutUseCase logoutUseCase;
     private final ReissueUseCase reissueUseCase;
     private final ReportTheftUseCase reportTheftUseCase;
+    private final TokenStatusUseCase tokenStatusUseCase;
 
     @Value("${jwt.refresh-token-validity}")
     private long refreshTokenValidity;
 
     @Value("${cookie.secure}")
     private boolean cookieSecure;
+
+    @Value("${internal.secret}")
+    private String internalSecret;
+
+    @GetMapping("/internal/token-status")
+    public ResponseEntity<TokenStatusResult> checkTokenStatus(
+        @RequestHeader("X-Token") String token,
+        @RequestHeader("X-User-Id") UUID userId,
+        @RequestHeader("X-Token-Iat") long tokenIssuedAtMillis,
+        @RequestHeader(value = "X-Internal-Secret", required = false) String secret) {
+
+        if (!internalSecret.equals(secret)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        return ResponseEntity.ok(tokenStatusUseCase.checkTokenStatus(token, userId, tokenIssuedAtMillis));
+    }
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponseDto<TokenResponseDto>> login(

--- a/service/user/src/main/java/jabaclass/user/auth/presentation/dto/response/TokenStatusResult.java
+++ b/service/user/src/main/java/jabaclass/user/auth/presentation/dto/response/TokenStatusResult.java
@@ -1,6 +1,6 @@
 package jabaclass.user.auth.presentation.dto.response;
 
-public record TokenStatusResult(boolean valid, String reason) {
+public record TokenStatusResult(boolean tokenValid, String reason) {
 
 	public static TokenStatusResult valid() {
 		return new TokenStatusResult(true, null);

--- a/service/user/src/main/java/jabaclass/user/auth/presentation/dto/response/TokenStatusResult.java
+++ b/service/user/src/main/java/jabaclass/user/auth/presentation/dto/response/TokenStatusResult.java
@@ -1,0 +1,16 @@
+package jabaclass.user.auth.presentation.dto.response;
+
+public record TokenStatusResult(boolean valid, String reason) {
+
+	public static TokenStatusResult valid() {
+		return new TokenStatusResult(true, null);
+	}
+
+	public static TokenStatusResult blacklisted() {
+		return new TokenStatusResult(false, "BLACKLISTED");
+	}
+
+	public static TokenStatusResult forceLogout() {
+		return new TokenStatusResult(false, "FORCE_LOGOUT");
+	}
+}

--- a/service/user/src/main/java/jabaclass/user/common/config/CacheConfig.java
+++ b/service/user/src/main/java/jabaclass/user/common/config/CacheConfig.java
@@ -1,0 +1,28 @@
+package jabaclass.user.common.config;
+
+import java.time.Duration;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+	@Bean
+	public CacheManager cacheManager() {
+		CaffeineCacheManager manager = new CaffeineCacheManager("tokenStatus");
+		manager.setCaffeine(
+			Caffeine.newBuilder()
+				.expireAfterWrite(Duration.ofSeconds(60))
+				.maximumSize(10_000)
+		);
+
+		return manager;
+	}
+}

--- a/service/user/src/main/java/jabaclass/user/common/config/RedisCircuitBreakerConfig.java
+++ b/service/user/src/main/java/jabaclass/user/common/config/RedisCircuitBreakerConfig.java
@@ -1,0 +1,41 @@
+package jabaclass.user.common.config;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+
+@Configuration
+public class RedisCircuitBreakerConfig {
+
+	@Bean
+	public CircuitBreakerRegistry circuitBreakerRegistry() {
+		CircuitBreakerConfig readConfig = CircuitBreakerConfig.custom()
+			.slidingWindowType(SlidingWindowType.COUNT_BASED)
+			.slidingWindowSize(5)
+			.minimumNumberOfCalls(3)
+			.failureRateThreshold(60)
+			.waitDurationInOpenState(Duration.ofSeconds(20))
+			.permittedNumberOfCallsInHalfOpenState(2)
+			.build();
+
+		CircuitBreakerConfig writeConfig = CircuitBreakerConfig.custom()
+			.slidingWindowType(SlidingWindowType.COUNT_BASED)
+			.slidingWindowSize(5)
+			.minimumNumberOfCalls(3)
+			.failureRateThreshold(80)
+			.waitDurationInOpenState(Duration.ofSeconds(30))
+			.permittedNumberOfCallsInHalfOpenState(2)
+			.build();
+
+		return CircuitBreakerRegistry.of(Map.of(
+			"redis-read", readConfig,
+			"redis-write", writeConfig
+		));
+	}
+}

--- a/service/user/src/main/java/jabaclass/user/user/application/exception/UserErrorCode.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/exception/UserErrorCode.java
@@ -9,8 +9,7 @@ import lombok.RequiredArgsConstructor;
 public enum UserErrorCode implements ErrorCode {
 
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-	EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
-	SELLER_SETTLEMENT_ACCOUNT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "판매자 또는 관리자만 정산 계좌를 등록할 수 있습니다.");
+	EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 이메일입니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/service/UserService.java
@@ -126,11 +126,9 @@ public class UserService implements UserUseCase {
 	@Transactional
 	public SellerSettlementAccountResponseDto upsertSellerSettlementAccount(
 		UUID userId,
-		String currentUserRole,
 		UpsertSellerSettlementAccountRequestDto request
 	) {
 		User user = getUser(userId);
-		validateSellerSettlementAccountAccess(currentUserRole, user);
 
 		SellerSettlementAccount account = sellerSettlementAccountRepository.findByUserId(userId)
 			.map(existing -> {
@@ -230,28 +228,6 @@ public class UserService implements UserUseCase {
 		log.info("UserService.getUser lookup userId={}", userId);
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-	}
-
-	private void validateSellerSettlementAccountAccess(String currentUserRole, User user) {
-		UserRole role = resolveRole(currentUserRole);
-		if (!isSellerSettlementAccountAllowed(role) || !isSellerSettlementAccountAllowed(user.getRole())) {
-			throw new BusinessException(UserErrorCode.SELLER_SETTLEMENT_ACCOUNT_ACCESS_DENIED);
-		}
-	}
-
-	private UserRole resolveRole(String currentUserRole) {
-		if (currentUserRole == null) {
-			throw new BusinessException(UserErrorCode.SELLER_SETTLEMENT_ACCOUNT_ACCESS_DENIED);
-		}
-		try {
-			return UserRole.valueOf(currentUserRole);
-		} catch (IllegalArgumentException e) {
-			throw new BusinessException(UserErrorCode.SELLER_SETTLEMENT_ACCOUNT_ACCESS_DENIED);
-		}
-	}
-
-	private boolean isSellerSettlementAccountAllowed(UserRole role) {
-		return role == UserRole.SELLER || role == UserRole.ADMIN;
 	}
 
 	private void saveUser(User user) {

--- a/service/user/src/main/java/jabaclass/user/user/application/usercase/UserUseCase.java
+++ b/service/user/src/main/java/jabaclass/user/user/application/usercase/UserUseCase.java
@@ -27,7 +27,6 @@ public interface UserUseCase {
 
 	SellerSettlementAccountResponseDto upsertSellerSettlementAccount(
 		UUID userId,
-		String currentUserRole,
 		UpsertSellerSettlementAccountRequestDto request
 	);
 

--- a/service/user/src/main/java/jabaclass/user/user/domain/model/User.java
+++ b/service/user/src/main/java/jabaclass/user/user/domain/model/User.java
@@ -1,6 +1,7 @@
 package jabaclass.user.user.domain.model;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 import jabaclass.user.common.model.BaseEntity;
 import jabaclass.user.deposit.domain.exception.DepositErrorCode;
@@ -68,6 +69,9 @@ public class User extends BaseEntity {
 
 	@Column(name = "last_login_user_agent", length = 512)
 	private String lastLoginUserAgent;
+
+	@Column(name = "force_logout_at")
+	private LocalDateTime forceLogoutAt;
 
 	public void updateProfile(String name, String phone) {
 		this.name = name;

--- a/service/user/src/main/java/jabaclass/user/user/domain/model/User.java
+++ b/service/user/src/main/java/jabaclass/user/user/domain/model/User.java
@@ -102,4 +102,8 @@ public class User extends BaseEntity {
 		this.lastLoginIp = ip;
 		this.lastLoginUserAgent = userAgent;
 	}
+
+	public void forceLogout() {
+		this.forceLogoutAt = LocalDateTime.now();
+	}
 }

--- a/service/user/src/main/java/jabaclass/user/user/presentation/controller/UserApi.java
+++ b/service/user/src/main/java/jabaclass/user/user/presentation/controller/UserApi.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jabaclass.user.common.apidocs.ApiErrorSpec;
 import jabaclass.user.common.apidocs.ApiErrorSpecs;
 import jabaclass.user.common.auth.CurrentUser;
-import jabaclass.user.common.auth.CurrentUserRole;
 import jabaclass.user.mail.application.exception.MailErrorCode;
 import jabaclass.user.user.application.exception.UserErrorCode;
 import jabaclass.user.user.presentation.dto.request.ChangeMyEmailRequestDto;
@@ -194,15 +193,9 @@ public interface UserApi {
 			constant = "USER_NOT_FOUND",
 			summary = "사용자를 찾을 수 없습니다"
 		),
-		@ApiErrorSpec(
-			value = UserErrorCode.class,
-			constant = "SELLER_SETTLEMENT_ACCOUNT_ACCESS_DENIED",
-			summary = "판매자 또는 관리자만 정산 계좌를 등록할 수 있습니다"
-		)
-	})
+})
 	ResponseEntity<SellerSettlementAccountResponseDto> upsertSellerSettlementAccount(
 		@CurrentUser UUID userId,
-		@CurrentUserRole String currentUserRole,
 		@Valid @RequestBody UpsertSellerSettlementAccountRequestDto request
 	);
 

--- a/service/user/src/main/java/jabaclass/user/user/presentation/controller/UserController.java
+++ b/service/user/src/main/java/jabaclass/user/user/presentation/controller/UserController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import jabaclass.user.common.auth.CurrentUser;
-import jabaclass.user.common.auth.CurrentUserRole;
 import jabaclass.user.user.application.usercase.UserUseCase;
 import jabaclass.user.user.presentation.dto.request.ChangeMyEmailRequestDto;
 import jabaclass.user.user.presentation.dto.request.EmailCheckRequestDto;
@@ -87,10 +86,9 @@ public class UserController implements UserApi {
 	@PutMapping("/me/seller-settlement-account")
 	public ResponseEntity<SellerSettlementAccountResponseDto> upsertSellerSettlementAccount(
 		@CurrentUser UUID userId,
-		@CurrentUserRole String currentUserRole,
 		@Valid @RequestBody UpsertSellerSettlementAccountRequestDto request
 	) {
-		return ResponseEntity.ok(userUseCase.upsertSellerSettlementAccount(userId, currentUserRole, request));
+		return ResponseEntity.ok(userUseCase.upsertSellerSettlementAccount(userId, request));
 	}
 
 	@Override

--- a/service/user/src/main/resources/application-prod.yml
+++ b/service/user/src/main/resources/application-prod.yml
@@ -102,3 +102,6 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
+
+internal:
+  secret: ${USER_INTERNAL_SECRET}

--- a/service/user/src/main/resources/application.yml
+++ b/service/user/src/main/resources/application.yml
@@ -45,3 +45,6 @@ management:
     health:
       probes:
         enabled: true
+
+internal:
+  secret: ${INTERNAL_SECRET:local-dev-secret}

--- a/service/user/src/main/resources/application.yml
+++ b/service/user/src/main/resources/application.yml
@@ -47,4 +47,4 @@ management:
         enabled: true
 
 internal:
-  secret: ${INTERNAL_SECRET:local-dev-secret}
+  secret: ${USER_INTERNAL_SECRET}

--- a/service/user/src/test/java/jabaclass/user/auth/application/service/AuthServiceTest.java
+++ b/service/user/src/test/java/jabaclass/user/auth/application/service/AuthServiceTest.java
@@ -1,0 +1,470 @@
+package jabaclass.user.auth.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.jsonwebtoken.Claims;
+
+import jabaclass.user.auth.application.exception.AuthErrorCode;
+import jabaclass.user.auth.application.exception.AuthException;
+import jabaclass.user.auth.domain.model.TokenBlacklist;
+import jabaclass.user.auth.domain.repository.TokenBlacklistRepository;
+import jabaclass.user.auth.infrastructure.jwt.JwtProvider;
+import jabaclass.user.auth.infrastructure.jwt.TokenProvider;
+import jabaclass.user.auth.presentation.dto.request.LoginRequestDto;
+import jabaclass.user.auth.presentation.dto.response.TokenResult;
+import jabaclass.user.auth.presentation.dto.response.TokenStatusResult;
+import jabaclass.user.mail.application.service.MailService;
+import jabaclass.user.user.domain.model.SocialType;
+import jabaclass.user.user.domain.model.User;
+import jabaclass.user.user.domain.model.UserRole;
+import jabaclass.user.user.domain.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock PasswordEncoder passwordEncoder;
+    @Mock TokenProvider tokenProvider;
+    @Mock JwtProvider jwtProvider;
+    @Mock MailService mailService;
+    @Mock TokenBlacklistRepository tokenBlacklistRepository;
+    @Mock CircuitBreakerRegistry circuitBreakerRegistry;
+    @Mock CircuitBreaker redisReadCb;
+    @Mock CircuitBreaker redisWriteCb;
+    @Mock StringRedisTemplate redisTemplate;
+    @Mock ValueOperations<String, String> valueOps;
+
+    @InjectMocks
+    AuthService authService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        when(circuitBreakerRegistry.circuitBreaker("redis-read", "redis-read")).thenReturn(redisReadCb);
+        when(circuitBreakerRegistry.circuitBreaker("redis-write", "redis-write")).thenReturn(redisWriteCb);
+        authService.init();
+
+        ReflectionTestUtils.setField(authService, "refreshTokenValidity", 604800000L);
+        ReflectionTestUtils.setField(authService, "accessTokenValidity", 300000L);
+        ReflectionTestUtils.setField(authService, "baseUrl", "http://localhost:8080");
+
+        // CB 기본 동작: pass-through (lenient — 특정 테스트에서 CB OPEN으로 override)
+        lenient().doAnswer(inv -> inv.getArgument(0, Callable.class).call())
+            .when(redisReadCb).executeCallable(any());
+        lenient().doAnswer(inv -> {
+            inv.getArgument(0, Runnable.class).run();
+            return null;
+        }).when(redisWriteCb).executeRunnable(any());
+
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    }
+
+    private User mockUser(UUID userId, String refreshToken) {
+        User user = mock(User.class);
+        lenient().when(user.getId()).thenReturn(userId);
+        lenient().when(user.getEmail()).thenReturn("test@test.com");
+        lenient().when(user.getName()).thenReturn("테스트유저");
+        lenient().when(user.getRole()).thenReturn(UserRole.USER);
+        lenient().when(user.getRefreshToken()).thenReturn(refreshToken);
+        lenient().when(user.getLastLoginIp()).thenReturn(null);  // 최초 로그인 → 새 기기 알림 없음
+        return user;
+    }
+
+    private LoginRequestDto mockLoginRequest(String email, String password) {
+        LoginRequestDto req = mock(LoginRequestDto.class);
+        when(req.getEmail()).thenReturn(email);
+        lenient().when(req.getPassword()).thenReturn(password);
+        return req;
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("login()")
+    class LoginTest {
+
+        @Test
+        @DisplayName("정상 로그인 — DB와 Redis에 모두 저장")
+        void success() {
+            UUID userId = UUID.randomUUID();
+            User user = mockUser(userId, null);
+            when(user.getPassword()).thenReturn("encoded");
+            when(userRepository.findByEmailAndSocialType("test@test.com", SocialType.SYSTEM))
+                .thenReturn(Optional.of(user));
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(passwordEncoder.matches("pw", "encoded")).thenReturn(true);
+            when(tokenProvider.generateAccessToken(userId, UserRole.USER)).thenReturn("access");
+            when(tokenProvider.generateRefreshToken(userId, UserRole.USER)).thenReturn("refresh");
+
+            TokenResult result = authService.login(mockLoginRequest("test@test.com", "pw"), "127.0.0.1", "Agent");
+
+            assertThat(result.getAccessToken()).isEqualTo("access");
+            assertThat(result.getRefreshToken()).isEqualTo("refresh");
+            verify(user).updateRefreshToken("refresh");                                             // DB-first
+            verify(valueOps).set(eq("refresh:" + userId), eq("refresh"), any(Duration.class));     // Redis
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 이메일 — USER_NOT_FOUND")
+        void userNotFound() {
+            when(userRepository.findByEmailAndSocialType(anyString(), eq(SocialType.SYSTEM)))
+                .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> authService.login(mockLoginRequest("none@test.com", "pw"), "127.0.0.1", "Agent"))
+                .isInstanceOf(AuthException.class)
+                .satisfies(e -> assertThat(((AuthException) e).getErrorCode()).isEqualTo(AuthErrorCode.USER_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("비밀번호 불일치 — USER_NOT_FOUND")
+        void wrongPassword() {
+            UUID userId = UUID.randomUUID();
+            User user = mockUser(userId, null);
+            when(user.getPassword()).thenReturn("encoded");
+            when(userRepository.findByEmailAndSocialType("test@test.com", SocialType.SYSTEM))
+                .thenReturn(Optional.of(user));
+            when(passwordEncoder.matches("wrong", "encoded")).thenReturn(false);
+
+            assertThatThrownBy(() -> authService.login(mockLoginRequest("test@test.com", "wrong"), "127.0.0.1", "Agent"))
+                .isInstanceOf(AuthException.class)
+                .satisfies(e -> assertThat(((AuthException) e).getErrorCode()).isEqualTo(AuthErrorCode.USER_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("Redis write CB OPEN — DB에는 저장되고 Redis는 스킵")
+        void writeRedisOpen_dbSaved() {
+            UUID userId = UUID.randomUUID();
+            User user = mockUser(userId, null);
+            when(user.getPassword()).thenReturn("encoded");
+            when(userRepository.findByEmailAndSocialType("test@test.com", SocialType.SYSTEM))
+                .thenReturn(Optional.of(user));
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(passwordEncoder.matches("pw", "encoded")).thenReturn(true);
+            when(tokenProvider.generateAccessToken(userId, UserRole.USER)).thenReturn("access");
+            when(tokenProvider.generateRefreshToken(userId, UserRole.USER)).thenReturn("refresh");
+            doThrow(mock(CallNotPermittedException.class)).when(redisWriteCb).executeRunnable(any());
+
+            TokenResult result = authService.login(mockLoginRequest("test@test.com", "pw"), "127.0.0.1", "Agent");
+
+            assertThat(result.getAccessToken()).isEqualTo("access");
+            verify(user).updateRefreshToken("refresh");                                     // DB 저장 확인
+            verify(valueOps, never()).set(anyString(), anyString(), any(Duration.class));   // Redis 스킵 확인
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("reissue()")
+    class ReissueTest {
+
+        private static final String OLD_RT = "oldRefreshToken";
+        private UUID userId;
+        private Claims claims;
+
+        @BeforeEach
+        void setUp() {
+            userId = UUID.randomUUID();
+            claims = mock(Claims.class);
+            when(jwtProvider.parseClaims(OLD_RT)).thenReturn(claims);
+            when(jwtProvider.isRefreshToken(claims)).thenReturn(true);
+            lenient().when(jwtProvider.getUserId(claims)).thenReturn(userId);
+            lenient().when(jwtProvider.getRole(claims)).thenReturn("USER");
+        }
+
+        @Test
+        @DisplayName("Redis hit — 정상 재발급")
+        void success_redisHit() {
+            User user = mockUser(userId, OLD_RT);
+            when(valueOps.get("refresh:" + userId)).thenReturn(OLD_RT);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(tokenProvider.generateAccessToken(userId, UserRole.USER)).thenReturn("newAccess");
+            when(tokenProvider.generateRefreshToken(userId, UserRole.USER)).thenReturn("newRefresh");
+
+            TokenResult result = authService.reissue(OLD_RT);
+
+            assertThat(result.getAccessToken()).isEqualTo("newAccess");
+            assertThat(result.getRefreshToken()).isEqualTo("newRefresh");
+            verify(user).updateRefreshToken("newRefresh");
+        }
+
+        @Test
+        @DisplayName("Redis miss — DB fallback으로 재발급, findById 1회만 호출")
+        void success_redisMiss_dbFallback() {
+            User user = mockUser(userId, OLD_RT);
+            when(valueOps.get("refresh:" + userId)).thenReturn(null);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(tokenProvider.generateAccessToken(userId, UserRole.USER)).thenReturn("newAccess");
+            when(tokenProvider.generateRefreshToken(userId, UserRole.USER)).thenReturn("newRefresh");
+
+            TokenResult result = authService.reissue(OLD_RT);
+
+            assertThat(result.getAccessToken()).isEqualTo("newAccess");
+            verify(userRepository, times(1)).findById(userId);  // lazy — DB 1회만 조회
+        }
+
+        @Test
+        @DisplayName("Redis read CB OPEN — DB fallback으로 재발급")
+        void cbOpen_dbFallback() throws Exception {
+            User user = mockUser(userId, OLD_RT);
+            doThrow(mock(CallNotPermittedException.class)).when(redisReadCb).executeCallable(any());
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(tokenProvider.generateAccessToken(userId, UserRole.USER)).thenReturn("newAccess");
+            when(tokenProvider.generateRefreshToken(userId, UserRole.USER)).thenReturn("newRefresh");
+
+            TokenResult result = authService.reissue(OLD_RT);
+
+            assertThat(result.getAccessToken()).isEqualTo("newAccess");
+        }
+
+        @Test
+        @DisplayName("DB의 refreshToken이 null — ALREADY_LOGGED_OUT")
+        void alreadyLoggedOut() {
+            User user = mockUser(userId, null);  // refreshToken = null
+            when(valueOps.get("refresh:" + userId)).thenReturn(null);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            assertThatThrownBy(() -> authService.reissue(OLD_RT))
+                .isInstanceOf(AuthException.class)
+                .satisfies(e -> assertThat(((AuthException) e).getErrorCode())
+                    .isEqualTo(AuthErrorCode.ALREADY_LOGGED_OUT));
+        }
+
+        @Test
+        @DisplayName("RTR 감지 — SUSPECTED_TOKEN_THEFT + DB에 forceLogout 저장")
+        void rtrDetected() {
+            User user = mockUser(userId, "storedToken");  // stored != provided
+            when(valueOps.get("refresh:" + userId)).thenReturn("storedToken");
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            assertThatThrownBy(() -> authService.reissue(OLD_RT))
+                .isInstanceOf(AuthException.class)
+                .satisfies(e -> assertThat(((AuthException) e).getErrorCode())
+                    .isEqualTo(AuthErrorCode.SUSPECTED_TOKEN_THEFT));
+
+            verify(user).forceLogout();
+            verify(user).updateRefreshToken(null);
+        }
+
+        @Test
+        @DisplayName("Refresh Token이 아닌 토큰 — INVALID_REFRESH_TOKEN")
+        void invalidTokenType() {
+            when(jwtProvider.isRefreshToken(claims)).thenReturn(false);
+
+            assertThatThrownBy(() -> authService.reissue(OLD_RT))
+                .isInstanceOf(AuthException.class)
+                .satisfies(e -> assertThat(((AuthException) e).getErrorCode())
+                    .isEqualTo(AuthErrorCode.INVALID_REFRESH_TOKEN));
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("logout()")
+    class LogoutTest {
+
+        @Test
+        @DisplayName("정상 로그아웃 — DB blacklist 저장 + Redis write")
+        void success() {
+            UUID userId = UUID.randomUUID();
+            User user = mockUser(userId, "refresh");
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            long future = System.currentTimeMillis() + 300_000L;
+            Claims claims = mock(Claims.class);
+            when(jwtProvider.parseClaims("access")).thenReturn(claims);
+            when(claims.getExpiration()).thenReturn(new Date(future));
+
+            authService.logout(userId, "access");
+
+            verify(user).updateRefreshToken(null);
+            verify(tokenBlacklistRepository).save(any(TokenBlacklist.class));
+            verify(valueOps).set(startsWith("blacklist:"), eq("logout"), any(Duration.class));
+        }
+
+        @Test
+        @DisplayName("이미 만료된 accessToken — blacklist 미등록")
+        void expiredToken_noBlacklist() {
+            UUID userId = UUID.randomUUID();
+            User user = mockUser(userId, "refresh");
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            long past = System.currentTimeMillis() - 1_000L;
+            Claims claims = mock(Claims.class);
+            when(jwtProvider.parseClaims("expired")).thenReturn(claims);
+            when(claims.getExpiration()).thenReturn(new Date(past));
+
+            authService.logout(userId, "expired");
+
+            verify(tokenBlacklistRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Redis write CB OPEN — DB blacklist 저장, Redis 스킵")
+        void writeRedisOpen_dbBlacklistSaved() {
+            UUID userId = UUID.randomUUID();
+            User user = mockUser(userId, "refresh");
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            long future = System.currentTimeMillis() + 300_000L;
+            Claims claims = mock(Claims.class);
+            when(jwtProvider.parseClaims("access")).thenReturn(claims);
+            when(claims.getExpiration()).thenReturn(new Date(future));
+            doThrow(mock(CallNotPermittedException.class)).when(redisWriteCb).executeRunnable(any());
+
+            authService.logout(userId, "access");
+
+            verify(tokenBlacklistRepository).save(any(TokenBlacklist.class));               // DB 저장 확인
+            verify(valueOps, never()).set(anyString(), anyString(), any(Duration.class));   // Redis 스킵 확인
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("reportTheft()")
+    class ReportTheftTest {
+
+        @Test
+        @DisplayName("정상 신고 — forceLogout + Redis 정리")
+        void success() throws Exception {
+            UUID userId = UUID.randomUUID();
+            User user = mockUser(userId, "refresh");
+            String token = "theftToken";
+
+            when(valueOps.get("theft_report:" + token)).thenReturn(userId.toString());
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            authService.reportTheft(token);
+
+            verify(user).forceLogout();
+            verify(user).updateRefreshToken(null);
+            verify(redisTemplate).delete("theft_report:" + token);
+        }
+
+        @Test
+        @DisplayName("Redis에 토큰 없음 — THEFT_REPORT_TOKEN_EXPIRED")
+        void tokenNotFound() throws Exception {
+            when(valueOps.get(startsWith("theft_report:"))).thenReturn(null);
+
+            assertThatThrownBy(() -> authService.reportTheft("invalid"))
+                .isInstanceOf(AuthException.class)
+                .satisfies(e -> assertThat(((AuthException) e).getErrorCode())
+                    .isEqualTo(AuthErrorCode.THEFT_REPORT_TOKEN_EXPIRED));
+        }
+
+        @Test
+        @DisplayName("Redis read CB OPEN — THEFT_REPORT_TOKEN_EXPIRED")
+        void cbOpen_throwsExpired() throws Exception {
+            doThrow(mock(CallNotPermittedException.class)).when(redisReadCb).executeCallable(any());
+
+            assertThatThrownBy(() -> authService.reportTheft("token"))
+                .isInstanceOf(AuthException.class)
+                .satisfies(e -> assertThat(((AuthException) e).getErrorCode())
+                    .isEqualTo(AuthErrorCode.THEFT_REPORT_TOKEN_EXPIRED));
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("checkTokenStatus()")
+    class CheckTokenStatusTest {
+
+        @Test
+        @DisplayName("유효한 토큰 — valid")
+        void valid() {
+            UUID userId = UUID.randomUUID();
+            when(tokenBlacklistRepository.existsByTokenHashAndExpiresAtAfter(any(), any())).thenReturn(false);
+            User user = mockUser(userId, null);
+            when(user.getForceLogoutAt()).thenReturn(null);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            TokenStatusResult result = authService.checkTokenStatus("token", userId, System.currentTimeMillis());
+
+            assertThat(result.tokenValid()).isTrue();
+        }
+
+        @Test
+        @DisplayName("블랙리스트 토큰 — blacklisted")
+        void blacklisted() {
+            UUID userId = UUID.randomUUID();
+            when(tokenBlacklistRepository.existsByTokenHashAndExpiresAtAfter(any(), any())).thenReturn(true);
+
+            TokenStatusResult result = authService.checkTokenStatus("token", userId, System.currentTimeMillis());
+
+            assertThat(result.tokenValid()).isFalse();
+            assertThat(result.reason()).isEqualTo("BLACKLISTED");
+        }
+
+        @Test
+        @DisplayName("forceLogout 이전 발급 토큰 — forceLogout")
+        void forceLogout() {
+            UUID userId = UUID.randomUUID();
+            when(tokenBlacklistRepository.existsByTokenHashAndExpiresAtAfter(any(), any())).thenReturn(false);
+
+            LocalDateTime forceLogoutAt = LocalDateTime.now();
+            User user = mockUser(userId, null);
+            when(user.getForceLogoutAt()).thenReturn(forceLogoutAt);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            long issuedBefore = forceLogoutAt.minusSeconds(10)
+                .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+
+            TokenStatusResult result = authService.checkTokenStatus("token", userId, issuedBefore);
+
+            assertThat(result.tokenValid()).isFalse();
+            assertThat(result.reason()).isEqualTo("FORCE_LOGOUT");
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("issueOAuth2Tokens()")
+    class IssueOAuth2TokensTest {
+
+        @Test
+        @DisplayName("OAuth2 토큰 발급 — DB와 Redis에 모두 저장")
+        void success() {
+            UUID userId = UUID.randomUUID();
+            User user = mockUser(userId, null);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(tokenProvider.generateAccessToken(userId, UserRole.USER)).thenReturn("access");
+            when(tokenProvider.generateRefreshToken(userId, UserRole.USER)).thenReturn("refresh");
+
+            TokenResult result = authService.issueOAuth2Tokens(userId, UserRole.USER);
+
+            assertThat(result.getAccessToken()).isEqualTo("access");
+            assertThat(result.getRefreshToken()).isEqualTo("refresh");
+            verify(user).updateRefreshToken("refresh");                                         // DB-first
+            verify(valueOps).set(eq("refresh:" + userId), eq("refresh"), any(Duration.class)); // Redis
+        }
+    }
+}

--- a/service/user/src/test/java/jabaclass/user/user/application/service/UserServiceTest.java
+++ b/service/user/src/test/java/jabaclass/user/user/application/service/UserServiceTest.java
@@ -434,7 +434,6 @@ class UserServiceTest {
 		// when
 		SellerSettlementAccountResponseDto result = userService.upsertSellerSettlementAccount(
 			userId,
-			UserRole.SELLER.name(),
 			request
 		);
 
@@ -481,7 +480,6 @@ class UserServiceTest {
 		// when
 		SellerSettlementAccountResponseDto result = userService.upsertSellerSettlementAccount(
 			userId,
-			UserRole.ADMIN.name(),
 			request
 		);
 
@@ -491,49 +489,4 @@ class UserServiceTest {
 		assertThat(result.accountHolder()).isEqualTo("새예금주");
 		assertThat(result.active()).isFalse();
 	}
-
-	@Test
-	void 일반_사용자는_정산_계좌를_등록할_수_없다() {
-		// given
-		UpsertSellerSettlementAccountRequestDto request = new UpsertSellerSettlementAccountRequestDto(
-			"088",
-			"123-456-789",
-			"일반사용자",
-			true
-		);
-
-		given(userRepository.findById(userId)).willReturn(Optional.of(user));
-
-		// when & then
-		assertThatThrownBy(() -> userService.upsertSellerSettlementAccount(
-			userId,
-			UserRole.USER.name(),
-			request
-		))
-			.isInstanceOf(BusinessException.class)
-			.hasMessage(UserErrorCode.SELLER_SETTLEMENT_ACCOUNT_ACCESS_DENIED.getMessage());
-	}
-
-	@Test
-	void 현재_사용자_권한이_null이면_정산_계좌를_등록할_수_없다() {
-		// given
-		UpsertSellerSettlementAccountRequestDto request = new UpsertSellerSettlementAccountRequestDto(
-			"088",
-			"123-456-789",
-			"권한없음",
-			true
-		);
-
-		given(userRepository.findById(userId)).willReturn(Optional.of(user));
-
-		// when & then
-		assertThatThrownBy(() -> userService.upsertSellerSettlementAccount(
-			userId,
-			null,
-			request
-		))
-			.isInstanceOf(BusinessException.class)
-			.hasMessage(UserErrorCode.SELLER_SETTLEMENT_ACCOUNT_ACCESS_DENIED.getMessage());
-	}
-
 }

--- a/service/user/src/test/resources/application-test.yml
+++ b/service/user/src/test/resources/application-test.yml
@@ -81,3 +81,6 @@ jwt:
   secret: "test-environment-secret-key-must-be-32-chars-long-!!!"
   access-token-validity: 1800000
   refresh-token-validity: 604800000
+
+internal:
+  secret: test-internal-secret


### PR DESCRIPTION
## 관련 이슈
- Close #360 

## 변경 요약
- API Gateway: Redis 장애 시 Circuit Breaker → User 서비스 내부 API fallback 적용                                                                                                                                                                                       
- User Service: Refresh Token DB-first 저장 + Redis Circuit Breaker (read/write 분리) 도입                                                                                                                                                                              
- User Service: Redis 장애 시 `reissue()` DB fallback, 로그아웃/RTR 처리 안정성 보장                                                                                                                                                                                    
- OAuth2SuccessHandler: `AuthService.issueOAuth2Tokens()` 위임으로 일반 로그인과 CB 경로 통일

## 주요 변경점
### 설계 의도 (왜 이렇게 했는가)                                                                                                                                                                                                                                        
                                                            
기존 구조는 Refresh Token을 Redis에만 저장했다. Redis 장애 발생 시 재발급이 불가능하여 모든 사용자가 강제 로그아웃되는 문제가 있었다. 또한 Gateway의 blacklist/force_logout 조회도 Redis에만 의존해, Redis 다운 시 로그아웃된 토큰이 유효한 것처럼 통과될 수 있었다.    
   
이를 해결하기 위해 두 가지 원칙을 적용했다.                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                         
1. **DB-first**: Redis는 캐시다. Refresh Token은 항상 DB(`User.refreshToken`)에 먼저 저장하고 Redis는 그 이후에 쓴다. Redis write 실패는 swallow한다.
2. **Circuit Breaker**: Redis 장애가 전파되지 않도록 CB로 격리하고, OPEN 시 DB 또는 내부 API로 fallback한다.                                                                                                                                                            
                                                                                                                                                                                                                                                                          
---                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                          
### 1. API Gateway — Redis CB + TokenStatusClient fallback
                                                                                                                                                                                                                                                                          
**`JwtAuthenticationFilter`**
- Redis blacklist/force_logout 조회를 `reactor-resilience4j` CB (`redis-auth`)로 감쌌다.                                                                                                                                                                                
- CB OPEN 시 `RedisCircuitOpenException` → `TokenStatusClient.check()` fallback                                                                                                                                                                                         
  - User 서비스 내부 API (`POST /api/v1/auth/internal/token-status`)를 호출한다.                                                                                                                                                                                        
  - `X-Internal-Secret` 헤더로 인증한다.                                                                                                                                                                                                                                
- `enrichIfAuthenticated()` (화이트리스트 경로의 선택적 인증): fail-open. Redis/CB 장애 시 user context 없이 통과.                                                                                                                                                      

**CB 설정** (`redis-auth`): COUNT_BASED, window 3, failureRate 34%, wait 30s                                                                                                                                                                                            

--- 

### 2. User Service — DB-first + read/write Circuit Breaker 분리

**read CB (`redis-read`)**: failureRate 60%, wait 20s, minimumCalls 3
**write CB (`redis-write`)**: failureRate 80%, wait 30s, minimumCalls 3

read와 write를 분리한 이유: Redis가 읽기는 불안정하지만 쓰기는 정상인 경우(또는 그 반대)가 있다. 두 CB를 공유하면 write 오류 하나로 read CB가 열려 DB fallback이 잘못 트리거될 수 있다.
                                                                                                                                                                                 
**`login()` / `issueOAuth2Tokens()`**                     
- `user.updateRefreshToken(refreshToken)` → DB write (먼저)                                                                                                                                                                                                             
- `redisTemplate.set("refresh:{userId}", ...)` → write CB 적용, 실패 시 swallow
                                                                                                                                                                                                                                                                          
**`reissue()`**                                           
- Redis read CB로 `"refresh:{userId}"` 조회
- CB OPEN 또는 Redis 장애 → `null` 반환 → `User.refreshToken` DB에서 조회 (fallback)                                                                                                                                                                                    
- RTR 감지 시: `@Transactional(noRollbackFor = AuthException.class)` — `SUSPECTED_TOKEN_THEFT` 예외를 던지지만 `forceLogout()` + `refreshToken = null` DB write는 rollback되지 않고 커밋된다. 이 보장이 없으면 Redis 장애 상황에서 RTR 감지 후 DB가 원복되어 공격자     
  토큰이 계속 유효해지는 문제가 생긴다.                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                          
**`logout()`**                                                                                                                                                                                                                                                          
- `user.updateRefreshToken(null)` → DB write              
- Redis `"refresh:{userId}"` 삭제 → write CB
- `TokenBlacklist.of(sha256(accessToken), expiresAt)` → DB write                                                                                                                                                                                                        
- Redis `"blacklist:{accessToken}"` 등록 → write CB                                                                                                                                                                                                                     
- `@CacheEvict("tokenStatus", key=accessToken)` → Caffeine 즉시 무효화 (로그아웃 직후 Caffeine 캐시에서 valid가 반환되는 것 방지)                                                                                                                                       
                                                                                                                                                                                                                                                                          
**`reportTheft()`**                                                                                                                                                                                                                                                     
- `theft_report` 토큰은 Redis only (설계 의도). Redis가 살아있어야 신고 가능하며, Redis 장애 시 `THEFT_REPORT_TOKEN_EXPIRED` 반환 (graceful — 사용자 보호보다 가용성 우선, 재로그인 유도).                                                                              
- CB OPEN 시 동일 처리.
- @CacheEvict(allEntries = true) → tokenStatus Caffeine 캐시 전체 무효화. 탈취 신고는 한 사용자의 모든 기기 토큰이 
대상이므로 token 단위 evict로는 대응 불가. 이후 첫 checkTokenStatus() 호출 시 DB에서 forceLogoutAt을 재조회하여 즉시 차단.                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                          
---                                                                                                                                                                                                                                                                     
                                                            
### 3. OAuth2SuccessHandler 리팩토링
                                                                                                                                                                                                                                                                          
기존: `OAuth2SuccessHandler`가 `tokenProvider`, `redisTemplate`을 직접 주입받아 토큰 발급 + Redis 저장을 직접 처리했다.
변경: `AuthService.issueOAuth2Tokens(userId, role)`에 위임. 일반 로그인과 동일한 DB-first + write CB 경로를 탄다.                                                                                                                                                       
이유: OAuth2 로그인도 Redis write를 해야 하는데, CB가 적용되지 않은 직접 호출이었다.                                                                                                                                                                                    
                                                                                                                                                                                                                                                                          
---                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                          
 ### 4. 기타 수정                                                                                                                                                                                                                                                                                                                  
- `application-dev.yml`: Redis timeout 미설정으로 장애 시 스레드가 무한 블로킹되는 문제 → `connect-timeout: 1000ms`, `timeout: 500ms` 추가
- `application-dev.yml`: 로깅 패키지 경로 오타 수정 (`com.jabaclass: DEBUG` → `jabaclass: DEBUG`)                                                                                                                                                                       
- `CircuitBreakerRegistry.of(Map)` 생성 시 named config 명시: `circuitBreakerRegistry.circuitBreaker("redis-read", "redis-read")`                                                                                                                                       
  - named config 없이 `circuitBreaker("redis-read")`만 호출하면 DEFAULT config(minimumCalls: 100)가 적용되어 CB가 절대 열리지 않는다. 
- TokenStatusClient: 매 요청마다 webClientBuilder.build() 호출 → 생성자에서 1회 빌드 후 재사용                                                                                              
- JwtAuthenticationFilter: claims.getIssuedAt() null 체크 추가 — null 시 LocalDateTime.MIN (fail-safe: FORCE_LOGOUT 판정)

## 테스트
- [x] 로컬 실행 확인
- [x] 테스트 통과
- [x] (해당 시) Postman/Swagger로 API 확인

**검증 시나리오**
- Redis 정상: 로그인 → 재발급 → 로그아웃 정상 동작
- Redis 중단 → 로그인: DB에 refresh token 저장, Redis write 오류 swallow
- Redis 중단 → 재발급: CB OPEN 후 DB fallback으로 재발급 성공                                                                                                                                                                                                           
- Redis 중단 → 재발급 RTR: DB commit 보장 확인 (force_logout DB 반영)                                                                                                                                                                                                   
- Redis 복구 후 HALF-OPEN → CB CLOSED 자동 복귀 

## 리뷰 포인트
- **write retry 없음**: write 재시도는 멱등성이 보장되지 않는 경우를 피하기 위해 의도적으로 CB만 적용하고 retry는 배제했다.                                                                                                                                             
- **theft_report Redis-only**: 설계 의도. DB 저장 시 7일 후 정리 로직이 별도로 필요하고, 보안 알림 링크 만료를 Redis TTL로 자연스럽게 처리하는 것이 더 간결하다고 판단했다.
- **fail-open vs fail-close**: `enrichIfAuthenticated()`(화이트리스트 선택적 인증)는 fail-open, `checkTokenStatus()` fallback은 User 서비스에 물어보므로 결과에 따라 차단 가능. 각 경로의 성격에 맞게 분리했다.