### PR TITLE
feat: S3 파일 업로드 서버 측 검증 추가

### DIFF
--- a/service/product/src/main/java/jabaclass/product/application/exception/FileErrorCode.java
+++ b/service/product/src/main/java/jabaclass/product/application/exception/FileErrorCode.java
@@ -6,7 +6,9 @@ public enum FileErrorCode {
 
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
     FILE_NOT_UPLOADED(HttpStatus.BAD_REQUEST, "S3에 파일이 존재하지 않습니다."),
-    FILE_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "이미 처리된 파일입니다.");
+    FILE_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "이미 처리된 파일입니다."),
+    FILE_INVALID_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 형식입니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 제한을 초과했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/service/product/src/main/java/jabaclass/product/application/service/FileUploadService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/FileUploadService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -63,7 +64,7 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
     }
 
     @Override
-    @Transactional
+    @Transactional(noRollbackFor = FileException.class)
     public void completeUpload(UUID fileId) {
 
         File file = fileRepository.findById(fileId)
@@ -78,7 +79,7 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
     }
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW, noRollbackFor = FileException.class)
     public FileConfirmResponse validateAndConfirm(UUID fileId) {
 
         File file = fileRepository.findById(fileId)

--- a/service/product/src/main/java/jabaclass/product/application/service/FileUploadService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/FileUploadService.java
@@ -1,10 +1,10 @@
 package jabaclass.product.application.service;
 
 import java.time.LocalDateTime;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+import jabaclass.product.common.config.FileUploadProperties;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -32,13 +32,7 @@ import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 @RequiredArgsConstructor
 public class FileUploadService implements RequestUploadUseCase, CompleteUploadUseCase, ValidateFileUseCase {
 
-    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
-        "image/jpeg", "image/png"
-    );
-
-    // 개발 편의상 정해놓은 값. 운영 환경에서 정책에 따라 수정
-    private static final long MAX_FILE_SIZE = 10L * 1024 * 1024;    // 10MB
-
+    private final FileUploadProperties fileUploadProperties;
     private final FileRepository fileRepository;
     private final S3Uploader s3Uploader;
     private final ApplicationEventPublisher eventPublisher;
@@ -47,7 +41,7 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
     @Transactional
     public UploadResponseDto requestUpload(UUID userId, UploadRequestDto request) {
 
-        if (!ALLOWED_CONTENT_TYPES.contains(request.getContentType())) {
+        if (!fileUploadProperties.getAllowedContentTypes().contains(request.getContentType())) {
             throw new FileException(FileErrorCode.FILE_INVALID_TYPE);
         }
 
@@ -79,25 +73,8 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
             throw new FileException(FileErrorCode.FILE_ALREADY_CONFIRMED);
         }
 
-        HeadObjectResponse metadata = s3Uploader.getMetadata(file.getStoragePath())
-            .orElseThrow(() -> {
-                file.confirmFail();
-                return new FileException(FileErrorCode.FILE_NOT_UPLOADED);
-            });
-
-        if (!ALLOWED_CONTENT_TYPES.contains(metadata.contentType())) {
-            s3Uploader.deleteObject(file.getStoragePath());
-            file.confirmFail();
-            throw new FileException(FileErrorCode.FILE_INVALID_TYPE);
-        }
-
-        if (metadata.contentLength() > MAX_FILE_SIZE) {
-            s3Uploader.deleteObject(file.getStoragePath());
-            file.confirmFail();
-            throw new FileException(FileErrorCode.FILE_SIZE_EXCEEDED);
-        }
-
-        file.confirmSuccess(metadata.contentLength());
+        HeadObjectResponse metadata = fetchMetadataOrFail(file);
+        validateMetadata(file, metadata);
     }
 
     @Override
@@ -112,26 +89,34 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
         }
 
         if (file.getStatus() == FileStatus.PENDING) {
-            HeadObjectResponse metadata = s3Uploader.getMetadata(file.getStoragePath())
-                .orElseThrow(() -> new FileException(FileErrorCode.FILE_NOT_UPLOADED));
-
-            if (!ALLOWED_CONTENT_TYPES.contains(metadata.contentType())) {
-                s3Uploader.deleteObject(file.getStoragePath());
-                file.confirmFail();
-                throw new FileException(FileErrorCode.FILE_INVALID_TYPE);
-            }
-
-            if (metadata.contentLength() > MAX_FILE_SIZE) {
-                s3Uploader.deleteObject(file.getStoragePath());
-                file.confirmFail();
-                throw new FileException(FileErrorCode.FILE_SIZE_EXCEEDED);
-            }
-
-            file.confirmSuccess(metadata.contentLength());
+            HeadObjectResponse metadata = fetchMetadataOrFail(file);
+            validateMetadata(file, metadata);
             return new FileConfirmResponse(file.getId(), file.getStoragePath());
         }
 
         throw new FileException(FileErrorCode.FILE_NOT_UPLOADED);
