### PR TITLE
refactor: 첫 번째 모니터링 이후 DB connection 줄이기 위한 로직 수정

### DIFF
--- a/.github/k3s/gateway-rules-config.yml
+++ b/.github/k3s/gateway-rules-config.yml
@@ -13,6 +13,8 @@ data:
         - method: GET
           path: /api/v1/auth/report-theft
         - method: POST
+          path: /api/v1/auth/report-theft
+        - method: POST
           path: /api/v1/users/register
         - method: POST
           path: /api/v1/users/email-check

--- a/api-gateway/src/main/resources/gateway-rules.yml
+++ b/api-gateway/src/main/resources/gateway-rules.yml
@@ -7,6 +7,8 @@ gateway:
     - method: GET
       path: /api/v1/auth/report-theft
     - method: POST
+      path: /api/v1/auth/report-theft
+    - method: POST
       path: /api/v1/users/register
     - method: POST
       path: /api/v1/users/email-check

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -100,26 +100,9 @@ public class AuthService
             throw new AuthException(AuthErrorCode.USER_NOT_FOUND);
         }
 
-        // 3. 새 기기 판별 — in-memory
+        // 3. 새 기기 판별 — in-memory (commitLoginWrites 이전, 변경 전 lastLoginIp 기준)
         boolean isNewDevice = user.getLastLoginIp() != null &&
             (!clientIp.equals(user.getLastLoginIp()) || !userAgent.equals(user.getLastLoginUserAgent()));
-
-        if (isNewDevice) {
-            log.warn("[AUTH] 새 기기 로그인 감지. userId={}, ip={}", user.getId(), clientIp);
-            String theftReportToken = UUID.randomUUID().toString();
-            try {
-                redisWriteCb.executeRunnable(() -> redisTemplate.opsForValue().set(
-                    THEFT_REPORT_PREFIX + theftReportToken,
-                    user.getId().toString(),
-                    Duration.ofMillis(refreshTokenValidity)
-                ));
-                sendSecurityAlertAsync(user.getEmail(), user.getName(), clientIp, userAgent, theftReportToken);
-            } catch (CallNotPermittedException e) {
-                log.warn("[AUTH] Redis write CB OPEN, 새 기기 보안 알림 스킵. userId={}", user.getId());
-            } catch (Exception e) {
-                log.warn("[AUTH] 새 기기 보안 알림 등록 실패, 로그인 계속 진행. userId={}", user.getId());
-            }
-        }
 
         // 4. 토큰 생성 — I/O 없음
         String accessToken = tokenProvider.generateAccessToken(user.getId(), user.getRole());
@@ -132,6 +115,9 @@ public class AuthService
         executeWriteWithCb(() -> redisTemplate.opsForValue().set(
             "refresh:" + user.getId(), refreshToken, Duration.ofMillis(refreshTokenValidity)
         ), "refresh:" + user.getId());
+
+        // 7. 새 기기 보안 알림 — DB 커밋 성공 후 발송
+        sendNewDeviceAlertIfNeeded(isNewDevice, user.getId(), user.getEmail(), user.getName(), clientIp, userAgent);
 
         log.info("[AUTH] 로그인 성공. userId={}, ip={}", user.getId(), clientIp);
         return new TokenResult(accessToken, refreshToken);
@@ -304,28 +290,11 @@ public class AuthService
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
 
+        // 변경 전 lastLoginIp 기준으로 판별
         boolean isNewDevice = user.getLastLoginIp() != null &&
             (!clientIp.equals(user.getLastLoginIp()) || !userAgent.equals(user.getLastLoginUserAgent()));
 
-        if (isNewDevice) {
-            log.warn("[AUTH] OAuth2 새 기기 로그인 감지. userId={}, ip={}", userId, clientIp);
-            String theftReportToken = UUID.randomUUID().toString();
-            try {
-                redisWriteCb.executeRunnable(() -> redisTemplate.opsForValue().set(
-                    THEFT_REPORT_PREFIX + theftReportToken,
-                    userId.toString(),
-                    Duration.ofMillis(refreshTokenValidity)
-                ));
-                sendSecurityAlertAsync(user.getEmail(), user.getName(), clientIp, userAgent, theftReportToken);
-            } catch (CallNotPermittedException e) {
-                log.warn("[AUTH] Redis write CB OPEN, OAuth2 새 기기 보안 알림 스킵. userId={}", userId);
-            } catch (Exception e) {
-                log.warn("[AUTH] OAuth2 새 기기 보안 알림 등록 실패, 로그인 계속 진행. userId={}", userId);
-            }
-        }
-
         user.updateLastLogin(clientIp, userAgent);
