### PR TITLE
refactor: redis 장애일 때 OAuth2 로그인 동작하도록 로직 수정

### DIFF
--- a/service/user/src/main/java/jabaclass/user/auth/infrastructure/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/service/user/src/main/java/jabaclass/user/auth/infrastructure/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,6 +1,8 @@
 package jabaclass.user.auth.infrastructure.oauth2;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Base64;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,6 +26,7 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 	public static final String COOKIE_NAME = "oauth2_auth_request";
 	private static final String REDIS_KEY_PREFIX = "oauth2:state:";
 	private static final int COOKIE_MAX_AGE = 60; // 1분
+	private static final String FALLBACK_PREFIX = "fb:";
 
 	private final StringRedisTemplate redisTemplate;
 	private final ObjectMapper objectMapper;
@@ -32,10 +35,16 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 	public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
 		return CookieUtils.getCookie(request, COOKIE_NAME)
 			.map(cookie -> {
-				String key = REDIS_KEY_PREFIX + cookie.getValue();
-				String json = redisTemplate.opsForValue().get(key);
-				if (json == null) return null;
+				String value = cookie.getValue();
 				try {
+					if (value.startsWith(FALLBACK_PREFIX)) {
+						String json = new String(
+							Base64.getUrlDecoder().decode(value.substring(FALLBACK_PREFIX.length())),
+							StandardCharsets.UTF_8);
+						return objectMapper.readValue(json, OAuth2AuthorizationRequestDto.class).toRequest();
+					}
+					String json = redisTemplate.opsForValue().get(REDIS_KEY_PREFIX + value);
+					if (json == null) return null;
 					return objectMapper.readValue(json, OAuth2AuthorizationRequestDto.class).toRequest();
 				} catch (Exception e) {
 					return null;
@@ -56,14 +65,17 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 			String json = objectMapper.writeValueAsString(
 				OAuth2AuthorizationRequestDto.from(authorizationRequest));
 
+			try {
 				redisTemplate.opsForValue().set(
-				REDIS_KEY_PREFIX + state,
-					json,
-					Duration.ofSeconds(COOKIE_MAX_AGE)
-				);
-
-				log.info("[AUTH] OAuth2 state 저장. key={}, ttl={}s", REDIS_KEY_PREFIX + state, COOKIE_MAX_AGE);
+					REDIS_KEY_PREFIX + state, json, Duration.ofSeconds(COOKIE_MAX_AGE));
+				log.info("[AUTH] OAuth2 state Redis 저장. key={}", REDIS_KEY_PREFIX + state);
 				CookieUtils.addCookie(response, COOKIE_NAME, state, COOKIE_MAX_AGE);
+			} catch (Exception redisEx) {
+				log.warn("[AUTH] Redis 장애, OAuth2 state 쿠키 직접 저장으로 fallback.");
+				String encoded = FALLBACK_PREFIX + Base64.getUrlEncoder()
+					.encodeToString(json.getBytes(StandardCharsets.UTF_8));
+				CookieUtils.addCookie(response, COOKIE_NAME, encoded, COOKIE_MAX_AGE);
+			}
 		} catch (Exception e) {
 			throw new RuntimeException("OAuth2 요청 저장 실패", e);
 		}
@@ -74,8 +86,16 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 		HttpServletRequest request, HttpServletResponse response) {
 		OAuth2AuthorizationRequest authRequest = loadAuthorizationRequest(request);
 		if (authRequest != null) {
-			String key = REDIS_KEY_PREFIX + authRequest.getState();
-			redisTemplate.delete(key);
+			CookieUtils.getCookie(request, COOKIE_NAME).ifPresent(cookie -> {
+				String value = cookie.getValue();
+				if (!value.startsWith(FALLBACK_PREFIX)) {
+					try {
+						redisTemplate.delete(REDIS_KEY_PREFIX + value);
+					} catch (Exception e) {
+						log.warn("[AUTH] Redis 장애, OAuth2 state 삭제 스킵.");
+					}
+				}
+			});
 			CookieUtils.deleteCookie(request, response, COOKIE_NAME);
 		}
 		return authRequest;

--- a/service/user/src/main/java/jabaclass/user/auth/infrastructure/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/service/user/src/main/java/jabaclass/user/auth/infrastructure/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -4,8 +4,12 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
@@ -27,6 +31,10 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 	private static final String REDIS_KEY_PREFIX = "oauth2:state:";
 	private static final int COOKIE_MAX_AGE = 60; // 1분
 	private static final String FALLBACK_PREFIX = "fb:";
+	private static final String HMAC_ALGORITHM = "HmacSHA256";
+
+	@Value("${jwt.secret}")
+	private String jwtSecret;
 
 	private final StringRedisTemplate redisTemplate;
 	private final ObjectMapper objectMapper;
@@ -37,14 +45,22 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 			.map(cookie -> {
 				String value = cookie.getValue();
 				try {
+					String json;
 					if (value.startsWith(FALLBACK_PREFIX)) {
-						String json = new String(
-							Base64.getUrlDecoder().decode(value.substring(FALLBACK_PREFIX.length())),
-							StandardCharsets.UTF_8);
-						return objectMapper.readValue(json, OAuth2AuthorizationRequestDto.class).toRequest();
+						String payload = value.substring(FALLBACK_PREFIX.length());
+						int dotIndex = payload.lastIndexOf('.');
+						if (dotIndex < 0) return null;
+						String encoded = payload.substring(0, dotIndex);
+						String storedHmac = payload.substring(dotIndex + 1);
+						if (!computeHmac(encoded).equals(storedHmac)) {
+							log.warn("[AUTH] OAuth2 fallback 쿠키 HMAC 검증 실패 — 변조 의심");
+							return null;
+						}
+						json = new String(Base64.getUrlDecoder().decode(encoded), StandardCharsets.UTF_8);
+					} else {
+						json = redisTemplate.opsForValue().get(REDIS_KEY_PREFIX + value);
+						if (json == null) return null;
 					}
-					String json = redisTemplate.opsForValue().get(REDIS_KEY_PREFIX + value);
-					if (json == null) return null;
 					return objectMapper.readValue(json, OAuth2AuthorizationRequestDto.class).toRequest();
 				} catch (Exception e) {
 					return null;
@@ -72,9 +88,11 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 				CookieUtils.addCookie(response, COOKIE_NAME, state, COOKIE_MAX_AGE);
 			} catch (Exception redisEx) {
 				log.warn("[AUTH] Redis 장애, OAuth2 state 쿠키 직접 저장으로 fallback.");
-				String encoded = FALLBACK_PREFIX + Base64.getUrlEncoder()
+				String encoded = Base64.getUrlEncoder()
 					.encodeToString(json.getBytes(StandardCharsets.UTF_8));
-				CookieUtils.addCookie(response, COOKIE_NAME, encoded, COOKIE_MAX_AGE);
+				String hmac = computeHmac(encoded);
+				CookieUtils.addCookie(response, COOKIE_NAME,
+					FALLBACK_PREFIX + encoded + "." + hmac, COOKIE_MAX_AGE);
 			}
 		} catch (Exception e) {
 			throw new RuntimeException("OAuth2 요청 저장 실패", e);
@@ -99,5 +117,15 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 			CookieUtils.deleteCookie(request, response, COOKIE_NAME);
 		}
 		return authRequest;
+	}
+
+	private String computeHmac(String data) {
+		try {
+			Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+			mac.init(new SecretKeySpec(jwtSecret.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM));
+			return Base64.getUrlEncoder().encodeToString(mac.doFinal(data.getBytes(StandardCharsets.UTF_8)));
+		} catch (Exception e) {
+			throw new RuntimeException("HMAC 계산 실패", e);
+		}
 	}
 }

