### PR TITLE
feat: AI 서비스 Prometheus 메트릭 노출 설정 추가

### DIFF
--- a/service/ai/build.gradle
+++ b/service/ai/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     // Swagger / OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'
 
+    // monitoring
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 }

--- a/service/ai/src/main/resources/application.yml
+++ b/service/ai/src/main/resources/application.yml
@@ -25,8 +25,13 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health, prometheus
   endpoint:
     health:
       probes:
         enabled: true
+    prometheus:
+      enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}


### PR DESCRIPTION
## 관련 이슈
- Close #

## 변경 요약
- AI 서비스 Prometheus 메트릭 노출 설정 추가
- Grafana 대시보드에서 식별할 수 있도록 application 태그 추가

## 테스트
- [ ] 로컬 실행 확인
- [ ] 테스트 통과
- [ ] (해당 시) Postman/Swagger로 API 확인

## 리뷰 포인트