-        log.info("[AUTH] OAuth2 로그인 성공. userId={}, ip={}", userId, clientIp);
 
         String accessToken = tokenProvider.generateAccessToken(userId, role);
         String refreshToken = tokenProvider.generateRefreshToken(userId, role);
@@ -334,6 +303,11 @@ public class AuthService
         executeWriteWithCb(() -> redisTemplate.opsForValue().set(
             "refresh:" + userId, refreshToken, Duration.ofMillis(refreshTokenValidity)
         ), "refresh:" + userId);
+
+        log.info("[AUTH] OAuth2 로그인 성공. userId={}, ip={}", userId, clientIp);
+
+        // 모든 write 완료 후 알림 발송
+        sendNewDeviceAlertIfNeeded(isNewDevice, userId, user.getEmail(), user.getName(), clientIp, userAgent);
 
         return new TokenResult(accessToken, refreshToken);
     }
@@ -349,6 +323,25 @@ public class AuthService
         } catch (Exception e) {
             log.warn("[AUTH] Redis 장애, DB fallback. userId={}", userId);
             return null;
+        }
+    }
+
+    private void sendNewDeviceAlertIfNeeded(boolean isNewDevice, UUID userId, String email, String name,
+            String clientIp, String userAgent) {
+        if (!isNewDevice) return;
+        log.warn("[AUTH] 새 기기 로그인 감지. userId={}, ip={}", userId, clientIp);
+        String theftReportToken = UUID.randomUUID().toString();
+        try {
+            redisWriteCb.executeRunnable(() -> redisTemplate.opsForValue().set(
+                THEFT_REPORT_PREFIX + theftReportToken,
+                userId.toString(),
+                Duration.ofMillis(refreshTokenValidity)
+            ));
+            sendSecurityAlertAsync(email, name, clientIp, userAgent, theftReportToken);
+        } catch (CallNotPermittedException e) {
+            log.warn("[AUTH] Redis write CB OPEN, 새 기기 보안 알림 스킵. userId={}", userId);
+        } catch (Exception e) {
+            log.warn("[AUTH] 새 기기 보안 알림 등록 실패, 로그인 계속 진행. userId={}", userId);
         }
     }
 

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/AuthService.java
@@ -26,6 +26,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import jabaclass.user.auth.application.usecase.TokenStatusUseCase;
@@ -62,6 +63,7 @@ public class AuthService
     private final MailService mailService;
     private final TokenBlacklistRepository tokenBlacklistRepository;
     private final CircuitBreakerRegistry circuitBreakerRegistry;
+    private final LoginWriter loginWriter;
     private CircuitBreaker redisReadCb;
     private CircuitBreaker redisWriteCb;
 
@@ -86,27 +88,53 @@ public class AuthService
     }
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public TokenResult login(LoginRequestDto request, String clientIp, String userAgent) {
 
+        // 1. TX1(readOnly): user 조회 후 커넥션 반납 — Spring Data JPA 자체 TX
         User user = userRepository.findByEmailAndSocialType(request.getEmail(), SocialType.SYSTEM)
             .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
 
+        // 2. bcrypt — DB 커넥션 없음 (~100-300ms)
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new AuthException(AuthErrorCode.USER_NOT_FOUND);
         }
 
-        handleLoginSecurity(user.getId(), clientIp, userAgent);
+        // 3. 새 기기 판별 — in-memory
+        boolean isNewDevice = user.getLastLoginIp() != null &&
+            (!clientIp.equals(user.getLastLoginIp()) || !userAgent.equals(user.getLastLoginUserAgent()));
 