+    }
+
+    private HeadObjectResponse fetchMetadataOrFail(File file) {
+        return s3Uploader.getMetadata(file.getStoragePath())
+            .orElseThrow(() -> {
+                file.confirmFail();
+                return new FileException(FileErrorCode.FILE_NOT_UPLOADED);
+            });
+    }
+
+    private void validateMetadata(File file, HeadObjectResponse metadata) {
+        if (!fileUploadProperties.getAllowedContentTypes().contains(metadata.contentType())) {
+            s3Uploader.deleteObject(file.getStoragePath());
+            file.confirmFail();
+            throw new FileException(FileErrorCode.FILE_INVALID_TYPE);
+        }
+        if (metadata.contentLength() > fileUploadProperties.getMaxFileSize()) {
+            s3Uploader.deleteObject(file.getStoragePath());
+            file.confirmFail();
+            throw new FileException(FileErrorCode.FILE_SIZE_EXCEEDED);
+        }
+        file.confirmSuccess(metadata.contentLength());
     }
 
     // 24시간 이상 PENDING 상태 파일 정리 (매일 새벽 3시)

--- a/service/product/src/main/java/jabaclass/product/application/service/FileUploadService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/FileUploadService.java
@@ -1,6 +1,7 @@
 package jabaclass.product.application.service;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -25,10 +26,18 @@ import jabaclass.product.infrastructure.s3.S3Uploader;
 import jabaclass.product.presentation.dto.request.UploadRequestDto;
 import jabaclass.product.application.dto.FileConfirmResponse;
 import jabaclass.product.presentation.dto.response.UploadResponseDto;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
 @Service
 @RequiredArgsConstructor
 public class FileUploadService implements RequestUploadUseCase, CompleteUploadUseCase, ValidateFileUseCase {
+
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
+        "image/jpeg", "image/png"
+    );
+
+    // 개발 편의상 정해놓은 값. 운영 환경에서 정책에 따라 수정
+    private static final long MAX_FILE_SIZE = 10L * 1024 * 1024;    // 10MB
 
     private final FileRepository fileRepository;
     private final S3Uploader s3Uploader;
@@ -37,6 +46,10 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
     @Override
     @Transactional
     public UploadResponseDto requestUpload(UUID userId, UploadRequestDto request) {
+
+        if (!ALLOWED_CONTENT_TYPES.contains(request.getContentType())) {
+            throw new FileException(FileErrorCode.FILE_INVALID_TYPE);
+        }
 
         UUID fileId = UUID.randomUUID();
         String storagePath = userId + "/" + fileId + "/" + request.getOriginalName();
@@ -50,7 +63,7 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
 
         fileRepository.save(file);
 
-        String uploadUrl = s3Uploader.generatePresignedUrl(storagePath);
+        String uploadUrl = s3Uploader.generatePresignedUrl(storagePath, request.getContentType());
 
         return new UploadResponseDto(file.getId(), uploadUrl, storagePath);
     }
@@ -66,12 +79,25 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
             throw new FileException(FileErrorCode.FILE_ALREADY_CONFIRMED);
         }
 
-        if (!s3Uploader.existsInS3(file.getStoragePath())) {
+        HeadObjectResponse metadata = s3Uploader.getMetadata(file.getStoragePath())
+            .orElseThrow(() -> {
+                file.confirmFail();
+                return new FileException(FileErrorCode.FILE_NOT_UPLOADED);
+            });
+
+        if (!ALLOWED_CONTENT_TYPES.contains(metadata.contentType())) {
+            s3Uploader.deleteObject(file.getStoragePath());
             file.confirmFail();
-            throw new FileException(FileErrorCode.FILE_NOT_UPLOADED);
+            throw new FileException(FileErrorCode.FILE_INVALID_TYPE);
         }
 
-        file.confirmSuccess();
+        if (metadata.contentLength() > MAX_FILE_SIZE) {
+            s3Uploader.deleteObject(file.getStoragePath());
+            file.confirmFail();
+            throw new FileException(FileErrorCode.FILE_SIZE_EXCEEDED);
+        }
+
+        file.confirmSuccess(metadata.contentLength());
     }
 
     @Override
