### PR TITLE
fix: Monitoring을 통한 성능 비교 후 BCrypt length 다시 원상복구

### DIFF
--- a/service/user/src/main/java/jabaclass/user/common/config/SecurityConfig.java
+++ b/service/user/src/main/java/jabaclass/user/common/config/SecurityConfig.java
@@ -53,6 +53,6 @@ public class SecurityConfig {
 
 	@Bean
 	public PasswordEncoder passwordEncoder() {
-		return new BCryptPasswordEncoder(9);
+		return new BCryptPasswordEncoder();
 	}
 }


### PR DESCRIPTION
## 관련 이슈
- Close #398 

## 변경 요약
- 최근 성능 최적화를 위해 Cost Factor를 9로 낮추어 운영했으나, 부하 테스트 및 인프라 자원 모니터링 결과를 바탕으로 보안성과 시스템 안정성 사이의 최적의 균형점(Sweet Spot)을 찾기 위해 다시 10으로 복구하기로 결정하였습니다.

## 주요 변경점
- BCrypt length를 다시 원상 복구 했습니다.

## 테스트
### 최적화(Strength 9) 후 진행한 30명 스트레스 테스트에서 예상과 정반대의 결과가 도출되었습니다.
- **성능의 역설 (Performance Paradox):** 연산 속도를 높였음에도 불구하고 **평균 응답 시간 14.99s, 실패율 76.66%** 기록.

## 원인 분석
### 기술적 원인 분석 (Root Cause Analysis)
- CPU 연산 속도 향상이 오히려 다수 유저의 DB 커넥션 동시 점유를 유발하여, 1 vCPU 환경의 물리적 한계인 컨텍스트 스위칭 오버헤드와 자원 경합을 초래함.

### 결정 및 근거 (Technical Decision)
- 보안 표준(Strength 10)을 준수함과 동시에 의도적인 연산 부하로 유입 속도를 조절(Throttling)하여, 인프라 하위 계층의 과부하를 방지하고 시스템 전체 가용성을 100%로 확보함.