+        if (isNewDevice) {
+            log.warn("[AUTH] 새 기기 로그인 감지. userId={}, ip={}", user.getId(), clientIp);
+            String theftReportToken = UUID.randomUUID().toString();
+            try {
+                redisWriteCb.executeRunnable(() -> redisTemplate.opsForValue().set(
+                    THEFT_REPORT_PREFIX + theftReportToken,
+                    user.getId().toString(),
+                    Duration.ofMillis(refreshTokenValidity)
+                ));
+                sendSecurityAlertAsync(user.getEmail(), user.getName(), clientIp, userAgent, theftReportToken);
+            } catch (CallNotPermittedException e) {
+                log.warn("[AUTH] Redis write CB OPEN, 새 기기 보안 알림 스킵. userId={}", user.getId());
+            } catch (Exception e) {
+                log.warn("[AUTH] 새 기기 보안 알림 등록 실패, 로그인 계속 진행. userId={}", user.getId());
+            }
+        }
+
+        // 4. 토큰 생성 — I/O 없음
         String accessToken = tokenProvider.generateAccessToken(user.getId(), user.getRole());
         String refreshToken = tokenProvider.generateRefreshToken(user.getId(), user.getRole());
 
-        user.updateRefreshToken(refreshToken);
+        // 5. TX2(write): DB에 refreshToken + lastLogin 저장 — LoginWriter 프록시를 통해 별도 TX
+        loginWriter.commitLoginWrites(user.getId(), refreshToken, clientIp, userAgent);
+
+        // 6. Redis에 refreshToken 저장 (DB 커밋 이후)
         executeWriteWithCb(() -> redisTemplate.opsForValue().set(
             "refresh:" + user.getId(), refreshToken, Duration.ofMillis(refreshTokenValidity)
         ), "refresh:" + user.getId());
 
-		return new TokenResult(accessToken, refreshToken);
+        log.info("[AUTH] 로그인 성공. userId={}, ip={}", user.getId(), clientIp);
+        return new TokenResult(accessToken, refreshToken);
     }
 
     @Transactional(noRollbackFor = AuthException.class)
@@ -121,20 +149,10 @@ public class AuthService
         UUID userId = jwtProvider.getUserId(claims);
         String role = jwtProvider.getRole(claims);
 
-        String stored;
+        // Step 1: stored RT 조회 — Redis 우선, 실패 시 DB
+        // user: Redis miss 시 이미 로드됨. Redis hit 시 null (이후 필요한 시점에 단 1회 로드)
+        String stored = loadFromRedis(userId);
         User user = null;
-
-        try {
-            stored = redisReadCb.executeCallable(
-                () -> redisTemplate.opsForValue().get("refresh:" + userId)
-            );
-        } catch (CallNotPermittedException e) {
-            log.warn("[AUTH] Redis read CB OPEN, DB fallback. userId={}", userId);
-            stored = null;
-        } catch (Exception e) {
-            log.warn("[AUTH] Redis 장애, DB fallback. userId={}", userId);
-            stored = null;
-        }
 
         if (stored == null) {
             user = userRepository.findById(userId)
@@ -145,6 +163,7 @@ public class AuthService
             stored = user.getRefreshToken();
         }
 
+        // Step 2: RTR 검증
         if (!stored.equals(refreshToken)) {
             if (user == null) {
                 user = userRepository.findById(userId)
@@ -152,19 +171,17 @@ public class AuthService
             }
             user.forceLogout();
             user.updateRefreshToken(null);
-
             executeWriteWithCb(() -> redisTemplate.opsForValue().set(
                 FORCE_LOGOUT_PREFIX + userId,
                 LocalDateTime.now().toString(),
                 Duration.ofMillis(accessTokenValidity)
             ), FORCE_LOGOUT_PREFIX + userId);
-
             executeWriteWithCb(() -> redisTemplate.delete("refresh:" + userId), "refresh:" + userId);
-
             log.warn("[AUTH] RTR 재사용 감지 - force_logout 설정. userId={}", userId);
             throw new AuthException(AuthErrorCode.SUSPECTED_TOKEN_THEFT);
         }
 