--- a/service/user/src/main/resources/application-prod.yml
+++ b/service/user/src/main/resources/application-prod.yml
@@ -56,8 +56,8 @@ spring:
     redis:
       host: ${APP_REDIS_HOST:redis}
       port: ${APP_REDIS_PORT:6379}
-      connect-timeout: 200
-      timeout: 200
+      connect-timeout: 200ms
+      timeout: 200ms
 
   jpa:
     hibernate:

--- a/service/user/src/main/resources/application-prod.yml
+++ b/service/user/src/main/resources/application-prod.yml
@@ -56,8 +56,8 @@ spring:
     redis:
       host: ${APP_REDIS_HOST:redis}
       port: ${APP_REDIS_PORT:6379}
-      connect-timeout: 3s
-      timeout: 2s
+      connect-timeout: 200
+      timeout: 200
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 관련 이슈                                                                                                                                                                                  
  - Close #360                                              
                                                                                                                                                                                                
  ## 변경 요약                                                                                                                                                                                  
  - Redis 장애 시 OAuth2 로그인 동작하도록 쿠키 fallback 적용                                                                                                                                   
  - Redis timeout 단축으로 CB 오픈 속도 개선                                                                                                                                                    
                                                                                                                                                                                                
  ## 주요 변경점                                                                                                                                                                                
                                                                                                                                                                                                
  ### 1. OAuth2 state Redis 장애 대응                                                                                                                                                           
                                                                                                                                                                                                
  `HttpCookieOAuth2AuthorizationRequestRepository`의 Redis 호출에 장애 대응이 없어 Redis 다운 시 OAuth2 로그인이 500으로 실패하는 문제 수정.                                                    
                                                            
  **변경 전**: Redis 저장 실패 → `RuntimeException` 전파 → 500                                                                                                                                  
                                                            
  **변경 후**: Redis 저장 실패 → `fb:` prefix + Base64 인코딩으로 쿠키에 직접 저장 (fallback)                                                                                                   
  - `saveAuthorizationRequest()`: Redis 실패 시 쿠키에 직접 저장
  - `loadAuthorizationRequest()`: `fb:` prefix 감지 시 쿠키에서 직접 복원, Redis 조회 생략                                                                                                      
  - `removeAuthorizationRequest()`: `fb:` prefix면 Redis delete 스킵
                                                                                                                                                                                                
  ### 2. Redis timeout 단축 (User Service)                  

  Redis 장애 시 CB가 열리기 전까지 매 요청이 timeout만큼 블로킹되어 503 발생.

  - `connect-timeout`: 1000ms → 200ms
  - `timeout`: 500ms → 200ms

  CB `minimumCalls: 3` 도달 전 요청의 지연을 최소화하여 503 방지.

  ## 테스트
  - [x] Redis 정상: OAuth2 로그인 정상 동작 (Redis 저장)
  - [x] Redis 중단: OAuth2 로그인 쿠키 fallback으로 정상 동작
  - [x] Redis 중단: 로그인/재발급/로그아웃 503 없이 정상 동작                                                                                                                                   
                                                                                                                                                                                                
  ## 리뷰 포인트                                                                                                                                                                                
  - **쿠키 크기**: OAuth2AuthorizationRequest JSON Base64 인코딩 시 약 1~2KB, 쿠키 4KB 제한 내 안전                                                                                             
  - **timeout 200ms**: Gateway Redis timeout(300ms)보다 짧아 User 서비스가 더 빠르게 실패 인식