@@ -79,17 +105,29 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
     public FileConfirmResponse validateAndConfirm(UUID fileId) {
 
         File file = fileRepository.findById(fileId)
-                .orElseThrow(() -> new FileException(FileErrorCode.FILE_NOT_FOUND));
+            .orElseThrow(() -> new FileException(FileErrorCode.FILE_NOT_FOUND));
 
         if (file.getStatus() == FileStatus.SUCCESS) {
             return new FileConfirmResponse(file.getId(), file.getStoragePath());
         }
 
         if (file.getStatus() == FileStatus.PENDING) {
-            if (!s3Uploader.existsInS3(file.getStoragePath())) {
-                throw new FileException(FileErrorCode.FILE_NOT_UPLOADED);
+            HeadObjectResponse metadata = s3Uploader.getMetadata(file.getStoragePath())
+                .orElseThrow(() -> new FileException(FileErrorCode.FILE_NOT_UPLOADED));
+
+            if (!ALLOWED_CONTENT_TYPES.contains(metadata.contentType())) {
+                s3Uploader.deleteObject(file.getStoragePath());
+                file.confirmFail();
+                throw new FileException(FileErrorCode.FILE_INVALID_TYPE);
             }
-            file.confirmSuccess();
+
+            if (metadata.contentLength() > MAX_FILE_SIZE) {
+                s3Uploader.deleteObject(file.getStoragePath());
+                file.confirmFail();
+                throw new FileException(FileErrorCode.FILE_SIZE_EXCEEDED);
+            }
+
+            file.confirmSuccess(metadata.contentLength());
             return new FileConfirmResponse(file.getId(), file.getStoragePath());
         }
 
@@ -104,7 +142,7 @@ public class FileUploadService implements RequestUploadUseCase, CompleteUploadUs
 
         try (Stream<File> files = fileRepository.streamByStatusAndCreatedAtBefore(FileStatus.PENDING, threshold)) {
             files.forEach(file -> {
-                file.confirmFail();  // DB 상태 변경
+                file.confirmFail();
                 eventPublisher.publishEvent(new FileCleanupEvent(file.getStoragePath()));
             });
         }

--- a/service/product/src/main/java/jabaclass/product/common/config/FileUploadProperties.java
+++ b/service/product/src/main/java/jabaclass/product/common/config/FileUploadProperties.java
@@ -1,0 +1,16 @@
+package jabaclass.product.common.config;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@ConfigurationProperties(prefix = "file.upload")
+@Getter
+@Setter
+public class FileUploadProperties {
+	private List<String> allowedContentTypes;
+	private long maxFileSize;
+}

--- a/service/product/src/main/java/jabaclass/product/config/S3Config.java
+++ b/service/product/src/main/java/jabaclass/product/config/S3Config.java
@@ -1,16 +1,19 @@
 package jabaclass.product.config;
 
-import jabaclass.product.infrastructure.s3.S3Properties;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
+import jabaclass.product.common.config.FileUploadProperties;
+import jabaclass.product.infrastructure.s3.S3Properties;
+
 @Configuration
-@EnableConfigurationProperties(S3Properties.class)
+@EnableConfigurationProperties({S3Properties.class, FileUploadProperties.class})
 public class S3Config {
 
     @Value("${spring.cloud.aws.region.static}")

--- a/service/product/src/main/java/jabaclass/product/domain/model/File.java
+++ b/service/product/src/main/java/jabaclass/product/domain/model/File.java
@@ -67,8 +67,9 @@ public class File {
         this.status = FileStatus.PENDING;
     }
 
-    public void confirmSuccess() {
+    public void confirmSuccess(long size) {
         this.status = FileStatus.SUCCESS;
+        this.size = size;
     }
 
     public void confirmFail() {

--- a/service/product/src/main/java/jabaclass/product/infrastructure/s3/S3Uploader.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/s3/S3Uploader.java
@@ -1,8 +1,13 @@
 package jabaclass.product.infrastructure.s3;
 
 import java.time.Duration;
+import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Component;
+
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
@@ -21,12 +26,13 @@ public class S3Uploader {
     private final S3Client s3Client;
     private final S3Properties s3Properties;
 
-    public String generatePresignedUrl(String storagePath) {
+    public String generatePresignedUrl(String storagePath, String contentType) {
         PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
                 .signatureDuration(Duration.ofMinutes(s3Properties.getPresignedUrlExpiration()))
                 .putObjectRequest(req -> req
                         .bucket(s3Properties.getBucket())
                         .key(storagePath)
+                        .contentType(contentType)
                 )
                 .build();
 
@@ -46,16 +52,20 @@ public class S3Uploader {
         return presignedRequest.url().toString();
     }
 
-    public boolean existsInS3(String key) {
+    public Optional<HeadObjectResponse> getMetadata(String key) {
         try {
-            s3Client.headObject(HeadObjectRequest.builder()
-                    .bucket(s3Properties.getBucket())
-                    .key(key)
-                    .build());
-            return true;
+            HeadObjectResponse response = s3Client.headObject(HeadObjectRequest.builder()
+                .bucket(s3Properties.getBucket())
+                .key(key)
+                .build());
+            return Optional.of(response);
         } catch (NoSuchKeyException e) {
-            return false;
+            return Optional.empty();
         }
+    }
+
+    public boolean existsInS3(String key) {
+        return getMetadata(key).isPresent();
     }
 
     public void deleteObject(String storagePath) {

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/request/UploadRequestDto.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/request/UploadRequestDto.java
@@ -8,4 +8,7 @@ public class UploadRequestDto {
 
     @NotBlank(message = "파일명을 입력해주세요")
     private String originalName;
+
+    @NotBlank(message = "파일 형식을 입력해주세요")
+    private String contentType;
 }

--- a/service/product/src/main/resources/application.yml
+++ b/service/product/src/main/resources/application.yml
@@ -46,3 +46,11 @@ resilience4j:
         waitDurationInOpenState: 30s
         failureRateThreshold: 50
         eventConsumerBufferSize: 10
+
+file:
+  upload:
+    allowed-content-types:
+      - image/jpeg
+      - image/png
+    ## 개발 편의상 설정해놓은 수치 10MB
+    max-file-size: 10485760


### PR DESCRIPTION
 ## 관련 이슈                            
                                                                                                                                                                                                                                                                                                   
  ## 변경 요약                                                                                                                                                                                                                                                                                     
  - S3 파일 업로드에 서버 측 Content-Type 및 파일 크기 검증 추가                                                                                                                                                                                                                                   
  - presigned PUT URL에 Content-Type 고정으로 S3 레벨 업로드 제한 적용                                                                                                                                                                                                                             
                                                                      
  ## 주요 변경점                                                                                                                                                                                                                                                                                   
  - `UploadRequestDto`에 `contentType` 필드 추가 (허용값: image/jpeg, image/png)
  - `S3Uploader.generatePresignedUrl()`에 contentType 파라미터 추가 → presigned URL 서명 조건에 Content-Type 포함, S3가 업로드 시점에 불일치 요청 거부                                                                                                                                             
  - `S3Uploader.getMetadata()` 추가 → headObject 결과를 Optional로 반환, 기존 `existsInS3()`가 내부적으로 위임                                                                                                                                                                                     
  - `FileUploadService.completeUpload()` — headObject로 실제 업로드된 파일의 contentType·size 사후 검증, 위반 시 S3 삭제 및 FAIL 처리                                                                                                                                                              
  - `FileUploadService.validateAndConfirm()` — 상품 등록 시 PENDING 파일 동일 검증 적용                                                                                                                                                                                                            
  - `File.confirmSuccess(long size)` — 검증 통과 시 실제 파일 크기 DB 저장                                                                                                                                                                                                                         
  - `FileErrorCode`에 `FILE_INVALID_TYPE`, `FILE_SIZE_EXCEEDED` 추가                                                                                                                                                                                                                               
  - `FileUploadProperties` 추가 — 허용 Content-Type 목록·최대 파일 크기를 `application.yml`로 외부화, 코드 수정 없이 정책 변경 가능                                                                                                                                                                
  - `completeUpload()` 트랜잭션 — `noRollbackFor = FileException.class` 적용으로 검증 실패 시 FAIL 상태가 DB에 정상 반영되도록 수정                                                                                                                                                                
  - `validateAndConfirm()` 트랜잭션 — `REQUIRES_NEW + noRollbackFor` 적용으로 상품 등록 트랜잭션과 분리, 파일 FAIL 상태가 상품 등록 롤백과 무관하게 커밋되도록 수정                                                                                                                                
  - `fetchMetadataOrFail()`, `validateMetadata()` private 메서드 추출로 중복 검증 로직 제거                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                   
  ## 테스트                                                                                                                                                                                                                                                                                        
  - [x] 로컬 실행 확인                                                                                                                                                                                                                                                                             
  - [x] Postman으로 API 확인                                                                                                                                                                                                                                                                       
    - 허용 타입 외 contentType 요청 → 400 FILE_INVALID_TYPE                                                                                                                                                                                                                                        
    - 10MB 초과 파일 completeUpload → 400 FILE_SIZE_EXCEEDED                                                                                                                                                                                                                                       
    - 정상 파일 업로드 후 상품 등록 → 201 정상 처리                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                   
  ## 리뷰 포인트                              
  - presigned PUT URL은 S3 레벨에서 파일 크기를 강제할 수 없어 사후 검증(headObject) 방식으로 구현, 초과 파일은 completeUpload 시점에 S3에서 즉시 삭제됨                                                                                                                                           
  - contentType은 클라이언트가 선언한 값을 presigned URL 서명에 포함시켜 S3가 업로드 시 강제하도록 설계, 프론트는 PUT 요청 시 동일한 Content-Type 헤더 필수                                                                                                                                        
  - validateAndConfirm()은 ProductService.create() 트랜잭션 내에서 호출되므로 REQUIRES_NEW로 별도 트랜잭션 분리, 파일 상태 변경과 상품 등록 롤백이 서로 영향을 주지 않도록 설계