+        // Step 3: 새 토큰 발급
         UserRole userRole;
         try {
             userRole = UserRole.valueOf(role);
@@ -175,17 +192,17 @@ public class AuthService
         String newAccessToken = tokenProvider.generateAccessToken(userId, userRole);
         String newRefreshToken = tokenProvider.generateRefreshToken(userId, userRole);
 
+        // Step 4: DB 업데이트 (Redis hit 경로: 이 시점에 1번만 조회)
         if (user == null) {
             user = userRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
         }
-
         user.updateRefreshToken(newRefreshToken);
         executeWriteWithCb(() -> redisTemplate.opsForValue().set(
             "refresh:" + userId, newRefreshToken, Duration.ofMillis(refreshTokenValidity)
         ), "refresh:" + userId);
 
-		return new TokenResult(newAccessToken, newRefreshToken);
+        return new TokenResult(newAccessToken, newRefreshToken);
     }
 
     @CacheEvict(cacheNames = "tokenStatus", key = "#accessToken")
@@ -282,6 +299,59 @@ public class AuthService
         return TokenStatusResult.valid();
     }
 
+    @Transactional
+    public TokenResult issueOAuth2Tokens(UUID userId, UserRole role, String clientIp, String userAgent) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+        boolean isNewDevice = user.getLastLoginIp() != null &&
+            (!clientIp.equals(user.getLastLoginIp()) || !userAgent.equals(user.getLastLoginUserAgent()));
+
+        if (isNewDevice) {
+            log.warn("[AUTH] OAuth2 새 기기 로그인 감지. userId={}, ip={}", userId, clientIp);
+            String theftReportToken = UUID.randomUUID().toString();
+            try {
+                redisWriteCb.executeRunnable(() -> redisTemplate.opsForValue().set(
+                    THEFT_REPORT_PREFIX + theftReportToken,
+                    userId.toString(),
+                    Duration.ofMillis(refreshTokenValidity)
+                ));
+                sendSecurityAlertAsync(user.getEmail(), user.getName(), clientIp, userAgent, theftReportToken);
+            } catch (CallNotPermittedException e) {
+                log.warn("[AUTH] Redis write CB OPEN, OAuth2 새 기기 보안 알림 스킵. userId={}", userId);
+            } catch (Exception e) {
+                log.warn("[AUTH] OAuth2 새 기기 보안 알림 등록 실패, 로그인 계속 진행. userId={}", userId);
+            }
+        }
+
+        user.updateLastLogin(clientIp, userAgent);
+        log.info("[AUTH] OAuth2 로그인 성공. userId={}, ip={}", userId, clientIp);
+
+        String accessToken = tokenProvider.generateAccessToken(userId, role);
+        String refreshToken = tokenProvider.generateRefreshToken(userId, role);
+
+        user.updateRefreshToken(refreshToken);
+        executeWriteWithCb(() -> redisTemplate.opsForValue().set(
+            "refresh:" + userId, refreshToken, Duration.ofMillis(refreshTokenValidity)
+        ), "refresh:" + userId);
+
+        return new TokenResult(accessToken, refreshToken);
+    }
+
+    private String loadFromRedis(UUID userId) {
+        try {
+            return redisReadCb.executeCallable(
+                () -> redisTemplate.opsForValue().get("refresh:" + userId)
+            );
+        } catch (CallNotPermittedException e) {
+            log.warn("[AUTH] Redis read CB OPEN, DB fallback. userId={}", userId);
+            return null;
+        } catch (Exception e) {
+            log.warn("[AUTH] Redis 장애, DB fallback. userId={}", userId);
+            return null;
+        }
+    }
+
     private void sendSecurityAlertAsync(String email, String name, String ip, String userAgent, String token) {
         CompletableFuture.runAsync(() -> {
             try {
@@ -318,7 +388,7 @@ public class AuthService
                   <p style="margin:0 0 28px;font-size:15px;line-height:1.7;color:#4b5563;">
                     회원님의 계정에 새로운 기기 또는 위치에서 로그인이 감지되었습니다.
                   </p>
-  
+
                   <div style="margin:0 0 28px;padding:24px;background:linear-gradient(180deg,#fff7f7 0%%,#fff1f1 100%%);border:1px solid #fecaca;border-radius:18px;">
                     <div style="font-size:13px;font-weight:700;letter-spacing:0.2px;color:#991b1b;margin-bottom:16px;">
                       로그인 정보
@@ -362,51 +432,6 @@ public class AuthService
             </div>
           </div>
           """.formatted(name, ip, userAgent, link);
-    }
-
-    @Transactional
-    public void handleLoginSecurity(UUID userId, String clientIp, String userAgent) {
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
-
-        boolean isNewDevice = user.getLastLoginIp() != null &&
-            (!clientIp.equals(user.getLastLoginIp()) || !userAgent.equals(user.getLastLoginUserAgent()));
-
-        if (isNewDevice) {
-            log.warn("[AUTH] 새 기기 로그인 감지. userId={}, ip={}", user.getId(), clientIp);
-            String theftReportToken = UUID.randomUUID().toString();
-            try {
-                redisWriteCb.executeRunnable(() -> redisTemplate.opsForValue().set(
-                    THEFT_REPORT_PREFIX + theftReportToken,
-                    user.getId().toString(),
-                    Duration.ofMillis(refreshTokenValidity)
-                ));
-                sendSecurityAlertAsync(user.getEmail(), user.getName(), clientIp, userAgent, theftReportToken);
-            } catch (CallNotPermittedException e) {
-                log.warn("[AUTH] Redis write CB OPEN, 새 기기 보안 알림 스킵. userId={}", userId);
-            } catch (Exception e) {
-                log.warn("[AUTH] 새 기기 보안 알림 등록 실패, 로그인 계속 진행. userId={}", userId);
-            }
-        }
-
-        user.updateLastLogin(clientIp, userAgent);
-        log.info("[AUTH] 로그인 성공. userId={}, ip={}", user.getId(), clientIp);
-    }
-
-    @Transactional
-    public TokenResult issueOAuth2Tokens(UUID userId, UserRole role) {
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
-
-        String accessToken = tokenProvider.generateAccessToken(userId, role);
-        String refreshToken = tokenProvider.generateRefreshToken(userId, role);
-
-        user.updateRefreshToken(refreshToken);
-        executeWriteWithCb(() -> redisTemplate.opsForValue().set(
-            "refresh:" + userId, refreshToken, Duration.ofMillis(refreshTokenValidity)
-        ), "refresh:" + userId);
-
-        return new TokenResult(accessToken, refreshToken);
     }
 
     private static String sha256(String input) {

--- a/service/user/src/main/java/jabaclass/user/auth/application/service/LoginWriter.java
+++ b/service/user/src/main/java/jabaclass/user/auth/application/service/LoginWriter.java
@@ -1,0 +1,30 @@
+package jabaclass.user.auth.application.service;
+
+import java.util.UUID;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import jabaclass.user.auth.application.exception.AuthErrorCode;
+import jabaclass.user.auth.application.exception.AuthException;
+import jabaclass.user.user.domain.model.User;
+import jabaclass.user.user.domain.repository.UserRepository;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LoginWriter {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void commitLoginWrites(UUID userId, String refreshToken, String clientIp, String userAgent) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+        user.updateRefreshToken(refreshToken);
+        user.updateLastLogin(clientIp, userAgent);
+    }
+}

--- a/service/user/src/main/java/jabaclass/user/auth/infrastructure/oauth2/CookieUtils.java
+++ b/service/user/src/main/java/jabaclass/user/auth/infrastructure/oauth2/CookieUtils.java
@@ -2,45 +2,47 @@ package jabaclass.user.auth.infrastructure.oauth2;
 
 import java.util.Optional;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public class CookieUtils {
 
-	public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
-		Cookie[] cookies = request.getCookies();
-		if (cookies != null) {
-			for (Cookie cookie : cookies) {
-				if (cookie.getName().equals(name)) {
-					return Optional.of(cookie);
-				}
-			}
-		}
-		return Optional.empty();
-	}
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+        return Optional.empty();
+    }
 
-	public static void addCookie(HttpServletResponse response, String name,
-		String value, int maxAge) {
-		Cookie cookie = new Cookie(name, value);
-		cookie.setPath("/");
-		cookie.setHttpOnly(true);
-		cookie.setMaxAge(maxAge);
-		response.addCookie(cookie);
-	}
+    public static void addCookie(HttpServletResponse response, String name,
+        String value, int maxAge, boolean secure) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+            .path("/")
+            .httpOnly(true)
+            .secure(secure)
+            .sameSite("Lax")
+            .maxAge(maxAge)
+            .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
 
-	public static void deleteCookie(HttpServletRequest request,
-		HttpServletResponse response, String name) {
-		Cookie[] cookies = request.getCookies();
-		if (cookies != null) {
-			for (Cookie cookie : cookies) {
-				if (cookie.getName().equals(name)) {
-					cookie.setValue("");
-					cookie.setPath("/");
-					cookie.setMaxAge(0);
-					response.addCookie(cookie);
-				}
-			}
-		}
-	}
+    public static void deleteCookie(HttpServletResponse response, String name, boolean secure) {
+        ResponseCookie cookie = ResponseCookie.from(name, "")
+            .path("/")
+            .httpOnly(true)
+            .secure(secure)
+            .sameSite("Lax")
+            .maxAge(0)
+            .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
 }

--- a/service/user/src/main/java/jabaclass/user/auth/infrastructure/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/service/user/src/main/java/jabaclass/user/auth/infrastructure/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -36,6 +36,9 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 	@Value("${jwt.secret}")
 	private String jwtSecret;
 
+	@Value("${cookie.secure}")
+	private boolean cookieSecure;
+
 	private final StringRedisTemplate redisTemplate;
 	private final ObjectMapper objectMapper;
 
@@ -73,7 +76,7 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 	public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
 		HttpServletRequest request, HttpServletResponse response) {
 		if (authorizationRequest == null) {
-			CookieUtils.deleteCookie(request, response, COOKIE_NAME);
+			CookieUtils.deleteCookie(response, COOKIE_NAME, cookieSecure);
 			return;
 		}
 		try {
@@ -85,14 +88,14 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 				redisTemplate.opsForValue().set(
 					REDIS_KEY_PREFIX + state, json, Duration.ofSeconds(COOKIE_MAX_AGE));
 				log.info("[AUTH] OAuth2 state Redis 저장. key={}", REDIS_KEY_PREFIX + state);
-				CookieUtils.addCookie(response, COOKIE_NAME, state, COOKIE_MAX_AGE);
+				CookieUtils.addCookie(response, COOKIE_NAME, state, COOKIE_MAX_AGE, cookieSecure);
 			} catch (Exception redisEx) {
 				log.warn("[AUTH] Redis 장애, OAuth2 state 쿠키 직접 저장으로 fallback.");
 				String encoded = Base64.getUrlEncoder()
 					.encodeToString(json.getBytes(StandardCharsets.UTF_8));
 				String hmac = computeHmac(encoded);
 				CookieUtils.addCookie(response, COOKIE_NAME,
-					FALLBACK_PREFIX + encoded + "." + hmac, COOKIE_MAX_AGE);
+					FALLBACK_PREFIX + encoded + "." + hmac, COOKIE_MAX_AGE, cookieSecure);
 			}
 		} catch (Exception e) {
 			throw new RuntimeException("OAuth2 요청 저장 실패", e);
@@ -114,7 +117,7 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 					}
 				}
 			});
-			CookieUtils.deleteCookie(request, response, COOKIE_NAME);
+			CookieUtils.deleteCookie(response, COOKIE_NAME, cookieSecure);
 		}
 		return authRequest;
 	}

--- a/service/user/src/main/java/jabaclass/user/auth/infrastructure/oauth2/OAuth2SuccessHandler.java
+++ b/service/user/src/main/java/jabaclass/user/auth/infrastructure/oauth2/OAuth2SuccessHandler.java
@@ -47,9 +47,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
 		String clientIp = ClientIpUtils.extractIp(request);
 		String userAgent = Optional.ofNullable(request.getHeader("User-Agent")).orElse("unknown");
-		authService.handleLoginSecurity(user.getId(), clientIp, userAgent);
-
-		TokenResult tokens = authService.issueOAuth2Tokens(user.getId(), user.getRole());
+		TokenResult tokens = authService.issueOAuth2Tokens(user.getId(), user.getRole(), clientIp, userAgent);
 
 		response.addHeader(HttpHeaders.SET_COOKIE,
 			ResponseCookie.from("refresh_token", tokens.getRefreshToken())

--- a/service/user/src/main/java/jabaclass/user/auth/presentation/controller/AuthController.java
+++ b/service/user/src/main/java/jabaclass/user/auth/presentation/controller/AuthController.java
@@ -1,5 +1,6 @@
 package jabaclass.user.auth.presentation.controller;
 
+import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -57,6 +58,9 @@ public class AuthController {
 
     @Value("${internal.secret}")
     private String internalSecret;
+
+    @Value("${frontend.service-url}")
+    private String frontendServiceUrl;
 
     @GetMapping("/internal/token-status")
     public ResponseEntity<TokenStatusResult> checkTokenStatus(
@@ -128,6 +132,13 @@ public class AuthController {
     }
 
     @GetMapping("/report-theft")
+    public void reportTheftPage(
+            @RequestParam String token,
+            HttpServletResponse response) throws IOException {
+        response.sendRedirect(frontendServiceUrl + "/security/report-theft?token=" + token);
+    }
+
+    @PostMapping("/report-theft")
     public ResponseEntity<ApiResponseDto<Void>> reportTheft(@RequestParam String token) {
         reportTheftUseCase.reportTheft(token);
         return ResponseEntity.ok(ApiResponseDto.success(HttpStatus.OK, "계정 보호 조치가 완료되었습니다.", null));

--- a/service/user/src/main/resources/application.yml
+++ b/service/user/src/main/resources/application.yml
@@ -6,6 +6,8 @@ spring:
     name: user
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}  # 환경변수로 변경
+  jpa:
+    open-in-view: false
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     consumer:

--- a/service/user/src/main/resources/application.yml
+++ b/service/user/src/main/resources/application.yml
@@ -36,6 +36,9 @@ app:
     from: ${MAIL_FROM}
   base-url: ${BASE_URL:http://localhost:8080}
 
+frontend:
+  service-url: ${FRONTEND_SERVICE_URL:http://localhost:3000}
+
 management:
   endpoints:
     web:

--- a/service/user/src/test/java/jabaclass/user/auth/application/service/AuthServiceTest.java
+++ b/service/user/src/test/java/jabaclass/user/auth/application/service/AuthServiceTest.java
@@ -59,6 +59,7 @@ class AuthServiceTest {
     @Mock CircuitBreaker redisWriteCb;
     @Mock StringRedisTemplate redisTemplate;
     @Mock ValueOperations<String, String> valueOps;
+    @Mock LoginWriter loginWriter;
 
     @InjectMocks
     AuthService authService;
@@ -116,7 +117,6 @@ class AuthServiceTest {
             when(user.getPassword()).thenReturn("encoded");
             when(userRepository.findByEmailAndSocialType("test@test.com", SocialType.SYSTEM))
                 .thenReturn(Optional.of(user));
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
             when(passwordEncoder.matches("pw", "encoded")).thenReturn(true);
             when(tokenProvider.generateAccessToken(userId, UserRole.USER)).thenReturn("access");
             when(tokenProvider.generateRefreshToken(userId, UserRole.USER)).thenReturn("refresh");
@@ -125,7 +125,7 @@ class AuthServiceTest {
 
             assertThat(result.getAccessToken()).isEqualTo("access");
             assertThat(result.getRefreshToken()).isEqualTo("refresh");
-            verify(user).updateRefreshToken("refresh");                                             // DB-first
+            verify(loginWriter).commitLoginWrites(userId, "refresh", "127.0.0.1", "Agent");        // DB 위임 확인
             verify(valueOps).set(eq("refresh:" + userId), eq("refresh"), any(Duration.class));     // Redis
         }
 
@@ -163,7 +163,6 @@ class AuthServiceTest {
             when(user.getPassword()).thenReturn("encoded");
             when(userRepository.findByEmailAndSocialType("test@test.com", SocialType.SYSTEM))
                 .thenReturn(Optional.of(user));
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
             when(passwordEncoder.matches("pw", "encoded")).thenReturn(true);
             when(tokenProvider.generateAccessToken(userId, UserRole.USER)).thenReturn("access");
             when(tokenProvider.generateRefreshToken(userId, UserRole.USER)).thenReturn("refresh");
@@ -172,8 +171,8 @@ class AuthServiceTest {
             TokenResult result = authService.login(mockLoginRequest("test@test.com", "pw"), "127.0.0.1", "Agent");
 
             assertThat(result.getAccessToken()).isEqualTo("access");
-            verify(user).updateRefreshToken("refresh");                                     // DB 저장 확인
-            verify(valueOps, never()).set(anyString(), anyString(), any(Duration.class));   // Redis 스킵 확인
+            verify(loginWriter).commitLoginWrites(userId, "refresh", "127.0.0.1", "Agent"); // DB 위임 확인
+            verify(valueOps, never()).set(anyString(), anyString(), any(Duration.class));    // Redis 스킵 확인
         }
     }
 
@@ -459,7 +458,7 @@ class AuthServiceTest {
             when(tokenProvider.generateAccessToken(userId, UserRole.USER)).thenReturn("access");
             when(tokenProvider.generateRefreshToken(userId, UserRole.USER)).thenReturn("refresh");
 
-            TokenResult result = authService.issueOAuth2Tokens(userId, UserRole.USER);
+            TokenResult result = authService.issueOAuth2Tokens(userId, UserRole.USER, "127.0.0.1", "test-agent");
 
             assertThat(result.getAccessToken()).isEqualTo("access");
             assertThat(result.getRefreshToken()).isEqualTo("refresh");


### PR DESCRIPTION
## 관련 이슈
  - Close #394 
                                                                                                                                                                                                
## 변경 요약                                                                                                                                                                                  
  - 로그인 트랜잭션 분리로 DB 커넥션 고갈 문제 해결                                                                                                                                             
  - 새 기기 보안 이메일 링크 클릭 시 401 반환되던 버그 수정                                                                                                                                     
                                                                                                                                                                                                
  ## 주요 변경점                                                                                                                                                                                
  - `LoginWriter` 별도 컴포넌트 추출: bcrypt 실행 중 DB 커넥션을 점유하던 문제를 해결하기 위해 `login()`에 `Propagation.NOT_SUPPORTED` 적용, DB write는 별도 빈(LoginWriter)을 통해 프록시      
  트랜잭션으로 처리                                                                                                                                                                             
  - `login()` / `issueOAuth2Tokens()` 새 기기 판별 로직 통합: 기존 self-invocation으로 트랜잭션이 적용되지 않던 `handleLoginSecurity()` 제거 후 각 메서드에 인라인
  - `reissue()` Redis-first 전략 명확화: `loadFromRedis()` 추출, Redis hit/miss 경로별 DB 조회를 최대 1회로 제한                                                                                
  - `CookieUtils` Spring `ResponseCookie`로 전환: `jakarta.servlet.http.Cookie`는 SameSite 미지원 — OAuth2 콜백 리다이렉트를 위해 SameSite=Lax 적용                                             
  - `reportTheft` GET/POST 분리: 이메일 클라이언트(Gmail 등)의 링크 prefetch가 one-time Redis 토큰을 소모하는 문제 수정. GET은 프론트엔드 확인 페이지로 리다이렉트, POST에서 실제 강제 로그아웃 
  처리                                                                                                                                                                                          
  - Gateway whitelist에 `POST /api/v1/auth/report-theft` 추가                                                                                                                                   
                                                                                                                                                                                                
  ## 테스트                                                 
  - [ ] 로컬 실행 확인                                                                                                                                                                          
  - [ ] 테스트 통과                                                                                                                                                                             
  - [ ] (해당 시) Postman/Swagger로 API 확인
  - [ ] 새 기기 로그인 → 이메일 수신 → 프론트엔드 확인 페이지 → POST 호출 → 계정 보호 완료                                                                                                      
                                                                                                                                                                                                
  ## 리뷰 포인트
  - `Propagation.NOT_SUPPORTED`로 인해 `login()` 전체가 트랜잭션 없이 실행됨. bcrypt 이후 Redis write 실패 시 이메일은 미발송(동일 try 블록), DB write는 LoginWriter TX로 분리되어 있어 부분    
  실패 시나리오 고려 필요                                                                                                                                                                       
  - `reportTheft` GET이 단순 리다이렉트로 바뀌면서 기존에 직접 API를 호출하던 클라이언트가 있다면 동작 변경에 주의